### PR TITLE
proxylib: Reset the need_bytes_ after requested input_len being fulfilled

### DIFF
--- a/cilium/proxylib.cc
+++ b/cilium/proxylib.cc
@@ -196,6 +196,7 @@ FilterResult GoFilter::Instance::OnIO(bool reply, Buffer::Instance& data, bool e
   if (input_len < dir.need_bytes_) {
     return FILTER_OK;
   }
+  dir.need_bytes_ = 0;
   
   const int max_ops = 16; // Make shorter for testing purposes
   FilterOp ops_[max_ops];


### PR DESCRIPTION
Hi, 
While I am writing my own golang share module under proxylib, I find it might be a bug that the need_bytes_ isn't reset across message boundaries.

The problem I encountered is my golang share module will not be called if the current input length is smaller than the need_bytes_  which is requested in the previous boundary.

So I think the need_bytes_ should be reset once the input length is fulfilled and not carry to next boundary.