### PR TITLE
Add Arm64 Support for Envoy image building

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,26 @@
+#
+# Cilium incremental build. Should be fast given builder-deps is up-to-date!
+#
+# cilium-builder tag is the Git SHA of the compatible build image commit.
+# Keeping the old images available will allow older versions to be built
+# while allowing the new versions to make changes that are not backwards compatible.
+#
+#FROM quay.io/cilium/cilium-envoy-builder-arm64:c31482c3e49670980c05cafc914320f7949b266f as builder
+FROM quay.io/cilium/cilium-envoy-builder:latest-arm64 as builder
+LABEL maintainer="maintainer@cilium.io"
+WORKDIR /go/src/github.com/cilium/cilium/envoy
+COPY . ./
+ARG V
+#
+# Please do not add any dependency updates before the 'make install' here,
+# as that will mess with caching for incremental builds!
+#
+RUN ./tools/get_workspace_status
+RUN make BAZEL_BUILD_OPTS=--jobs=2 PKG_BUILD=1 V=$V DESTDIR=/tmp/install cilium-envoy install
+
+#
+# Extract installed cilium-envoy binaries to an otherwise empty image
+#
+FROM scratch
+LABEL maintainer="maintainer@cilium.io"
+COPY --from=builder /tmp/install /

--- a/Dockerfile.builder.arm64
+++ b/Dockerfile.builder.arm64
@@ -1,0 +1,91 @@
+FROM ubuntu:18.04 as bazel-builder
+LABEL maintainer="maintainer@cilium.io"
+
+RUN mkdir -p /go/src/github.com/cilium/cilium/envoy
+WORKDIR /go/src/github.com/cilium/cilium/envoy
+COPY . ./
+
+#
+# Install Bazel
+#
+
+RUN apt-get update && apt-get install -y unzip zip curl
+
+
+RUN export BAZEL_VERSION=`cat BAZEL_VERSION` && echo $BAZEL_VERSION && \
+     curl -sfL https://github.com/Tick-Tocker/bazel-arm64/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-aarch64 \
+               -o /usr/bin/bazel  && \
+         chmod +x /usr/bin/bazel
+
+#
+# Builder dependencies. This takes a long time to build from scratch!
+# Also note that if build fails due to C++ internal error or similar,
+# it is possible that the image build needs more RAM than available by
+# default on non-Linux docker installs.
+#
+#
+
+FROM ubuntu:18.04 as builder
+LABEL maintainer="maintainer@cilium.io"
+
+COPY --from=bazel-builder /usr/bin/bazel /usr/bin/bazel
+
+#
+# Additional Envoy Build dependencies
+#
+RUN apt-get update \
+    && apt-get install -y curl build-essential automake clang cmake git \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+                build-essential \
+		automake \
+		cmake \
+		g++ \
+		git \
+		libtool \
+		make \
+		ninja-build \
+		python3 \
+		wget \
+		zip \
+                unzip \
+                openjdk-11-jdk \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+#
+# Install Go
+#
+ENV GOROOT /usr/local/go
+ENV GOPATH /go
+ENV PATH "$GOROOT/bin:$GOPATH/bin:$PATH"
+ENV GO_VERSION 1.13.4
+
+RUN curl -sfL https://dl.google.com/go/go${GO_VERSION}.linux-arm64.tar.gz | tar -xzC /usr/local && \
+        go get -d -u github.com/gordonklaus/ineffassign && \
+        cd /go/src/github.com/gordonklaus/ineffassign && \
+        git checkout -b 1003c8bd00dc2869cb5ca5282e6ce33834fed514 1003c8bd00dc2869cb5ca5282e6ce33834fed514 && \
+        go install && \
+        go get -d github.com/cilium/go-bindata/... && \
+        cd /go/src/github.com/cilium/go-bindata && \
+        git checkout -b e950ad39c6092155a6d89f04c90b1c46d8c97d49 e950ad39c6092155a6d89f04c90b1c46d8c97d49 && \
+        go install github.com/cilium/go-bindata/go-bindata
+
+RUN mkdir -p /go/src/github.com/cilium/cilium/envoy
+WORKDIR /go/src/github.com/cilium/cilium/envoy
+COPY . ./
+
+#
+# Install Bazel
+#
+
+COPY --from=bazel-builder /usr/bin/bazel /usr/bin/bazel
+
+#
+# Build and keep the cache
+#
+
+RUN make BAZEL_BUILD_OPTS=--jobs=1 PKG_BUILD=1 cilium-envoy && rm ./bazel-bin/cilium-envoy
+#
+# Absolutely nothing after making envoy deps!
+#

--- a/push_manifest.sh
+++ b/push_manifest.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+UPLOAD_IMAGE="false"
+
+# override defaults from arguments
+while [ "$1" != "" ]; do
+    case $1 in
+        -i | --image-upload )
+            UPLOAD_IMAGE="true"
+            echo "Upload image: ${UPLOAD_IMAGE}"
+            ;;
+        * )
+            break;;
+    esac
+    shift
+done
+
+IMAGE_NAME=${1:-}
+IMAGE_TAG=${2:-latest}
+DOCKER_REPOSITORY=${3:-quay.io/cilium}
+DOCKER_REGISTRY=${4:-}
+IMAGE_ARCH=("amd64" "arm64")
+
+if [ -z "${IMAGE_NAME}" ]
+then
+  echo "Please specify a image name!"
+  echo -e "\nUsage::\n\tpush_manifest.sh IMAGE_NAME [IMAGE_TAG] [DOCKER_REPOSITORY] [DOCKER_REGISTRY]"
+  echo -e "\nExample::\n\tpush_manifest.sh cilium-envoy latest"
+  exit 1
+fi
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+if [ "${UPLOAD_IMAGE}" = "true" ]; then
+    for arch in "${IMAGE_ARCH[@]}"
+    do
+	docker push ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}-${arch}
+    done
+fi
+
+docker manifest create --amend ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG} \
+	${DOCKER_REGISTRY}${DOCKER_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}-amd64 \
+	${DOCKER_REGISTRY}${DOCKER_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}-arm64
+
+docker manifest push ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}


### PR DESCRIPTION
Add Arm64 Dockerfile.builder and Dockerfile support for
image building on its builder and envoy image itself.

At the same time, we add the multi-arch support with
fat-manifest for both aarch64 and x86_64. After pushing
the images for the 2 arches, we can just use the cmd:
make docker-envoy-manifest
to enable multi-arch of both images which would greatly
facilitate the image pulling and use.

This patch would not affect the current use and building
for those of x86_64 platform with the following consideration:
1. The current 'amd64' arched images would be tagged as the
default images as the original;
2. The current building images tagged with 'SOURCE_VERSION'
would be tagged as the "latest", which would facilitate its use and
the local building of following images.

Signed-off-by: trevor tao <trevor.tao@arm.com>