### PR TITLE
Add SO_REUSEADDR to upstream connections to fix failing retries

### DIFF
--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -57,7 +57,18 @@ class SocketMarkOption : public Network::Socket::Option,
       }
     }
 
+    // Allow reuse of the original source address. This may by needed for
+    // retries to not fail on "address already in use" when using a specific
+    // source address and port.
     if (src_address_) {
+      uint32_t one = 1;
+      auto status = socket.setSocketOption(SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+      if (status.rc_ < 0) {
+	ENVOY_LOG(critical,
+		  "Failed to set socket option SO_REUSEADDR: {}",
+		  Envoy::errorDetails(errno));
+	return false;
+      }
       socket.addressProvider().setLocalAddress(src_address_);
     }
 


### PR DESCRIPTION
Add SO_REUSEADDR to upstream connections when original source address
is used. This is needed to allow bind() to succeed before connect() if
a previous socket using the same source address and port is in
TIME_WAIT state when performing a retry, possibly to a different
destination host.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>