### PR TITLE
bazel: Allow to distdir all dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ BAZEL_BUILD_OPTS ?= --jobs=3
 # Dockerfile builds require special options
 ifdef PKG_BUILD
 BAZEL_BUILD_OPTS += --local_resources 4096,2.0,1.0
-all: install-bazel clean-bins $(CILIUM_ENVOY_RELEASE_BIN) shutdown-bazel
+all: precheck install-bazel clean-bins $(CILIUM_ENVOY_RELEASE_BIN) shutdown-bazel
 else
-all: install-bazel clean-bins envoy-default api shutdown-bazel
+all: precheck install-bazel clean-bins envoy-default api shutdown-bazel
 endif
 
 # Fetch and install Bazel if needed
@@ -160,6 +160,9 @@ clean: force clean-bins
 veryclean: force clean-bins
 	-sudo $(BAZEL) $(BAZEL_OPTS) clean
 	-sudo rm -Rf $(BAZEL_CACHE)
+
+precheck:
+	tools/check_repositories.sh
 
 check: $(CHECK_FORMAT) force-non-root
 	CLANG_FORMAT=$(CLANG_FORMAT) BUILDIFIER=$(BUILDIFIER) $(CHECK_FORMAT) --add-excluded-prefixes="./linux/" check

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,12 +8,14 @@ workspace(name = "cilium")
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
 ENVOY_SHA = "4ef8562b2194f222ce8a3d733fb04c629eaf0667"
+ENVOY_SHA256 = "bbb09ff2048bb2b14d8fb9ec957c6ddc7bfee147cca8d51f3d42b4e8084860bf"
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "envoy",
     url = "https://github.com/envoyproxy/envoy/archive/" + ENVOY_SHA + ".zip",
+    sha256 = ENVOY_SHA256,
     strip_prefix = "envoy-" + ENVOY_SHA,
 )
 
@@ -43,10 +45,12 @@ go_register_toolchains(go_version = GO_VERSION)
 # Cf. https://github.com/istio/proxy.
 
 ISTIO_PROXY_SHA = "67a0375be569f9158b361e8f5c2a76a0c1b0a02e"
+ISTIO_PROXY_SHA256 = "c625d3f9624aa5e3d794181733661da8bf6f4185d0f07dd032a3508b4782ca39"
 
 http_archive(
     name = "istio_proxy",
     url = "https://github.com/istio/proxy/archive/" + ISTIO_PROXY_SHA + ".zip",
+    sha256 = ISTIO_PROXY_SHA256,
     strip_prefix = "proxy-" + ISTIO_PROXY_SHA,
 )
 

--- a/tools/check_repositories.sh
+++ b/tools/check_repositories.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -eu
+
+# Check whether any git repositories are defined.
+# Git repository definition contains `commit` and `remote` fields.
+if grep -nr "commit =\|remote =" WORKSPACE; then
+  echo "Using git repositories is not allowed."
+  echo "To ensure that all dependencies can be stored offline in distdir, only HTTP repositories are allowed."
+  exit 1
+fi
+
+# Check whether number of defined `url =` and `sha256 =` kwargs in repository
+# definitions is equal.
+urls_count=$(git grep -E "url =" -- WORKSPACE | wc -l)
+sha256sums_count=$(git grep -E "sha256 =" -- WORKSPACE | wc -l)
+
+if [[ $urls_count != $sha256sums_count ]]; then
+  echo "Found more defined repository URLs than SHA256 sums, which means that there are some repositories without sums."
+  echo "Dependencies without SHA256 sums cannot be stored in distdir."
+  echo "Please ensure that every repository has a SHA256 sum."
+  echo "Repositories are defined in the WORKSPACE file."
+  exit 1
+fi


### PR DESCRIPTION
To use --distdir option of Bazel (which allows to use previously
fetched tarballs instead of downloading dependencies during
build), all dependencies should use http instead of git and need
to have sha256 sums specified.

This change defines all sha256 sums and provides a precheck script
which will prevent defining repositories using git or http without
sha256 sum.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>