### PR TITLE
Add Arm64 Support for Envoy image building

### DIFF
--- a/Dockerfile.builder.multi_arch
+++ b/Dockerfile.builder.multi_arch
@@ -1,0 +1,66 @@
+#
+# Builder dependencies. This takes a long time to build from scratch!
+# Also note that if build fails due to C++ internal error or similar,
+# it is possible that the image build needs more RAM than available by
+# default on non-Linux docker installs.
+#
+# Using cilium-builder as the base to ensure libc etc. are in sync.
+#
+# The base image here should be multi-arched beforehand when used for non-amd64
+# platforms, e.g, arm64 platform.
+#
+FROM quay.io/cilium/cilium-builder:2020-05-05 as builder
+
+LABEL maintainer="maintainer@cilium.io"
+
+ARG ARCH=amd64
+
+WORKDIR /go/src/github.com/cilium/cilium/envoy
+COPY . ./
+
+#
+# Additional Envoy Build dependencies
+#
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		automake \
+		cmake \
+		g++ \
+		git \
+		libtool \
+		make \
+		ninja-build \
+		python3 \
+		python \
+		wget \
+		zip \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+#
+# Install Bazel
+#
+RUN export BAZEL_VERSION=`cat .bazelversion` \
+        && if [ "$ARCH" = "amd64" ] ; then \
+	     curl -sfL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh -o bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh \
+	     && chmod +x bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh \
+	     && ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh \
+	     && mv /usr/local/bin/bazel /usr/bin \
+	     && rm bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh ; \
+           elif [ "$ARCH" = "arm64" ] ; then \
+             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip zip build-essential openjdk-11-jdk && \
+             echo "deb https://download.opensuse.org/repositories/home:/mrostecki:/bazel/xUbuntu_20.04/ /" > /etc/apt/sources.list.d/bazel.list && \
+             curl -L https://download.opensuse.org/repositories/home:/mrostecki:/bazel/xUbuntu_20.04/Release.key | apt-key add - && \
+             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y bazel ; \
+           fi
+ 
+
+#
+# Build and keep the cache
+#
+RUN make BAZEL_BUILD_OPTS=--jobs=5 PKG_BUILD=1 ./bazel-bin/cilium-envoy && rm ./bazel-bin/cilium-envoy
+
+#
+# Absolutely nothing after making envoy deps!
+#

--- a/Dockerfile.multi_arch
+++ b/Dockerfile.multi_arch
@@ -1,0 +1,30 @@
+#
+# Cilium incremental build. Should be fast given builder-deps is up-to-date!
+#
+# cilium-builder tag is the Git SHA of the compatible build image commit.
+# Keeping the old images available will allow older versions to be built
+# while allowing the new versions to make changes that are not backwards compatible.
+#
+# The base image here should be multi-arched beforehand when used on non-amd64 platforms, such as arm64
+# platform
+#
+FROM quay.io/cilium/cilium-envoy-builder-dev:bb7c198879e48ac01ab77e0f06084a53a386d9ca as builder
+LABEL maintainer="maintainer@cilium.io"
+
+WORKDIR /go/src/github.com/cilium/cilium/envoy
+COPY . ./
+
+ARG V
+#
+# Please do not add any dependency updates before the 'make install' here,
+# as that will mess with caching for incremental builds!
+#
+RUN ./tools/get_workspace_status
+RUN make BAZEL_BUILD_OPTS=--jobs=2 PKG_BUILD=1 V=$V DESTDIR=/tmp/install cilium-envoy install
+
+#
+# Extract installed cilium-envoy binaries to an otherwise empty image
+#
+FROM scratch
+LABEL maintainer="maintainer@cilium.io"
+COPY --from=builder /tmp/install /

--- a/tools/push_manifest.sh
+++ b/tools/push_manifest.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+IMAGE_NAME=${1:-}
+IMAGE_TAG=${2:-latest}
+DOCKER_REPOSITORY=${3:-cilium}
+DOCKER_REGISTRY=${4:-quay.io}
+MANIFEST_VERSION=${5:-v1.0.0}
+
+IMAGE_ARCH=("amd64" "arm64")
+
+UPLOAD_IMAGE="false"
+
+# override defaults from arguments
+while [ "$1" != "" ]; do
+    case $1 in
+        -i | --image-upload )
+            UPLOAD_IMAGE="true"
+            echo "Upload image: ${UPLOAD_IMAGE}"
+            ;;
+        * )
+            break;; 
+    esac
+    shift
+done
+
+function using_help() {
+  echo "Please specify a image name!"
+  echo -e "\nUsage::\n\tpush_manifest.sh IMAGE_NAME [IMAGE_TAG] [DOCKER_REPOSITORY] [DOCKER_REGISTRY]"
+  echo -e "\nExample::\n\tpush_manifest.sh cilium-envoy latest"
+  exit 1
+}
+
+
+function install_manifest() {
+  if [ ! -f "./manifest-tool" ]
+  then
+     wget https://github.com/estesp/manifest-tool/releases/download/${MANIFEST_VERSION}/manifest-tool-linux-${ARCH} \
+          -O manifest-tool
+     chmod +x ./manifest-tool
+  fi
+}
+
+if [ -z "${IMAGE_NAME}" ]
+then
+  using_help
+fi
+
+# push images
+if [ "${UPLOAD_IMAGE}" = "true" ]; then
+  for arch in "${IMAGE_ARCH[@]}"	
+  do
+    docker push ${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}-${arch}
+  done
+fi
+
+# get hardware name
+case `uname -m` in
+  'x86_64' )
+    ARCH=amd64
+    ;;
+  'aarch64' )
+    ARCH=arm64
+    ;;
+esac
+
+# install manifest-tool v1.0.0
+install_manifest
+
+for arch in "${IMAGE_ARCH[@]}"
+do
+  if [ -z "$PLATFORMS" ]; then
+    PLATFORMS="linux/${arch}"
+  else
+    PLATFORMS="$PLATFORMS,linux/${arch}"
+  fi
+done
+
+./manifest-tool push from-args --platforms ${PLATFORMS} \
+	--template ${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}-ARCH \
+	--target ${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}


### PR DESCRIPTION
 Add Arm64 Support for Envoy image building
    
Add Arm64 Dockerfile.builder and Dockerfile support for
image building on its builder and envoy image itself.
    
Uses multi-arch enabled Dockerfile.builder and Dockerfile to
enable image building on both amd64 and arm64 platform.
    
The multi-arch support with fat-manifest for both arm64 and amd64
is also added, i.e.,after pushing the images for the 2 arches,
we can just use the cmds:
        make envoy-builder-manifest
        make docker-envoy-manifest
to enable multi-arch of both images which would greatly
facilitate the image pulling and use.

This patch would not affect the current use and building
for those of x86_64 platform with the following consideration:
1. The current 'amd64' arched images would be tagged as the
default images as the original;
2. The current building images tagged with 'SOURCE_VERSION'
would be tagged as the "latest", which would facilitate its use and
the local building of following images.

Signed-off-by: trevor tao <trevor.tao@arm.com>