### PR TITLE
policy: Allow L7 LB egress without policy

### DIFF
--- a/cilium/accesslog.h
+++ b/cilium/accesslog.h
@@ -29,6 +29,9 @@ class AccessLog : Logger::Loggable<Logger::Id::router> {
                          const Network::Address::InstanceConstSharedPtr& destination_address,
                          const StreamInfo::StreamInfo&,
                          const Http::RequestHeaderMap&);
+    void UpdateFromRequest(uint32_t destination_identity,
+			   const Network::Address::InstanceConstSharedPtr& destination_address,
+			   const Http::RequestHeaderMap&);
     void UpdateFromResponse(const Http::ResponseHeaderMap&, TimeSource&);
 
     void InitFromConnection(const std::string& policy_name, bool ingress,

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -30,7 +30,7 @@ class Config : public Cilium::PolicyResolver,
 
   // PolicyResolver
   uint32_t resolvePolicyId(const Network::Address::Ip*) const override;
-  const std::shared_ptr<const PolicyInstance> getPolicy(const std::string&) const override;
+  const PolicyInstanceConstSharedPtr getPolicy(const std::string&) const override;
 
   virtual bool getMetadata(Network::ConnectionSocket &socket);
 

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -61,6 +61,8 @@ class PolicyInstance {
 
   virtual uint32_t getEndpointID() const PURE;
 };
+using PolicyInstanceConstSharedPtr = std::shared_ptr<const PolicyInstance>;
+
 
 class PolicyInstanceImpl;
 
@@ -96,8 +98,10 @@ class NetworkPolicyMap : public Singleton::Instance,
     startSubscription();
   }
 
-  const std::shared_ptr<const PolicyInstance> GetPolicyInstance(
+  const PolicyInstanceConstSharedPtr GetPolicyInstance(
       const std::string& endpoint_policy_name) const;
+
+  static PolicyInstanceConstSharedPtr AllowAllEgressPolicy;
 
   bool exists(const std::string& endpoint_policy_name) const {
     return GetPolicyInstanceImpl(endpoint_policy_name).get() != nullptr;

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -16,7 +16,7 @@ public:
   virtual ~PolicyResolver() = default;
 
   virtual uint32_t resolvePolicyId(const Network::Address::Ip*) const PURE;
-  virtual const std::shared_ptr<const PolicyInstance> getPolicy(const std::string&) const PURE;
+  virtual const PolicyInstanceConstSharedPtr getPolicy(const std::string&) const PURE;
 };
 
 class SocketMarkOption : public Network::Socket::Option,
@@ -133,7 +133,7 @@ class SocketMarkOption : public Network::Socket::Option,
 
 class SocketOption : public SocketMarkOption {
  public:
-  SocketOption(std::shared_ptr<const PolicyInstance> policy, uint32_t mark,
+  SocketOption(PolicyInstanceConstSharedPtr policy, uint32_t mark,
                uint32_t source_identity,
                bool ingress, uint16_t port, std::string&& pod_ip,
                Network::Address::InstanceConstSharedPtr src_address,
@@ -155,11 +155,11 @@ class SocketOption : public SocketMarkOption {
     return policy_id_resolver_->resolvePolicyId(ip);
   }
 
-  const std::shared_ptr<const PolicyInstance> getPolicy() const {
+  const PolicyInstanceConstSharedPtr getPolicy() const {
     return policy_id_resolver_->getPolicy(pod_ip_);
   }
  
-  const std::shared_ptr<const PolicyInstance> initial_policy_;
+  const PolicyInstanceConstSharedPtr initial_policy_;
   uint16_t port_;
   std::string pod_ip_;
 private:


### PR DESCRIPTION
Cilium Ingress forwards traffic via an Envoy listener on a NodePort, to
service backends in the cluster. Typically this traffic comes from
external sources, which do not have an egress network policy within the
cluster. Allow all traffic in this case. Note that traffic from sources
that have a defined policy (such as pods in the cluster) still adheres to
that policy.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>