### PR TITLE
Dockerfile: Pick up quay.io/cilium/cilium-builder:2020-02-26

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -6,7 +6,7 @@
 #
 # Using cilium-builder as the base to ensure libc etc. are in sync.
 #
-FROM quay.io/cilium/cilium-builder:2019-07-11 as builder
+FROM quay.io/cilium/cilium-builder:2020-02-26 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium/envoy
 COPY . ./


### PR DESCRIPTION
This builder image has go 1.14.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>