### PR TITLE
gha: Avoid using Envoy version in builder image tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            BUILDER_IMAGE=quay.io/cilium/cilium-envoy-builder:${{ env.ENVOY_VERSION }}-archive-latest
+            BUILDER_IMAGE=quay.io/cilium/cilium-envoy-builder:master-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
           cache-from: type=local,src=/tmp/buildx-cache
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max

--- a/.github/workflows/cache-build.yaml
+++ b/.github/workflows/cache-build.yaml
@@ -56,9 +56,9 @@ jobs:
           platforms: linux/amd64
           build-args: |
             COPY_CACHE_EXT=.new
-            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.ENVOY_VERSION }}-archive-latest
+            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
           push: true
-          tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.ENVOY_VERSION }}-archive-latest
+          tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -74,7 +74,7 @@ jobs:
           file: ./Dockerfile.tests
           platforms: linux/amd64
           build-args: |
-            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.ENVOY_VERSION }}-archive-latest
+            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max
           push: false
@@ -118,9 +118,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             COPY_CACHE_EXT=.new
-            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.ENVOY_VERSION }}-archive-latest
+            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:master-archive-latest
           push: true
-          tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.ENVOY_VERSION }}-archive-latest
+          tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:master-archive-latest
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -139,7 +139,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
-            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.ENVOY_VERSION }}-archive-latest
+            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:master-archive-latest
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max
           push: true
           tags: |


### PR DESCRIPTION
### Description

This commit is to avoid using envoy version in builder image tag, mainly
to avoid chicken and egg issue if we are bumping envoy version.

Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Note

This is step 1 of 2 phase commit, the next PR will move all builds to new tag, after this PR is merged.