### PR TITLE
tools: Match BAZEL_VERSION string instead of comparing

### DIFF
--- a/tools/install_bazel.sh
+++ b/tools/install_bazel.sh
@@ -3,7 +3,7 @@
 BAZEL_VERSION=$1
 
 echo "Checking if Bazel ${BAZEL_VERSION} needs to be installed..."
-if [[ $(command -v bazel) && "$(bazel version | grep 'label' | cut -d ' ' -f 3)" = ${BAZEL_VERSION} ]]; then
+if [[ $(command -v bazel) && "$(bazel version | grep 'label' | cut -d ' ' -f 3)" =~ ${BAZEL_VERSION} ]]; then
   echo "Bazel ${BAZEL_VERSION} already installed, skipping fetch."
 else
   wget -nv https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh


### PR DESCRIPTION
Some Bazel installations which are done not by the official script,
but i.e. from distribution packages created from tarballs, add
suffix to the version string. Example:

```
$ bazel version
Build label: 0.19.0- (@non-git)
Build target: bazel-out/k8-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Wed Nov 7 12:00:00 2018 (1541592000)
Build timestamp: 1541592000
Build timestamp as int: 1541592000
```

To prevent unnecessary Bazel installations, this change matches
BAZEL_VERSION string instead of comparing.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>