### PR TITLE
cilium: Do not use original source address for locally allocated destination identities

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -229,13 +229,14 @@ bool Config::getMetadata(Network::ConnectionSocket& socket) {
   // Use original source address with L7 LB for local endpoint sources as policy
   // enforcement after the proxy depends on it. Otherwise
   // only use the original source address if permitted and the destination is not
-  // in the same node and is not classified as WORLD.
+  // in the same node, is not a locally allocated identity, and is not classified as WORLD.
   //
   // NOTE: Both of these options (egress_mark_source_endpoint_id_ and
   // may_use_original_source_address_) are only used for egress, so the local
   // endpoint is the source, and the other node is the destination.
   if ((egress_mark_source_endpoint_id_ && policy->getEndpointID() != 0) ||
       (may_use_original_source_address_ &&
+       !(destination_identity & Cilium::ID::LocalIdentityFlag) &&
        destination_identity != Cilium::ID::WORLD && !npmap_->exists(other_ip))) {
     socket.addOptions(
         Network::SocketOptionFactory::buildIpTransparentOptions());

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -56,7 +56,13 @@ I masked(I addr, unsigned int plen) {
   return plen == 0 ? I(0) : addr & ~hton((I(1) << (PLEN_MAX - plen)) - 1);
 };
 
-enum ID : uint64_t { UNKNOWN = 0, WORLD = 2 };
+enum ID : uint64_t {
+  UNKNOWN = 0,
+  WORLD = 2,
+  // LocalIdentityFlag is the bit in the numeric identity that identifies
+  // a numeric identity to have local scope
+  LocalIdentityFlag = 1 << 24,
+};
 
 class PolicyHostMap : public Singleton::Instance,
                       public Config::SubscriptionCallbacks,


### PR DESCRIPTION
Identities for CIDR or FQDN policy based destinations are allocated
locally. These destinations are outside of the cluster and will see the
source address as masqueraded by the local node. This being the case do
not bother about using the original source address for these
destinations.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>