### PR TITLE
Fix proxy compilation failure on arm64

### DIFF
--- a/linux/type_mapper.h
+++ b/linux/type_mapper.h
@@ -13,7 +13,9 @@
 #define __s16 int16_t
 #define __s8 int8_t
 
+#if !defined(__aligned_u64)
 #define __aligned_u64 uint64_t
+#endif
 
 #define __be64 uint64_t
 #define __be32 uint32_t


### PR DESCRIPTION
'__aligned_u64' redefined causes the compilation fail
with the following error:
"./linux/type_mapper.h:16: error: "__aligned_u64" redefined [-Werror]"

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>