### PR TITLE
bazel: Use .tar.gz archives instead of .zip

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,13 +8,13 @@ workspace(name = "cilium")
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
 ENVOY_SHA = "4ef8562b2194f222ce8a3d733fb04c629eaf0667"
-ENVOY_SHA256 = "bbb09ff2048bb2b14d8fb9ec957c6ddc7bfee147cca8d51f3d42b4e8084860bf"
+ENVOY_SHA256 = "2adf4f824600e439fcc7329777872ca99637412ff8e6b6b6d562a4f3797268fa"
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "envoy",
-    url = "https://github.com/envoyproxy/envoy/archive/" + ENVOY_SHA + ".zip",
+    url = "https://github.com/envoyproxy/envoy/archive/" + ENVOY_SHA + ".tar.gz",
     sha256 = ENVOY_SHA256,
     strip_prefix = "envoy-" + ENVOY_SHA,
 )
@@ -45,11 +45,11 @@ go_register_toolchains(go_version = GO_VERSION)
 # Cf. https://github.com/istio/proxy.
 
 ISTIO_PROXY_SHA = "67a0375be569f9158b361e8f5c2a76a0c1b0a02e"
-ISTIO_PROXY_SHA256 = "c625d3f9624aa5e3d794181733661da8bf6f4185d0f07dd032a3508b4782ca39"
+ISTIO_PROXY_SHA256 = "41cf1a3fd7d51fb78118521635a573d2e1579e27b26e9eb05e8e89000d1ae3ac"
 
 http_archive(
     name = "istio_proxy",
-    url = "https://github.com/istio/proxy/archive/" + ISTIO_PROXY_SHA + ".zip",
+    url = "https://github.com/istio/proxy/archive/" + ISTIO_PROXY_SHA + ".tar.gz",
     sha256 = ISTIO_PROXY_SHA256,
     strip_prefix = "proxy-" + ISTIO_PROXY_SHA,
 )


### PR DESCRIPTION
Signed-off-by: Michal Rostecki <mrostecki@suse.de>