### PR TITLE
Istio: Upgrade glibc to 2.27

### DIFF
--- a/Dockerfile.istio_proxy.in
+++ b/Dockerfile.istio_proxy.in
@@ -5,6 +5,15 @@ FROM quay.io/cilium/cilium-envoy:84ee839e1d78ef858a39e390288ad417d35bb1d4 as cil
 
 FROM istio/proxytproxy:@ISTIO_VERSION@
 
+# Istio image runs on Xenial, which has too old glibc for Envoy built on Bionic
+# As a stopgap measure update the glibc to the required version (2.27)
+RUN echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu bionic main" | tee /etc/apt/sources.list.d/bionic.list \
+    && apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		libc6=2.27-3ubuntu1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Replace Istio's Envoy binary with Cilium's.
 COPY --from=cilium-envoy /usr/bin/cilium-envoy /usr/local/bin/envoy
 


### PR DESCRIPTION
Istio proxy image runs on older glibc (2.23), while our Envoy build requires 2.27.
Fix this for now by updating the glibc in the docker image. This bloats the image,
so a better solution is needed for a release.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>