### PR TITLE
accesslog: Only include x-request-id request header for response access logs

### DIFF
--- a/.github/workflows/cache-build.yaml
+++ b/.github/workflows/cache-build.yaml
@@ -54,7 +54,7 @@ jobs:
           platforms: linux/amd64
           build-args: |
             COPY_CACHE_EXT=.new
-            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-envoy-1.17.0-archive
+            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-envoy-1.17.3-archive
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-archive-latest
       - name: Cache Docker layers
@@ -115,7 +115,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             COPY_CACHE_EXT=.new
-            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:envoy-1.17.0-archive
+            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:envoy-1.17.3-archive
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:release-archive-latest
       - name: Cache Docker layers

--- a/cilium/api/accesslog.proto
+++ b/cilium/api/accesslog.proto
@@ -28,7 +28,7 @@ message HttpLogEntry {
   string path = 4;    // Envoy ":path" header
   string method = 5;  // Envoy ":method" header
 
-  // Request headers not included above
+  // Request or response headers not included above
   repeated KeyValue headers = 6;
 
   // Response info


### PR DESCRIPTION
Do not repeat any other request headers than `x-request-id` in response access logs.
