### PR TITLE
Use upstream callbacks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,6 +31,8 @@ http_archive(
         "@//patches:cross-aarch64.patch",
         "@//patches:clang-for-bpf.patch",
         "@//patches:unreferenced-parameters.patch",
+        "@//patches:envoy-upstream-network-auth.patch",
+        "@//patches:envoy-upstream-http-auth.patch",
     ],
     sha256 = ENVOY_SHA256,
     strip_prefix = ENVOY_REPO + "-" + ENVOY_SHA,

--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -111,7 +111,6 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
-        "//cilium:socket_option_lib",
         "//cilium/api:accesslog_proto_cc_proto",
         "@envoy//source/exe:envoy_common_lib",
     ],

--- a/cilium/accesslog.h
+++ b/cilium/accesslog.h
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "cilium/api/accesslog.pb.h"
-#include "cilium/socket_option.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
 #include "envoy/http/header_map.h"
@@ -23,15 +22,20 @@ class AccessLog : Logger::Loggable<Logger::Id::router> {
   // wrapper for protobuf
   class Entry {
    public:
-    void InitFromRequest(const std::string& policy_name,
-                         const Cilium::SocketOption& option,
+    void InitFromRequest(const std::string& policy_name, bool ingress,
+			 uint32_t source_identity,
+			 const Network::Address::InstanceConstSharedPtr& source_address,
+                         uint32_t destination_identity,
+                         const Network::Address::InstanceConstSharedPtr& destination_address,
                          const StreamInfo::StreamInfo&,
                          const Http::RequestHeaderMap&);
     void UpdateFromResponse(const Http::ResponseHeaderMap&, TimeSource&);
 
-    void InitFromConnection(const std::string& policy_name,
-                            const Cilium::SocketOption& option,
-                            const StreamInfo::StreamInfo&);
+    void InitFromConnection(const std::string& policy_name, bool ingress,
+			    uint32_t source_identity,
+			    const Network::Address::InstanceConstSharedPtr& source_address,
+                            uint32_t destination_identity,
+                            const Network::Address::InstanceConstSharedPtr& destination_address);
     bool UpdateFromMetadata(const std::string& l7proto,
                             const ProtobufWkt::Struct& metadata,
                             TimeSource& time_source);

--- a/cilium/l7policy.h
+++ b/cilium/l7policy.h
@@ -3,8 +3,10 @@
 #include <string>
 
 #include "absl/types/optional.h"
+
 #include "cilium/accesslog.h"
 #include "cilium/api/l7policy.pb.h"
+
 #include "source/common/common/logger.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/stats/stats_macros.h"
@@ -56,7 +58,7 @@ typedef std::shared_ptr<Config> ConfigSharedPtr;
 class AccessFilter : public Http::StreamFilter,
                      Logger::Loggable<Logger::Id::filter> {
 public:
-  AccessFilter(ConfigSharedPtr& config) : config_(config), denied_(false) {}
+  AccessFilter(ConfigSharedPtr& config) : config_(config) {}
 
   // Http::StreamFilterBase
   void onDestroy() override;
@@ -93,7 +95,7 @@ private:
   ConfigSharedPtr config_;
   Http::StreamDecoderFilterCallbacks* callbacks_;
 
-  bool denied_;
+  bool allowed_ = false;
   AccessLog::Entry log_entry_;
 };
 

--- a/cilium/network_filter.h
+++ b/cilium/network_filter.h
@@ -63,6 +63,8 @@ class Instance : public Network::Filter, Logger::Loggable<Logger::Id::filter> {
   const ConfigSharedPtr config_;
   Network::ReadFilterCallbacks* callbacks_ = nullptr;
   std::string l7proto_{};
+  bool should_buffer_ = false;
+  Buffer::OwnedImpl buffer_;  // Buffer for initial connection data
   Cilium::GoFilter::InstancePtr go_parser_{};
   Cilium::PortPolicyConstSharedPtr port_policy_{};
   Cilium::AccessLog::Entry log_entry_{};

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -29,12 +29,14 @@ class PortPolicy {
 
   virtual bool useProxylib(std::string& l7_proto) const PURE;
 
+  virtual bool Matches(uint64_t remote_id) const PURE;
+
   virtual bool allowed(
       const envoy::config::core::v3::Metadata& metadata) const PURE;
 
-  virtual Ssl::ContextConfig& getServerTlsContextConfig() const PURE;
+  virtual const Ssl::ContextConfig& getServerTlsContextConfig() const PURE;
   virtual Ssl::ContextSharedPtr getServerTlsContext() const PURE;
-  virtual Ssl::ContextConfig& getClientTlsContextConfig() const PURE;
+  virtual const Ssl::ContextConfig& getClientTlsContextConfig() const PURE;
   virtual Ssl::ContextSharedPtr getClientTlsContext() const PURE;
 };
 using PortPolicyConstSharedPtr = std::shared_ptr<const PortPolicy>;

--- a/patches/envoy-upstream-http-auth.patch
+++ b/patches/envoy-upstream-http-auth.patch
@@ -1,0 +1,186 @@
+From ea7413436d5127e4efad0a5e9e96c04733b07967 Mon Sep 17 00:00:00 2001
+From: Jarno Rajahalme <jarno@isovalent.com>
+Date: Fri, 21 Jan 2022 15:42:00 +0200
+Subject: [PATCH] upstream: Add callback for upstream authorization
+
+Add new StreamDecoderFilterCallbacks addUpstreamCallback() and
+iterateUpstreamCallbacks(). Decoder filters can add callbacks using
+addUpstreamCallback(), which will then get called after an upstream
+connection has been established and all header transformations have been
+performed, and just before upstream headers are encoded by the
+router. If any of the callbacks returns 'false', the router will issue
+a 403 local response instead of encoding the request upstream.
+
+This allows HTTP decoder filters to perform policy enforcement on the
+upstream requests taking effect after all potential header
+transformations have been performed.
+
+Callbacks can safely refer to memory held by the filter instance
+adding the callback, as the calls to the callbacks are only ever be
+done from the router filter in the same filter chain.
+
+Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
+---
+ envoy/http/filter.h                      | 29 ++++++++++++++++++++++++
+ source/common/http/async_client_impl.h   |  5 ++++
+ source/common/http/filter_manager.cc     | 21 +++++++++++++++++
+ source/common/http/filter_manager.h      |  8 +++++++
+ source/common/router/upstream_request.cc | 10 ++++++++
+ 5 files changed, 73 insertions(+)
+
+diff --git a/envoy/http/filter.h b/envoy/http/filter.h
+index 6e6cad73a..ef15aa183 100644
+--- a/envoy/http/filter.h
++++ b/envoy/http/filter.h
+@@ -320,6 +320,23 @@ public:
+ using RouteConfigUpdatedCallback = std::function<void(bool)>;
+ using RouteConfigUpdatedCallbackSharedPtr = std::shared_ptr<RouteConfigUpdatedCallback>;
+ 
++/**
++ * UpstreamCallback can be used to reject upstream host selection made by the router.
++ * This callback is passed the StreamInfo, and the final headers that can be used by
++ * the callback to inform its decision.
++ *
++ * The callback is called right befere the request is encoded on the already connected
++ * upstream connection. At this stage all header manipulations in the Envoy configuration
++ * have been performed so that the callback may inspect the final headers.
++ * 
++ * UpstreamCallback may not be called if a local reply is issued instead or forwarding
++ * the request.
++ *
++ * Returning 'true' allows the request to be forwarded. Returning 'false' prevents the
++ * request from being forwarded, and a 403 local response is issued instead.
++ */
++using UpstreamCallback = std::function<bool(Http::RequestHeaderMap&, StreamInfo::StreamInfo&)>;
++
+ /**
+  * Stream decoder filter callbacks add additional callbacks that allow a decoding filter to restart
+  * decoding if they decide to hold data (e.g. for buffering or rate limiting).
+@@ -632,6 +649,18 @@ public:
+    */
+   virtual bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
+                                         StreamInfo::StreamInfo&) PURE;
++
++  /*
++   * Adds the given callback to be executed later via 
++   */
++  virtual void addUpstreamCallback(const UpstreamCallback& cb) PURE;
++
++  /**
++   * Invokes all the added callbacks before forwarding requests from this stream upstream.
++   * Returns 'false' if any of the callbacks rejects the request, 'true' otherwise.
++   */
++  virtual bool iterateUpstreamCallbacks(Http::RequestHeaderMap&,
++                                        StreamInfo::StreamInfo&) PURE;
+ };
+ 
+ /**
+diff --git a/source/common/http/async_client_impl.h b/source/common/http/async_client_impl.h
+index d4ec87d72..5ed495954 100644
+--- a/source/common/http/async_client_impl.h
++++ b/source/common/http/async_client_impl.h
+@@ -330,6 +330,11 @@ private:
+                                 StreamInfo::StreamInfo&) override {
+     return true;
+   }
++  void addUpstreamCallback(const UpstreamCallback&) override {}
++  bool iterateUpstreamCallbacks(Http::RequestHeaderMap&,
++                                StreamInfo::StreamInfo&) override {
++    return true;
++  }
+   Router::RouteConstSharedPtr route() override { return route_; }
+   Router::RouteConstSharedPtr route(const Router::RouteCallback&) override { return nullptr; }
+   void setRoute(Router::RouteConstSharedPtr) override {}
+diff --git a/source/common/http/filter_manager.cc b/source/common/http/filter_manager.cc
+index a952d772e..663b9d2af 100644
+--- a/source/common/http/filter_manager.cc
++++ b/source/common/http/filter_manager.cc
+@@ -1444,10 +1444,31 @@ bool FilterManager::createFilterChain() {
+   return !upgrade_rejected;
+ }
+ 
++void FilterManager::addUpstreamCallback(const UpstreamCallback& cb) {
++  decoder_filter_upstream_cbs_.emplace_back(cb);
++}
++  
++bool FilterManager::iterateUpstreamCallbacks(Http::RequestHeaderMap& headers,
++                                             StreamInfo::StreamInfo& upstream_info) {
++  bool accept = true;
++  for (const auto& cb : decoder_filter_upstream_cbs_) {
++    accept = accept && cb(headers, upstream_info);
++  }
++  return accept;
++}
++
+ bool ActiveStreamDecoderFilter::iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
+                                                          StreamInfo::StreamInfo& stream_info) {
+   return parent_.filter_manager_callbacks_.iterateUpstreamCallbacks(host, stream_info);
++}
++
++void ActiveStreamDecoderFilter::addUpstreamCallback(const UpstreamCallback& cb) {
++  parent_.addUpstreamCallback(cb);
++}
+ 
++bool ActiveStreamDecoderFilter::iterateUpstreamCallbacks(Http::RequestHeaderMap& headers,
++                                                         StreamInfo::StreamInfo& stream_info) {
++  return parent_.iterateUpstreamCallbacks(headers, stream_info);
+ }
+ 
+ void ActiveStreamDecoderFilter::requestDataDrained() {
+diff --git a/source/common/http/filter_manager.h b/source/common/http/filter_manager.h
+index eb32a1dc7..8fd8b5efe 100644
+--- a/source/common/http/filter_manager.h
++++ b/source/common/http/filter_manager.h
+@@ -302,6 +302,9 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
+ 
+   bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
+                                 StreamInfo::StreamInfo& stream_info) override;
++  void addUpstreamCallback(const UpstreamCallback& cb) override;
++  bool iterateUpstreamCallbacks(Http::RequestHeaderMap& headers,
++                                StreamInfo::StreamInfo& stream_info) override;
+ 
+   StreamDecoderFilterSharedPtr handle_;
+   bool is_grpc_request_{};
+@@ -1018,6 +1021,9 @@ private:
+     return request_metadata_map_vector_.get();
+   }
+ 
++  void addUpstreamCallback(const UpstreamCallback&);
++  bool iterateUpstreamCallbacks(Http::RequestHeaderMap&, StreamInfo::StreamInfo&);
++
+   FilterManagerCallbacks& filter_manager_callbacks_;
+   Event::Dispatcher& dispatcher_;
+   const Network::Connection& connection_;
+@@ -1025,6 +1031,8 @@ private:
+   Buffer::BufferMemoryAccountSharedPtr account_;
+   const bool proxy_100_continue_;
+ 
++  std::vector<UpstreamCallback> decoder_filter_upstream_cbs_{};
++
+   std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
+   std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;
+   std::list<StreamFilterBase*> filters_;
+diff --git a/source/common/router/upstream_request.cc b/source/common/router/upstream_request.cc
+index 725054b32..c08dbadb9 100644
+--- a/source/common/router/upstream_request.cc
++++ b/source/common/router/upstream_request.cc
+@@ -508,6 +508,16 @@ void UpstreamRequest::onPoolReady(
+     max_stream_duration_timer_->enableTimer(*max_stream_duration);
+   }
+ 
++  bool accepted = parent_.callbacks()->iterateUpstreamCallbacks(*parent_.downstreamHeaders(),
++                                                                stream_info_);
++  if (!accepted) {
++    calling_encode_headers_ = false;
++    stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
++    parent_.callbacks()->sendLocalReply(Http::Code::Forbidden, "Access denied\r\n",
++                                        nullptr, absl::nullopt, absl::string_view());
++    return;
++  }
++  
+   const Http::Status status =
+       upstream_->encodeHeaders(*parent_.downstreamHeaders(), shouldSendEndStream());
+   calling_encode_headers_ = false;
+-- 
+2.34.1
+

--- a/patches/envoy-upstream-network-auth.patch
+++ b/patches/envoy-upstream-network-auth.patch
@@ -1,0 +1,349 @@
+From 8dd9163b988a061b22d7ed6446a2ee9b94975256 Mon Sep 17 00:00:00 2001
+From: Jarno Rajahalme <jarno@isovalent.com>
+Date: Mon, 24 Jan 2022 15:40:28 +0200
+Subject: [PATCH] network: Add callback for upstream authorization
+
+Add new ReadFilterCallbacks addUpstreamCallback() and
+iterateUpstreamCallbacks(). Network filters can add callbacks using
+addUpstreamCallback(), which will then get called after an upstream
+host has been selected, but before the upstream connection is
+established.  If any of the callbacks returns 'false', the connection
+is not established. For HTTP the router will issue a 403 local
+response.
+
+iterateUpstreamCallbacks() is also added to
+StreamDecoderFilterCallbacks so that the HTTP router filter can invoke
+the added callbacks before a new connection is established.
+
+These additions allow network read filters to perform network level
+policy enforcement based on the selected upstream host.
+
+Callbacks can safely refer to memory held by the filter instance
+adding the callback, as the calls to the callbacks are only ever be
+done from the tcp_proxy or router filter in the same filter chain.
+
+Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
+---
+ envoy/http/filter.h                         |  8 ++++++
+ envoy/network/filter.h                      | 28 +++++++++++++++++++++
+ envoy/tcp/upstream.h                        |  5 ++++
+ source/common/http/async_client_impl.h      |  4 +++
+ source/common/http/conn_manager_impl.h      |  5 ++++
+ source/common/http/filter_manager.cc        |  6 +++++
+ source/common/http/filter_manager.h         |  9 +++++++
+ source/common/network/filter_manager_impl.h | 21 ++++++++++++++++
+ source/common/router/router.cc              |  8 ++++++
+ source/common/tcp_proxy/tcp_proxy.cc        |  7 ++++++
+ source/common/tcp_proxy/tcp_proxy.h         |  1 +
+ source/common/tcp_proxy/upstream.cc         |  8 ++++++
+ source/common/tcp_proxy/upstream.h          |  2 ++
+ source/server/api_listener_impl.h           |  3 +++
+ 14 files changed, 115 insertions(+)
+
+diff --git a/envoy/http/filter.h b/envoy/http/filter.h
+index 3c4602069..6e6cad73a 100644
+--- a/envoy/http/filter.h
++++ b/envoy/http/filter.h
+@@ -624,6 +624,14 @@ public:
+    * load balancing.
+    */
+   virtual absl::optional<absl::string_view> upstreamOverrideHost() const PURE;
++
++  /**
++   * Invokes all the added network level callbacks before establishing a connection to the
++   * selected upstream host.
++   * Returns 'false' if any of the callbacks rejects the connection, 'true' otherwise.
++   */
++  virtual bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
++                                        StreamInfo::StreamInfo&) PURE;
+ };
+ 
+ /**
+diff --git a/envoy/network/filter.h b/envoy/network/filter.h
+index 16a5de4c2..fbd8de49e 100644
+--- a/envoy/network/filter.h
++++ b/envoy/network/filter.h
+@@ -110,6 +110,22 @@ public:
+ 
+ using WriteFilterSharedPtr = std::shared_ptr<WriteFilter>;
+ 
++/**
++ * UpstreamCallback can be used to reject upstream host selection made by the TCP proxy filter.
++ * This callback is passed the Upstream::HostDescriptionConstSharedPtr, and StreamInfo.
++ *
++ * The callback is called just after the upstream host has been picked, but before a connection is
++ * established. Here the callback can reject the selected upstream host and cause the be dropped.
++
++ * UpstreamCallback may not be called if the connection is dropped for another reason, such as
++ * no route, cluster is not found, etc.
++ *
++ * Returning 'true' allows the connection to be established. Returning 'false' prevents the
++ * connection to the selected host from being established.
++ */
++using UpstreamCallback = std::function<bool(Upstream::HostDescriptionConstSharedPtr,
++                                            StreamInfo::StreamInfo&)>;
++
+ /**
+  * Callbacks used by individual read filter instances to communicate with the filter manager.
+  */
+@@ -160,6 +176,18 @@ public:
+    * Set the currently selected upstream host for the connection.
+    */
+   virtual void upstreamHost(Upstream::HostDescriptionConstSharedPtr host) PURE;
++
++  /**
++   * Adds the given callback to be executed later via iterateUpstreamCallbacks().
++   */
++  virtual void addUpstreamCallback(const UpstreamCallback& cb) PURE;
++
++  /**
++   * Invokes all the added callbacks before connecting to the selected upstream host.
++   * Returns 'false' if any of the callbacks rejects the connection, 'true' otherwise.
++   */
++  virtual bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
++                                        StreamInfo::StreamInfo&) PURE;
+ };
+ 
+ /**
+diff --git a/envoy/tcp/upstream.h b/envoy/tcp/upstream.h
+index aeb711a08..3fce432b6 100644
+--- a/envoy/tcp/upstream.h
++++ b/envoy/tcp/upstream.h
+@@ -32,6 +32,11 @@ public:
+    * @param callbacks callbacks to communicate stream failure or creation on.
+    */
+   virtual void newStream(GenericConnectionPoolCallbacks& callbacks) PURE;
++
++  /**
++   * @return Upstream::HostDescriptionConstSharedPtr the host for which connections are pooled.
++   */
++  virtual Upstream::HostDescriptionConstSharedPtr host() const PURE;
+ };
+ 
+ // An API for the UpstreamRequest to get callbacks from either an HTTP or TCP
+diff --git a/source/common/http/async_client_impl.h b/source/common/http/async_client_impl.h
+index 6888ddaa2..d4ec87d72 100644
+--- a/source/common/http/async_client_impl.h
++++ b/source/common/http/async_client_impl.h
+@@ -326,6 +326,10 @@ private:
+   const Network::Connection* connection() override { return nullptr; }
+   Event::Dispatcher& dispatcher() override { return parent_.dispatcher_; }
+   void resetStream() override;
++  bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
++                                StreamInfo::StreamInfo&) override {
++    return true;
++  }
+   Router::RouteConstSharedPtr route() override { return route_; }
+   Router::RouteConstSharedPtr route(const Router::RouteCallback&) override { return nullptr; }
+   void setRoute(Router::RouteConstSharedPtr) override {}
+diff --git a/source/common/http/conn_manager_impl.h b/source/common/http/conn_manager_impl.h
+index 11e59f4d6..0fdb6a604 100644
+--- a/source/common/http/conn_manager_impl.h
++++ b/source/common/http/conn_manager_impl.h
+@@ -289,6 +289,11 @@ private:
+       return connection_manager_.enable_internal_redirects_with_body_;
+     }
+ 
++    bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
++				  StreamInfo::StreamInfo& stream_info) const override {
++      return connection_manager_.read_callbacks_->iterateUpstreamCallbacks(host, stream_info);
++    }
++
+     void traceRequest();
+ 
+     // Updates the snapped_route_config_ (by reselecting scoped route configuration), if a scope is
+diff --git a/source/common/http/filter_manager.cc b/source/common/http/filter_manager.cc
+index c435fb229..a952d772e 100644
+--- a/source/common/http/filter_manager.cc
++++ b/source/common/http/filter_manager.cc
+@@ -1444,6 +1444,12 @@ bool FilterManager::createFilterChain() {
+   return !upgrade_rejected;
+ }
+ 
++bool ActiveStreamDecoderFilter::iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
++                                                         StreamInfo::StreamInfo& stream_info) {
++  return parent_.filter_manager_callbacks_.iterateUpstreamCallbacks(host, stream_info);
++
++}
++
+ void ActiveStreamDecoderFilter::requestDataDrained() {
+   // If this is called it means the call to requestDataTooLarge() was a
+   // streaming call, or a 413 would have been sent.
+diff --git a/source/common/http/filter_manager.h b/source/common/http/filter_manager.h
+index 06de03b77..eb32a1dc7 100644
+--- a/source/common/http/filter_manager.h
++++ b/source/common/http/filter_manager.h
+@@ -300,6 +300,9 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
+       Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) override;
+   absl::optional<Router::ConfigConstSharedPtr> routeConfig();
+ 
++  bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
++                                StreamInfo::StreamInfo& stream_info) override;
++
+   StreamDecoderFilterSharedPtr handle_;
+   bool is_grpc_request_{};
+ };
+@@ -582,6 +585,12 @@ public:
+    * Returns whether internal redirects with request bodies is enabled.
+    */
+   virtual bool enableInternalRedirectsWithBody() const PURE;
++
++  /**
++   * Returns whether connection to the selected upstream host is allowed.
++   */
++  virtual bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
++                                        StreamInfo::StreamInfo&) const PURE;
+ };
+ 
+ /**
+diff --git a/source/common/network/filter_manager_impl.h b/source/common/network/filter_manager_impl.h
+index 879731609..6ff42ffa4 100644
+--- a/source/common/network/filter_manager_impl.h
++++ b/source/common/network/filter_manager_impl.h
+@@ -130,6 +130,13 @@ private:
+     void upstreamHost(Upstream::HostDescriptionConstSharedPtr host) override {
+       parent_.host_description_ = host;
+     }
++    void addUpstreamCallback(const UpstreamCallback& cb) override {
++      parent_.addUpstreamCallback(cb);
++    }
++    bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
++                                  StreamInfo::StreamInfo& stream_info) override {
++      return parent_.iterateUpstreamCallbacks(host, stream_info);
++    }
+ 
+     FilterManagerImpl& parent_;
+     ReadFilterSharedPtr filter_;
+@@ -160,6 +167,20 @@ private:
+   FilterStatus onWrite(ActiveWriteFilter* filter, WriteBufferSource& buffer_source);
+   void onResumeWriting(ActiveWriteFilter* filter, WriteBufferSource& buffer_source);
+ 
++  void addUpstreamCallback(const UpstreamCallback& cb) {
++    decoder_filter_upstream_cbs_.emplace_back(cb);
++  }
++    
++  bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
++				StreamInfo::StreamInfo& stream_info) {
++    bool accept = true;
++    for (const auto& cb : decoder_filter_upstream_cbs_) {
++      accept = accept && cb(host, stream_info);
++    }
++    return accept;
++  }
++
++  std::vector<UpstreamCallback> decoder_filter_upstream_cbs_{};
+   FilterManagerConnection& connection_;
+   const Socket& socket_;
+   Upstream::HostDescriptionConstSharedPtr host_description_;
+diff --git a/source/common/router/router.cc b/source/common/router/router.cc
+index 9adb05a4b..60252a0b8 100644
+--- a/source/common/router/router.cc
++++ b/source/common/router/router.cc
+@@ -632,6 +632,14 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
+     return Http::FilterHeadersStatus::StopIteration;
+   }
+ 
++  bool accepted = callbacks_->iterateUpstreamCallbacks(host, callbacks_->streamInfo());
++  if (!accepted) {
++    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
++    callbacks_->sendLocalReply(Http::Code::Forbidden, "Access denied\r\n",
++                               nullptr, absl::nullopt, absl::string_view());
++    return Http::FilterHeadersStatus::StopIteration;
++  }
++  
+   hedging_params_ = FilterUtility::finalHedgingParams(*route_entry_, headers);
+ 
+   timeout_ = FilterUtility::finalTimeout(*route_entry_, headers, !config_.suppress_envoy_headers_,
+diff --git a/source/common/tcp_proxy/tcp_proxy.cc b/source/common/tcp_proxy/tcp_proxy.cc
+index 4ce38e576..fb00aae10 100644
+--- a/source/common/tcp_proxy/tcp_proxy.cc
++++ b/source/common/tcp_proxy/tcp_proxy.cc
+@@ -423,6 +423,13 @@ bool Filter::maybeTunnel(Upstream::ThreadLocalCluster& cluster) {
+   generic_conn_pool_ = factory->createGenericConnPool(cluster, config_->tunnelingConfig(), this,
+                                                       *upstream_callbacks_);
+   if (generic_conn_pool_) {
++    bool accepted = read_callbacks_->iterateUpstreamCallbacks(generic_conn_pool_->host(), getStreamInfo());
++    if (!accepted) {
++      getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
++      onInitFailure(UpstreamFailureReason::UnauthorizedExternalService);
++      return true;
++    }
++
+     connecting_ = true;
+     connect_attempts_++;
+     getStreamInfo().setAttemptCount(connect_attempts_);
+diff --git a/source/common/tcp_proxy/tcp_proxy.h b/source/common/tcp_proxy/tcp_proxy.h
+index 22a49739c..5257a9243 100644
+--- a/source/common/tcp_proxy/tcp_proxy.h
++++ b/source/common/tcp_proxy/tcp_proxy.h
+@@ -328,6 +328,7 @@ protected:
+     NoHealthyUpstream,
+     ResourceLimitExceeded,
+     NoRoute,
++    UnauthorizedExternalService,
+   };
+ 
+   // Callbacks for different error and success states during connection establishment
+diff --git a/source/common/tcp_proxy/upstream.cc b/source/common/tcp_proxy/upstream.cc
+index 4fdb83854..cc0746b29 100644
+--- a/source/common/tcp_proxy/upstream.cc
++++ b/source/common/tcp_proxy/upstream.cc
+@@ -174,6 +174,10 @@ void TcpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
+   }
+ }
+ 
++Upstream::HostDescriptionConstSharedPtr TcpConnPool::host() const {
++  return conn_pool_data_.value().host();
++}
++
+ void TcpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason, absl::string_view,
+                                 Upstream::HostDescriptionConstSharedPtr host) {
+   upstream_handle_ = nullptr;
+@@ -231,6 +235,10 @@ void HttpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
+   }
+ }
+ 
++Upstream::HostDescriptionConstSharedPtr HttpConnPool::host() const {
++  return conn_pool_data_.value().host();
++}
++
+ void HttpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason, absl::string_view,
+                                  Upstream::HostDescriptionConstSharedPtr host) {
+   upstream_handle_ = nullptr;
+diff --git a/source/common/tcp_proxy/upstream.h b/source/common/tcp_proxy/upstream.h
+index fbae213d5..f85a3b324 100644
+--- a/source/common/tcp_proxy/upstream.h
++++ b/source/common/tcp_proxy/upstream.h
+@@ -26,6 +26,7 @@ public:
+ 
+   // GenericConnPool
+   void newStream(GenericConnectionPoolCallbacks& callbacks) override;
++  Upstream::HostDescriptionConstSharedPtr host() const override;
+ 
+   // Tcp::ConnectionPool::Callbacks
+   void onPoolFailure(ConnectionPool::PoolFailureReason reason,
+@@ -57,6 +58,7 @@ public:
+ 
+   // GenericConnPool
+   void newStream(GenericConnectionPoolCallbacks& callbacks) override;
++  Upstream::HostDescriptionConstSharedPtr host() const override;
+ 
+   // Http::ConnectionPool::Callbacks,
+   void onPoolFailure(ConnectionPool::PoolFailureReason reason,
+diff --git a/source/server/api_listener_impl.h b/source/server/api_listener_impl.h
+index 9d401fa27..9992cc07a 100644
+--- a/source/server/api_listener_impl.h
++++ b/source/server/api_listener_impl.h
+@@ -73,6 +73,9 @@ protected:
+     }
+     Network::Connection& connection() override { return connection_; }
+     const Network::Socket& socket() override { PANIC("not implemented"); }
++    void addUpstreamCallback(const Network::UpstreamCallback&) override {}
++    bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
++				  StreamInfo::StreamInfo&) override { return true; }
+ 
+     // Synthetic class that acts as a stub for the connection backing the
+     // Network::ReadFilterCallbacks.
+-- 
+2.34.1
+

--- a/tests/bpf_metadata.h
+++ b/tests/bpf_metadata.h
@@ -22,7 +22,7 @@ extern std::shared_ptr<const Cilium::NetworkPolicyMap> npmap;
 
 extern std::string policy_config;
 
-namespace Filter {
+namespace Cilium {
 namespace BpfMetadata {
 
 class TestConfig : public Config {

--- a/tests/cilium_http_integration.cc
+++ b/tests/cilium_http_integration.cc
@@ -19,19 +19,21 @@ CiliumHttpIntegrationTest::CiliumHttpIntegrationTest(const std::string& config)
 
 CiliumHttpIntegrationTest::~CiliumHttpIntegrationTest() {}
 
-void CiliumHttpIntegrationTest::initialize() {
-  HttpIntegrationTest::initialize();
+void CiliumHttpIntegrationTest::createEnvoy() {
+  // fake upstreams have been created by now, use the port from the 1st upstream
+  // in policy.
+  auto port = fake_upstreams_[0]->localAddress()->ip()->port();
+  policy_config = fmt::format(testPolicyFmt(), port);
   // Pass the fake upstream address to the cilium bpf filter that will set it as
   // an "original destination address".
   if (GetParam() == Network::Address::IpVersion::v4) {
     original_dst_address = std::make_shared<Network::Address::Ipv4Instance>(
-        Network::Test::getLoopbackAddressString(GetParam()),
-        fake_upstreams_.back()->localAddress()->ip()->port());
+        Network::Test::getLoopbackAddressString(GetParam()), port);
   } else {
     original_dst_address = std::make_shared<Network::Address::Ipv6Instance>(
-        Network::Test::getLoopbackAddressString(GetParam()),
-        fake_upstreams_.back()->localAddress()->ip()->port());
+        Network::Test::getLoopbackAddressString(GetParam()), port);
   }
+  HttpIntegrationTest::createEnvoy();  
 }
 
 }  // namespace Envoy

--- a/tests/cilium_http_integration.h
+++ b/tests/cilium_http_integration.h
@@ -12,10 +12,9 @@ class CiliumHttpIntegrationTest
   CiliumHttpIntegrationTest(const std::string& config);
   ~CiliumHttpIntegrationTest();
 
-  /**
-   * Initializer for an individual integration test.
-   */
-  void initialize() override;
+  void createEnvoy() override;
+
+  virtual std::string testPolicyFmt() PURE;
 
   AccessLogServer accessLogServer_;
 };

--- a/tests/cilium_http_integration_test.cc
+++ b/tests/cilium_http_integration_test.cc
@@ -8,55 +8,94 @@
 
 namespace Envoy {
 
-const std::string BASIC_POLICY = R"EOF(version_info: "0"
+// params: destination port number
+const std::string BASIC_POLICY_fmt = R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicy
   name: '{{ ntop_ip_loopback_address }}'
-  policy: 3
+  endpoint_id: 3
   ingress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/allowed' } ]
-        - headers: [ { name: ':path', safe_regex_match: { google_re2: {}, regex: '.*public$' } } ]
-        - headers: [ { name: ':authority', exact_match: 'allowedHOST' } ]
-        - headers: [ { name: ':authority', safe_regex_match: { google_re2: {}, regex: '.*REGEX.*' } } ]
-        - headers: [ { name: ':method', exact_match: 'PUT' }, { name: ':path', exact_match: '/public/opinions' } ]
+        - headers:
+          - name: ':path'
+            exact_match: '/allowed'
+        - headers:
+          - name: ':path'
+            safe_regex_match:
+              google_re2: {{}}
+              regex: '.*public$'
+        - headers:
+          - name: ':authority'
+            exact_match: 'allowedHOST'
+        - headers:
+          - name: ':authority'
+            safe_regex_match:
+              google_re2: {{}}
+              regex: '.*REGEX.*'
+        - headers:
+          - name: ':method'
+            exact_match: 'PUT'
+         - name: ':path'
+           exact_match: '/public/opinions'
     - remote_policies: [ 2 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/only-2-allowed' } ]
+        - headers:
+          - name: ':path'
+            exact_match: '/only-2-allowed'
   egress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/allowed' } ]
-        - headers: [ { name: ':path', safe_regex_match: { google_re2: {}, regex: '.*public$' } } ]
-        - headers: [ { name: ':authority', exact_match: 'allowedHOST' } ]
-        - headers: [ { name: ':authority', safe_regex_match: { google_re2: {}, regex: '.*REGEX.*' } } ]
-        - headers: [ { name: ':method', exact_match: 'PUT' }, { name: ':path', exact_match: '/public/opinions' } ]
+        - headers:
+          - name: ':path'
+            exact_match: '/allowed'
+        - headers:
+          - name: ':path'
+            safe_regex_match:
+              google_re2: {{}}
+              regex: '.*public$'
+        - headers:
+          - name: ':authority'
+            exact_match: 'allowedHOST'
+        - headers:
+          - name: ':authority'
+            safe_regex_match:
+              google_re2: {{}}
+              regex: '.*REGEX.*'
+        - headers:
+          - name: ':method'
+            exact_match: 'PUT'
+          - name: ':path'
+            exact_match: '/public/opinions'
     - remote_policies: [ 2 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/only-2-allowed' } ]
+        - headers:
+          - name: ':path'
+            exact_match: '/only-2-allowed'
 )EOF";
 
-const std::string HEADER_ACTION_POLICY = R"EOF(version_info: "0"
+const std::string HEADER_ACTION_POLICY_fmt = R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicy
   name: '{{ ntop_ip_loopback_address }}'
-  policy: 3
+  endpoint_id: 3
   ingress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/allowed' } ]
+        - headers:
+          - name: ':path'
+            exact_match: '/allowed'
           header_matches:
           - name: 'header42'
             match_action: FAIL_ON_MATCH
@@ -64,12 +103,18 @@ resources:
           - name: 'header1'
             value: 'value1'
             mismatch_action: REPLACE_ON_MISMATCH
-        - headers: [ { name: ':path', safe_regex_match: { google_re2: {}, regex: '.*public$' } } ]
+        - headers:
+          - name: ':path'
+            safe_regex_match:
+              google_re2: {{}}
+              regex: '.*public$'
           header_matches:
           - name: 'user-agent'
             value: 'CuRL'
             mismatch_action: DELETE_ON_MISMATCH
-        - headers: [ { name: ':authority', exact_match: 'allowedHOST' } ]
+        - headers:
+          - name: ':authority'
+            exact_match: 'allowedHOST'
           header_matches:
           - name: 'header2'
             value: 'value2'
@@ -77,31 +122,59 @@ resources:
           - name: 'header42'
             match_action: DELETE_ON_MATCH
             mismatch_action: CONTINUE_ON_MISMATCH
-        - headers: [ { name: ':authority', safe_regex_match: { google_re2: {}, regex: '.*REGEX.*' } } ]
+        - headers:
+          - name: ':authority'
+            safe_regex_match:
+              google_re2: {{}}
+              regex: '.*REGEX.*'
           header_matches:
           - name: 'header42'
             value: '42'
             mismatch_action: DELETE_ON_MISMATCH
-        - headers: [ { name: ':method', exact_match: 'PUT' }, { name: ':path', exact_match: '/public/opinions' } ]
+        - headers:
+          - name: ':method'
+            exact_match: 'PUT'
+          - name: ':path'
+            exact_match: '/public/opinions'
     - remote_policies: [ 2 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/only-2-allowed' } ]
+        - headers:
+          - name: ':path'
+            exact_match: '/only-2-allowed'
   egress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/allowed' } ]
-        - headers: [ { name: ':path', safe_regex_match: { google_re2: {}, regex: '.*public$' } } ]
-        - headers: [ { name: ':authority', exact_match: 'allowedHOST' } ]
-        - headers: [ { name: ':authority', safe_regex_match: { google_re2: {}, regex: '.*REGEX.*' } } ]
-        - headers: [ { name: ':method', exact_match: 'PUT' }, { name: ':path', exact_match: '/public/opinions' } ]
+        - headers:
+          - name: ':path'
+            exact_match: '/allowed'
+        - headers:
+          - name: ':path'
+            safe_regex_match:
+              google_re2: {{}}
+              regex: '.*public$'
+        - headers:
+          - name: ':authority'
+            exact_match: 'allowedHOST'
+        - headers:
+          - name: ':authority'
+            safe_regex_match:
+              google_re2: {{}}
+              regex: '.*REGEX.*'
+        - headers:
+          - name: ':method'
+            exact_match: 'PUT'
+          - name: ':path'
+            exact_match: '/public/opinions'
     - remote_policies: [ 2 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/only-2-allowed' } ]
+        - headers:
+          - name: ':path'
+            exact_match: '/only-2-allowed'
 )EOF";
 
 // params: is_ingress ("true", "false")
@@ -147,9 +220,6 @@ static_resources:
     filter_chains:
       filters:
       - name: cilium.network
-        typed_config:
-          "@type": type.googleapis.com/cilium.NetworkFilter
-          proxylib: "proxylib/libcilium.so"
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -185,9 +255,11 @@ class CiliumIntegrationTest : public CiliumHttpIntegrationTest {
   CiliumIntegrationTest(const std::string& config)
       : CiliumHttpIntegrationTest(config) {}
 
+  std::string testPolicyFmt() {
+    return TestEnvironment::substitute(HEADER_ACTION_POLICY_fmt, GetParam());
+  }
+
   void Denied(Http::TestRequestHeaderMapImpl&& headers) {
-    policy_config =
-        TestEnvironment::substitute(HEADER_ACTION_POLICY, GetParam());
     initialize();
     codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response = codec_client_->makeHeaderOnlyRequest(headers);
@@ -199,8 +271,6 @@ class CiliumIntegrationTest : public CiliumHttpIntegrationTest {
   }
 
   void Accepted(Http::TestRequestHeaderMapImpl&& headers) {
-    policy_config =
-        TestEnvironment::substitute(HEADER_ACTION_POLICY, GetParam());
     initialize();
     codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response =
@@ -588,22 +658,37 @@ TEST_P(CiliumIntegrationTest, L3DeniedPath) {
           {":authority", "host"}});
 }
 
-TEST_P(CiliumIntegrationTest, DuplicatePort) {
-  // This policy has a duplicate port number, and will be rejected.
-  policy_config =
-      TestEnvironment::substitute(BASIC_POLICY, GetParam()) + R"EOF(  - port: 80
+class CiliumIntegrationPortTest : public CiliumIntegrationTest {
+ public:
+  CiliumIntegrationPortTest()
+    : CiliumIntegrationTest() {}
+
+  std::string testPolicyFmt() {
+    return TestEnvironment::substitute(BASIC_POLICY_fmt, GetParam()) + R"EOF(  - port: {0}
     rules:
     - remote_policies: [ 2 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', safe_regex_match: { google_re2: {}, regex: '/only-2-allowed' } } ]
+        - headers:
+          - name: ':path'
+            safe_regex_match:
+              google_re2: {{}}
+              regex: '/only-2-allowed'
 )EOF";
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    IpVersions, CiliumIntegrationPortTest,
+    testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(CiliumIntegrationPortTest, DuplicatePort) {
+  initialize();
 
   // This would normally be allowed, but since the policy fails, everything will
   // be rejected.
   Http::TestRequestHeaderMapImpl headers = {
       {":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}};
-  initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeHeaderOnlyRequest(headers);
   ASSERT_TRUE(response->waitForEndStream());
@@ -683,6 +768,39 @@ TEST_P(CiliumIntegrationEgressTest, L3DeniedPath) {
   Denied({{":method", "GET"},
           {":path", "/only-2-allowed"},
           {":authority", "host"}});
+}
+
+
+const std::string L34_POLICY_fmt = R"EOF(version_info: "0"
+resources:
+- "@type": type.googleapis.com/cilium.NetworkPolicy
+  name: '{{ ntop_ip_loopback_address }}'
+  endpoint_id: 3
+  egress_per_port_policies:
+  - port: {0}
+    rules:
+    - remote_policies: [ 42 ]
+)EOF";
+
+class CiliumIntegrationEgressL34Test : public CiliumIntegrationEgressTest {
+ public:
+  CiliumIntegrationEgressL34Test() {}
+
+  std::string testPolicyFmt() {
+    return TestEnvironment::substitute(L34_POLICY_fmt, GetParam());
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    IpVersions, CiliumIntegrationEgressL34Test,
+    testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(CiliumIntegrationEgressL34Test, DeniedPathPrefix) {
+  Denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
+}
+
+TEST_P(CiliumIntegrationEgressL34Test, DeniedPathPrefix2) {
+  Denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 }
 
 }  // namespace Envoy

--- a/tests/cilium_tcp_integration.h
+++ b/tests/cilium_tcp_integration.h
@@ -11,7 +11,9 @@ class CiliumTcpIntegrationTest
  public:
   CiliumTcpIntegrationTest(const std::string& config);
 
-  virtual std::string testPolicy();
+  void createEnvoy() override;
+
+  virtual std::string testPolicyFmt();
 
   void initialize() override;
   void TearDown() override;

--- a/tests/cilium_tcp_integration_test.cc
+++ b/tests/cilium_tcp_integration_test.cc
@@ -364,18 +364,18 @@ static_resources:
           cluster: cluster1
 )EOF";
 
-const std::string TCP_POLICY_LINEPARSER = R"EOF(version_info: "0"
+const std::string TCP_POLICY_LINEPARSER_fmt = R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicy
   name: '{{ ntop_ip_loopback_address }}'
   policy: 3
   ingress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       l7_proto: "test.lineparser"
   egress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       l7_proto: "test.lineparser"
@@ -389,8 +389,8 @@ class CiliumGoLinetesterIntegrationTest : public CiliumTcpIntegrationTest {
                             cilium_linetester_config_fmt, GetParam()),
                         "true")) {}
 
-  std::string testPolicy() override {
-    return TestEnvironment::substitute(TCP_POLICY_LINEPARSER, GetParam());
+  std::string testPolicyFmt() override {
+    return TestEnvironment::substitute(TCP_POLICY_LINEPARSER_fmt, GetParam());
   }
 };
 
@@ -607,18 +607,18 @@ static_resources:
           cluster: cluster1
 )EOF";
 
-const std::string TCP_POLICY_BLOCKPARSER = R"EOF(version_info: "0"
+const std::string TCP_POLICY_BLOCKPARSER_fmt = R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicy
   name: '{{ ntop_ip_loopback_address }}'
   policy: 3
   ingress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       l7_proto: "test.blockparser"
   egress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       l7_proto: "test.blockparser"
@@ -632,8 +632,8 @@ class CiliumGoBlocktesterIntegrationTest : public CiliumTcpIntegrationTest {
                             cilium_blocktester_config_fmt, GetParam()),
                         "true")) {}
 
-  std::string testPolicy() override {
-    return TestEnvironment::substitute(TCP_POLICY_BLOCKPARSER, GetParam());
+  std::string testPolicyFmt() override {
+    return TestEnvironment::substitute(TCP_POLICY_BLOCKPARSER_fmt, GetParam());
   }
 };
 

--- a/tests/cilium_tls_http_integration_test.cc
+++ b/tests/cilium_tls_http_integration_test.cc
@@ -34,6 +34,13 @@ static_resources:
       seconds: 1
     transport_socket:
       name: "cilium.tls_wrapper"
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        upstream_http_protocol_options:
+          auto_sni: true
+          auto_san_validation: true
+        use_downstream_protocol_config: {{}}
   - name: xds-grpc-cilium
     connect_timeout:
       seconds: 5
@@ -296,13 +303,6 @@ TEST_P(CiliumTLSHttpIntegrationTest, DeniedPathPrefix) {
 TEST_P(CiliumTLSHttpIntegrationTest, AllowedPathPrefix) {
   Accepted(
       {{":method", "GET"}, {":path", "/allowed"}, {":authority", "localhost"}});
-}
-
-TEST_P(CiliumTLSHttpIntegrationTest, InvalidHostNameSNI) {
-  // SNI is now coming from the cilium listener filter, so it is accepted
-  Accepted({{":method", "GET"},
-            {":path", "/allowed"},
-            {":authority", "nonlocalhost"}});
 }
 
 TEST_P(CiliumTLSHttpIntegrationTest, AllowedPathPrefixStrippedHeader) {

--- a/tests/cilium_tls_http_integration_test.cc
+++ b/tests/cilium_tls_http_integration_test.cc
@@ -132,22 +132,22 @@ static_resources:
 // certificate_chain from test/config/integration/certs/servercert.pem
 // downstream_tls_context private_key from
 // test/config/integration/certs/serverkey.pem
-const std::string BASIC_TLS_POLICY = R"EOF(version_info: "0"
+const std::string BASIC_TLS_POLICY_fmt = R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicy
   name: '{{ ntop_ip_loopback_address }}'
   policy: 3
   ingress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/allowed' } ]
-        - headers: [ { name: ':path', safe_regex_match: { google_re2: {}, regex: '.*public$' } } ]
-        - headers: [ { name: ':authority', exact_match: 'allowedHOST' } ]
-        - headers: [ { name: ':authority', safe_regex_match: { google_re2: {}, regex: '.*REGEX.*' } } ]
-        - headers: [ { name: ':method', exact_match: 'PUT' }, { name: ':path', exact_match: '/public/opinions' } ]
+        - headers: [ {{ name: ':path', exact_match: '/allowed' }} ]
+        - headers: [ {{ name: ':path', safe_regex_match: {{ google_re2: {{}}, regex: '.*public$' }} }} ]
+        - headers: [ {{ name: ':authority', exact_match: 'allowedHOST' }} ]
+        - headers: [ {{ name: ':authority', safe_regex_match: {{ google_re2: {{}}, regex: '.*REGEX.*' }} }} ]
+        - headers: [ {{ name: ':method', exact_match: 'PUT' }}, {{ name: ':path', exact_match: '/public/opinions' }} ]
       upstream_tls_context:
         trusted_ca: "-----BEGIN CERTIFICATE-----\nMIID7zCCAtegAwIBAgIUTQZdxxw6y4+Te1kv8hDza/KXTHUwDQYJKoZIhvcNAQEL\nBQAwfzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcM\nDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBEx5ZnQxGTAXBgNVBAsMEEx5ZnQgRW5n\naW5lZXJpbmcxGTAXBgNVBAMMEFRlc3QgVXBzdHJlYW0gQ0EwHhcNMjAwODA1MTkx\nNjAyWhcNMjIwODA1MTkxNjAyWjB/MQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2Fs\naWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwETHlmdDEZ\nMBcGA1UECwwQTHlmdCBFbmdpbmVlcmluZzEZMBcGA1UEAwwQVGVzdCBVcHN0cmVh\nbSBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOFT8hbqRn+9AKU2\nIFtZKFFYpt7v2x1e8gtzgPm3TT7RJcV2GLeT1cOwubL81ArQmwfyVlwJkt1wK7Uw\n+Z4FvtcCjQc4dR3yxkIdhzZOiq7PbQgAjyRNNGmneYTAvpXwC+l8ZV2M66ihUKgj\n7iGiqQCvYhuYIb7BEnOj20nFuvHlxaDWOst4SQgZmRIkQyA8rrAIRfu7aQiCEla5\n86AXcXV4gmOW3dsKNoXO8Fr+9mtAmJKocLtlUkCeDW+WYqv6RLjMVa915khNQLde\nbL+5hYxBcKYB10wOVzSTCfM6fbqtpqJZEdlGjkKtQ2Szy3mpoAJKPmZYzodVhL6N\nLhoLjZ8CAwEAAaNjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYw\nHQYDVR0OBBYEFDtmHVOikybtJjVEI4Q7wvUbwgBkMB8GA1UdIwQYMBaAFDtmHVOi\nkybtJjVEI4Q7wvUbwgBkMA0GCSqGSIb3DQEBCwUAA4IBAQAT3kBm2uCpB4cAmdgu\nu6sqxUvYFzYlHFnWrQ3ZFwMrLRSzUdrcp2nSQz+e8VeXI2SkLPCD5Xg+8GGLWA5X\nlH6tvVx41cRqSr611ebxPVWkEeP+ALkHo4xUbcR5WUJD52VxzqYbhavYFjB2FzqA\nOfefKyXIhcKtezKBwaJbVn9FseH49q6UNjYODOY88rW+2mvDoZWBUuti8CxNhIiu\nRHnGimY7H565NpbPliVlo2GhiKhJvyPwK7+cjfj68HaoixlXHmrg506bczO/Gt1a\nUSQmjtB05h8bki0LQDiCQu1fdOPEflJnv3VdFz2SSKNRab2asP+KbRPURUW8f9zN\nGNxR\n-----END CERTIFICATE-----\n"
       downstream_tls_context:
@@ -156,22 +156,22 @@ resources:
     - remote_policies: [ 2 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/only-2-allowed' } ]
+        - headers: [ {{ name: ':path', exact_match: '/only-2-allowed' }} ]
   egress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/allowed' } ]
-        - headers: [ { name: ':path', safe_regex_match: { google_re2: {}, regex: '.*public$' } } ]
-        - headers: [ { name: ':authority', exact_match: 'allowedHOST' } ]
-        - headers: [ { name: ':authority', safe_regex_match: { google_re2: {}, regex: '.*REGEX.*' } } ]
-        - headers: [ { name: ':method', exact_match: 'PUT' }, { name: ':path', exact_match: '/public/opinions' } ]
+        - headers: [ {{ name: ':path', exact_match: '/allowed' }} ]
+        - headers: [ {{ name: ':path', safe_regex_match: {{ google_re2: {{}}, regex: '.*public$' }} }} ]
+        - headers: [ {{ name: ':authority', exact_match: 'allowedHOST' }} ]
+        - headers: [ {{ name: ':authority', safe_regex_match: {{ google_re2: {{}}, regex: '.*REGEX.*' }} }} ]
+        - headers: [ {{ name: ':method', exact_match: 'PUT' }}, {{ name: ':path', exact_match: '/public/opinions' }} ]
     - remote_policies: [ 2 ]
       http_rules:
         http_rules:
-        - headers: [ { name: ':path', exact_match: '/only-2-allowed' } ]
+        - headers: [ {{ name: ':path', exact_match: '/only-2-allowed' }} ]
 )EOF";
 
 /*
@@ -239,8 +239,11 @@ class CiliumHttpTLSIntegrationTest : public CiliumHttpIntegrationTest {
         std::vector<std::string>{});
   }
 
+  std::string testPolicyFmt() {
+    return TestEnvironment::substitute(BASIC_TLS_POLICY_fmt, GetParam());
+  }
+
   void Denied(Http::TestRequestHeaderMapImpl&& headers) {
-    policy_config = TestEnvironment::substitute(BASIC_TLS_POLICY, GetParam());
     initialize();
     auto response = codec_client_->makeHeaderOnlyRequest(headers);
     ASSERT_TRUE(response->waitForEndStream());
@@ -251,7 +254,6 @@ class CiliumHttpTLSIntegrationTest : public CiliumHttpIntegrationTest {
   }
 
   void Failed(Http::TestRequestHeaderMapImpl&& headers) {
-    policy_config = TestEnvironment::substitute(BASIC_TLS_POLICY, GetParam());
     initialize();
     auto response = codec_client_->makeHeaderOnlyRequest(headers);
     ASSERT_TRUE(response->waitForEndStream());
@@ -262,7 +264,6 @@ class CiliumHttpTLSIntegrationTest : public CiliumHttpIntegrationTest {
   }
 
   void Accepted(Http::TestRequestHeaderMapImpl&& headers) {
-    policy_config = TestEnvironment::substitute(BASIC_TLS_POLICY, GetParam());
     initialize();
     auto response =
         sendRequestAndWaitForResponse(headers, 0, default_response_headers_, 0);

--- a/tests/cilium_tls_tcp_integration_test.cc
+++ b/tests/cilium_tls_tcp_integration_test.cc
@@ -222,13 +222,13 @@ class CiliumTLSIntegrationTest : public CiliumTcpIntegrationTest {
 // certificate_chain from test/config/integration/certs/servercert.pem
 // downstream_tls_context private_key from
 // test/config/integration/certs/serverkey.pem
-const std::string TCP_POLICY_UPSTREAM_TLS = R"EOF(version_info: "0"
+const std::string TCP_POLICY_UPSTREAM_TLS_fmt = R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicy
   name: '{{ ntop_ip_loopback_address }}'
   policy: 3
   ingress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
       upstream_tls_context:
@@ -237,7 +237,7 @@ resources:
         certificate_chain: "-----BEGIN CERTIFICATE-----\nMIIEbDCCA1SgAwIBAgIUJuVBh0FKfFgIcO++ljWm7D47eYUwDQYJKoZIhvcNAQEL\nBQAwdjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcM\nDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBEx5ZnQxGTAXBgNVBAsMEEx5ZnQgRW5n\naW5lZXJpbmcxEDAOBgNVBAMMB1Rlc3QgQ0EwHhcNMjAwODA1MTkxNjAxWhcNMjIw\nODA1MTkxNjAxWjCBpjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWEx\nFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBEx5ZnQxGTAXBgNVBAsM\nEEx5ZnQgRW5naW5lZXJpbmcxGjAYBgNVBAMMEVRlc3QgQmFja2VuZCBUZWFtMSQw\nIgYJKoZIhvcNAQkBFhViYWNrZW5kLXRlYW1AbHlmdC5jb20wggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQC9JgaI7hxjPM0tsUna/QmivBdKbCrLnLW9Teak\nRH/Ebg68ovyvrRIlybDT6XhKi+iVpzVY9kqxhGHgrFDgGLBakVMiYJ5EjIgHfoo4\nUUAHwIYbunJluYCgANzpprBsvTC/yFYDVMqUrjvwHsoYYVm36io994k9+t813b70\no0l7/PraBsKkz8NcY2V2mrd/yHn/0HAhv3hl6iiJme9yURuDYQrae2ACSrQtsbel\nKwdZ/Re71Z1awz0OQmAjMa2HuCop+Q/1QLnqBekT5+DH1qKUzJ3Jkq6NRkERXOpi\n87j04rtCBteCogrO67qnuBZ2lH3jYEMb+lQdLkyNMLltBSdLAgMBAAGjgcAwgb0w\nDAYDVR0TAQH/BAIwADALBgNVHQ8EBAMCBeAwHQYDVR0lBBYwFAYIKwYBBQUHAwIG\nCCsGAQUFBwMBMEEGA1UdEQQ6MDiGHnNwaWZmZTovL2x5ZnQuY29tL2JhY2tlbmQt\ndGVhbYIIbHlmdC5jb22CDHd3dy5seWZ0LmNvbTAdBgNVHQ4EFgQU2XcTZbc0xKZf\ngNVKSvAbMZJCBoYwHwYDVR0jBBgwFoAUlkvaLFO0vpXGk3Pip6SfLg1yGIcwDQYJ\nKoZIhvcNAQELBQADggEBAFW05aca3hSiEz/g593GAV3XP4lI5kYUjGjbPSy/HmLr\nrdv/u3bGfacywAPo7yld+arMzd35tIYEqnhoq0+/OxPeyhwZXVVUatg5Oknut5Zv\n2+8l+mVW+8oFCXRqr2gwc8Xt4ByYN+HaNUYfoucnjDplOPukkfSuRhbxqnkhA14v\nLri2EbISX14sXf2VQ9I0dkm1hXUxiO0LlA1Z7tvJac9zPSoa6Oljke4D1iH2jzwF\nYn7S/gGvVQgkTmWrs3S3TGyBDi4GTDhCF1R+ESvXz8z4UW1MrCSdYUXbRtsT7sbE\nCjlFYuUyxCi1oe3IHCeXVDo/bmzwGQPDuF3WaDNSYWU=\n-----END CERTIFICATE-----\n"
         private_key: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAvSYGiO4cYzzNLbFJ2v0JorwXSmwqy5y1vU3mpER/xG4OvKL8\nr60SJcmw0+l4Sovolac1WPZKsYRh4KxQ4BiwWpFTImCeRIyIB36KOFFAB8CGG7py\nZbmAoADc6aawbL0wv8hWA1TKlK478B7KGGFZt+oqPfeJPfrfNd2+9KNJe/z62gbC\npM/DXGNldpq3f8h5/9BwIb94ZeooiZnvclEbg2EK2ntgAkq0LbG3pSsHWf0Xu9Wd\nWsM9DkJgIzGth7gqKfkP9UC56gXpE+fgx9ailMydyZKujUZBEVzqYvO49OK7QgbX\ngqIKzuu6p7gWdpR942BDG/pUHS5MjTC5bQUnSwIDAQABAoIBADEMwlcSAFSPuNln\nhzJ9udj0k8md4T8p5Usw/2WLyeJDdBjg30wjQniAJBXgDmyueWMNmFz4iYgdP1CG\n/vYOEPV7iCZ7Da/TDZd77hYKo+MevuhD4lSU1VEoyCDjNA8OxKyHJB77BwmlYS+0\nnE3UOPLji47EOVfUTbvnRBSmn3DCSHkQiRIUP1xMivoiZgKJn+D+FxSMwwiq2pQR\n5tdo7nh2A8RxlYUbaD6i4poUB26HVm8vthXahNEkLpXQOz8MWRzs6xOdDHRzi9kT\nItRLa4A/3LIATqviQ2EpwcALHXcULcNUMTHORC1EHPvheWR5nLuRllYzN4ReoeHC\n3+A5KEkCgYEA52rlh/22/rLckCWugjyJic17vkg46feSOGhjuP2LelrIxNlg491y\no28n8lQPSVnEp3/sT7Y3quVvdboq4DC9LTzq52f6/mCYh9UQRpljuSmFqC2MPG46\nZl5KLEVLzhjC8aTWkhVINSpz9vauXderOpFYlPW32lnRTjJWE276kj8CgYEA0T2t\nULnn7TBvRSpmeWzEBA5FFo2QYkYvwrcVe0pfUltV6pf05xUmMXYFjpezSTEmPhh6\n+dZdhwxDk+6j8Oo61rTWucDsIqMj5ZT1hPNph8yQtb5LRlRbLGVrirU9Tp7xTgMq\n3uRA2Eka1d98dDBsEbMIVFSZ2MX3iezSGRL6j/UCgYEAxZQ82HjEDn2DVwb1EXjC\nLQdliTZ8cTXQf5yQ19aRiSuNkpPN536ga+1xe7JNQuEDx8auafg3Ww98tFT4WmUC\nf2ctX9klMJ4kXISK2twHioVq+gW5X7b04YXLajTX3eTCPDHyiNLmzY2raMWAZdrG\n9MA3kyafjCt3Sn4rg3gTM10CgYEAtJ8WRpJEd8aQttcUIItYZdvfnclUMtE9l0su\nGwCnalN3xguol/X0w0uLHn0rgeoQhhfhyFtY3yQiDcg58tRvODphBXZZIMlNSnic\nvEjW9ygKXyjGmA5nqdpezB0JsB2aVep8Dm5g35Ozu52xNCc8ksbGUO265Jp3xbMN\n5iEw9CUCgYBmfoPnJwzA5S1zMIqESUdVH6p3UwHU/+XTY6JHAnEVsE+BuLe3ioi7\n6dU4rFd845MCkunBlASLV8MmMbod9xU0vTVHPtmANaUCPxwUIxXQket09t19Dzg7\nA23sE+5myXtcfz6YrPhbLkijV4Nd7fmecodwDckvpBaWTMrv52/Www==\n-----END RSA PRIVATE KEY-----\n"
   egress_per_port_policies:
-  - port: 80
+  - port: {0}
     rules:
     - remote_policies: [ 1 ]
 )EOF";
@@ -250,8 +250,8 @@ class CiliumTLSProxyIntegrationTest : public CiliumTLSIntegrationTest {
                             cilium_tls_tcp_proxy_config_fmt, GetParam()),
                         "true")) {}
 
-  std::string testPolicy() override {
-    return TestEnvironment::substitute(TCP_POLICY_UPSTREAM_TLS, GetParam());
+  std::string testPolicyFmt() override {
+    return TestEnvironment::substitute(TCP_POLICY_UPSTREAM_TLS_fmt, GetParam());
   }
 };
 
@@ -591,8 +591,8 @@ class CiliumDownstreamTLSIntegrationTest : public CiliumTLSIntegrationTest {
                 cilium_tls_downstream_tcp_proxy_config_fmt, GetParam()),
             "true")) {}
 
-  std::string testPolicy() override {
-    return TestEnvironment::substitute(TCP_POLICY_UPSTREAM_TLS, GetParam());
+  std::string testPolicyFmt() override {
+    return TestEnvironment::substitute(TCP_POLICY_UPSTREAM_TLS_fmt, GetParam());
   }
 };
 


### PR DESCRIPTION
Add upstream authorization callbacks to Envoy and use them for policy enforcement.

Resolve policy dynamically so that policy changes take effect during long lasting HTTP connections.
