### PR TITLE
envoy: Bump envoy version v1.21.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ to `default`.
 ### Using custom pre-compiled Envoy dependencies
 
 Docker build uses cached Bazel artifacts from
-`quay.io/cilium/cilium-envoy-builder:envoy-1.21.2-archive-latest` by
+`quay.io/cilium/cilium-envoy-builder:envoy-1.21.3-archive-latest` by
 default. You can overrride this by defining `BUILDER_IMAGE=<ref>`:
 
 ```
@@ -124,7 +124,7 @@ ARCH=multi make docker-builder-archive
 ```
 
 By default the pre-compiled dependencies image is tagged as
-`quay.io/cilium/cilium-envoy-builder:envoy-1.21.2-archive-latest`. You
+`quay.io/cilium/cilium-envoy-builder:envoy-1.21.3-archive-latest`. You
 can override the first two parts of this by defining
 `DOCKER_DEV_ACCOUNT=docker.io/me`,
 `BUILDER_ARCHIVE_TAG=my-builder-archive`, or completely by defining
@@ -175,7 +175,7 @@ make docker-tests
 
 This runs the integration tests after loading Bazel build cache for
 Envoy dependencies from
-`quay.io/cilium/cilium-envoy-builder:test-envoy-1.21.2-archive-latest`. Define
+`quay.io/cilium/cilium-envoy-builder:test-envoy-1.21.3-archive-latest`. Define
 `NO_CACHE=1` to compile tests from scratch.
 
 This command fails if any of the integration tests fail, printing the
@@ -195,7 +195,7 @@ make docker-tests-archive
 ```
 
 By default the pre-compiled test dependencies image is tagged as
-`quay.io/cilium/cilium-envoy-builder:test-envoy-1.21.2-archive-latest`. You
+`quay.io/cilium/cilium-envoy-builder:test-envoy-1.21.3-archive-latest`. You
 can override the first two parts of this by defining
 `DOCKER_DEV_ACCOUNT=docker.io/me`,
 `TESTS_ARCHIVE_TAG=my-test-archive`, or completely by defining

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,11 +10,12 @@ workspace(name = "cilium")
 ENVOY_PROJECT = "envoyproxy"
 ENVOY_REPO = "envoy"
 
-# https://github.com/envoyproxy/envoy/tree/v1.21.2
+# https://github.com/envoyproxy/envoy/tree/v1.21.2 (Tam: Update to v1.21.3 later)
 # NOTE: Update version number to file 'ENVOY_VERSION' to keep test and build docker images
 # for different versions.
-ENVOY_SHA = "7739bc921421cd1fde7b85baad9e660bd6f8bd75"
-ENVOY_SHA256 = "1b3af9a86d3bcb7b880c93590c0ad8506f934bce47f2e4c8577d888869f9d09e"
+# The below is latest commit from release/1.21 branch
+ENVOY_SHA = "bcd22abe760928dd2b44c4e9f02f2ddc01ca7857"
+ENVOY_SHA256 = "feecdb7a07e22aaadd9c6995f8065519bc0630c2e0321caedc7be8258719baae"
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 


### PR DESCRIPTION
This commit is to bump envoy version to v1.21.3.

For testing purpose, while waiting for official release, the latest
commit hash from release/1.21 branch is used.

Signed-off-by: Tam Mach <tam.mach@cilium.io>