### PR TITLE
bpf: support regular hash map for ipcache

### DIFF
--- a/cilium/bpf.cc
+++ b/cilium/bpf.cc
@@ -75,9 +75,12 @@ bool Bpf::open(const std::string &path) {
       }
       bpf_file.close();
 
-      if ((map_type == map_type_ || (map_type == BPF_MAP_TYPE_LRU_HASH &&
-                                     map_type_ == BPF_MAP_TYPE_HASH)) &&
-          key_size == key_size_ && value_size == value_size_) {
+      if ((map_type_ == map_type ||
+	   // BPF_MAP_TYPE_LRU_HASH and BPF_MAP_TYPE_LPM_TRIE are equivalent
+	   // to BPF_MAP_TYPE_HASH for lookups.
+	   (map_type_ == BPF_MAP_TYPE_HASH &&
+	    (map_type == BPF_MAP_TYPE_LRU_HASH || map_type == BPF_MAP_TYPE_LPM_TRIE))) && 
+          key_size_ == key_size && value_size_ == value_size) {
         return true;
       }
       if (log_on_error) {

--- a/cilium/ipcache.cc
+++ b/cilium/ipcache.cc
@@ -45,7 +45,7 @@ struct remote_endpoint_info {
 #define ENDPOINT_KEY_IPV6 2
 
 IPCache::IPCache(const std::string& bpf_root)
-    : Bpf(BPF_MAP_TYPE_LPM_TRIE, sizeof(struct ipcache_key),
+    : Bpf(BPF_MAP_TYPE_HASH, sizeof(struct ipcache_key),
           sizeof(struct remote_endpoint_info)),
       bpf_root_(bpf_root) {}
 


### PR DESCRIPTION
Older kernels do not support LPM maps. Add support for hash maps so
that ipcache lookups also work for the older kernels and the fallback
syncing ipcache over xDS can be avoided.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>