### PR TITLE
Build improvements

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@
 import %workspace%/envoy.bazelrc
 
 # Overrides workspace_status_command
-build --workspace_status_command=tools/get_workspace_status
+build --workspace_status_command="bash tools/get_workspace_status"
 build:remote --remote_timeout=7200
 
 # Enable path normalization by default.
@@ -26,3 +26,5 @@ build:release --fission=dbg
 
 # Always use toolchain
 build --crosstool_top=//bazel/toolchains:toolchain
+
+build --define manual_stamp=manual_stamp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile:1.2
 # 
 # BUILDER_BASE is a multi-platform image with all the build tools
 #

--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,11 @@ clang.bazelrc: bazel/setup_clang.sh /usr/lib/llvm-10
 	bazel/setup_clang.sh /usr/lib/llvm-10
 	echo "build --config=clang" >> $@
 
-envoy-deps-release: $(COMPILER_DEP)
+envoy-deps-release: $(COMPILER_DEP) SOURCE_VERSION
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) --config=release //:cilium-envoy-deps $(BAZEL_FILTER)
 
-bazel-bin/cilium-envoy: $(COMPILER_DEP)
+bazel-bin/cilium-envoy: $(COMPILER_DEP) SOURCE_VERSION
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) --config=release //:cilium-envoy $(BAZEL_FILTER)
 
@@ -101,12 +101,12 @@ clean: force
 	-$(QUIET) rm -f $(ENVOY_BINS) $(ENVOY_TESTS)
 
 .PHONY: envoy-test-deps
-envoy-test-deps: $(COMPILER_DEP) proxylib/libcilium.so
+envoy-test-deps: $(COMPILER_DEP) proxylib/libcilium.so SOURCE_VERSION
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build --build_tests_only $(BAZEL_BUILD_OPTS) --config=release -c fastbuild $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
 
 .PHONY: envoy-tests
-envoy-tests: $(COMPILER_DEP) proxylib/libcilium.so
+envoy-tests: $(COMPILER_DEP) proxylib/libcilium.so SOURCE_VERSION
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) --config=release -c fastbuild $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
 ifdef COPY_CACHE_EXT

--- a/Makefile.api
+++ b/Makefile.api
@@ -79,6 +79,8 @@ file_sep +=
 map_sep := ,M
 GO_MAPPINGS := $(patsubst %/,%,$(map_sep)$(subst $(file_sep),$(map_sep),$(RAW_GO_MAPPINGS)))
 
+export PATH:=$(HOME)/go/bin:$(PATH)
+
 all: godeps cilium-go-targets
 
 .PHONY: envoy-go-targets

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -27,21 +27,21 @@ all: precheck envoy-default
 api: force-non-root Makefile.api envoy-deps-fastbuild
 	$(MAKE) -f Makefile.api all
 
-envoy-deps-fastbuild: $(COMPILER_DEP)
+envoy-deps-fastbuild: $(COMPILER_DEP) SOURCE_VERSION
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:cilium-envoy-deps $(BAZEL_FILTER)
 
-envoy-default: $(COMPILER_DEP)
+envoy-default: $(COMPILER_DEP) SOURCE_VERSION
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:cilium-envoy $(BAZEL_FILTER)
 
 debug: envoy-debug
 
-envoy-debug: $(COMPILER_DEP)
+envoy-debug: $(COMPILER_DEP) SOURCE_VERSION
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) -c dbg //:cilium-envoy $(BAZEL_FILTER)
 
-$(CHECK_FORMAT): force-non-root
+$(CHECK_FORMAT): force-non-root SOURCE_VERSION
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:check_format.py
 
 veryclean: force-non-root clean
@@ -69,10 +69,10 @@ proxylib/libcilium.so:
 	fi
 
 # Run tests without debug by default.
-tests: proxylib/libcilium.so force-non-root
+tests: proxylib/libcilium.so force-non-root SOURCE_VERSION
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) //:envoy_binary_test $(BAZEL_FILTER)
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
 
-debug-tests: proxylib/libcilium.so force-non-root
+debug-tests: proxylib/libcilium.so force-non-root SOURCE_VERSION
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) -c debug $(BAZEL_TEST_OPTS) //:envoy_binary_test $(BAZEL_FILTER)
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) -c debug $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -100,8 +100,8 @@ BRANCH_TAG := $(shell echo $(BRANCH_NAME) | tr -c '[:alnum:]_.\n-' '-')
 BUILDER_IMAGE_OPTS ?=
 
 # target for builder archive
-BUILDER_ARCHIVE_TAG ?= $(ENVOY_VERSION)-archive-latest
-TESTS_ARCHIVE_TAG ?= test-$(ENVOY_VERSION)-archive-latest
+BUILDER_ARCHIVE_TAG ?= master-archive-latest
+TESTS_ARCHIVE_TAG ?= test-master-archive-latest
 
 ifndef NO_CACHE
   ifndef BUILDER_IMAGE
@@ -192,6 +192,7 @@ ifeq ($(BRANCH_TAG),"master")
   DOCKER_IMAHE_ENVOY_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:latest$(IMAGE_ARCH)
 else
   DOCKER_IMAGE_ENVOY_TAGS ?= -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(BRANCH_TAG)$(IMAGE_ARCH)
+  DOCKER_IMAGE_ENVOY_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(SOURCE_VERSION)$(IMAGE_ARCH)
 endif
 
 .PHONY: docker-image-envoy

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -22,11 +22,14 @@ ifdef ARCH
 endif
 
 DOCKER_DEV_ACCOUNT ?= quay.io/cilium
-CACHE_REF ?= docker.io/cilium/cilium-dev:cilium-envoy-cache
+# CACHE_REF ?= docker.io/cilium/cilium-dev:cilium-envoy-cache
+CACHE_REF ?=
 DOCKER_BUILD_OPTS ?=
 DOCKER_CACHE_OPTS ?=
 ifndef NO_CACHE
-  DOCKER_CACHE_OPTS += --cache-from=$(CACHE_REF)
+  ifneq ($(CACHE_REF),)
+    DOCKER_CACHE_OPTS += --cache-from=$(CACHE_REF)
+  endif
 endif
 ifdef DOCKER_BUILDX
   DOCKER := $(DOCKER) buildx
@@ -57,18 +60,7 @@ ifdef DOCKER_BUILDX
     endif
     DOCKER_BUILD_OPTS += $(DOCKER_PLATFORMS)
     ifdef CACHE_PUSH
-      ifeq ($(subst true,1,$(CACHE_PUSH)),1)
-        ifneq ($(findstring type=local,$(CACHE_REF)),)
-          CACHE_TO_REF := $(subst src=,dest=,$(CACHE_REF))
-	else ifneq ($(findstring type=registry,$(CACHE_REF)),)
-          CACHE_TO_REF := $(CACHE_REF)
-	else
-          CACHE_TO_REF := type=registry,ref=$(CACHE_REF)
-	endif
-      else
-        CACHE_TO_REF := $(CACHE_PUSH)
-      endif
-      DOCKER_CACHE_OPTS += --cache-to=$(CACHE_TO_REF),mode=max
+      DOCKER_CACHE_OPTS += --cache-to=$(CACHE_PUSH),mode=max
     endif
   endif
   $(info Using Docker Buildx builder "$(DOCKER_BUILDER)" with build flags "$(DOCKER_BUILD_OPTS)".)


### PR DESCRIPTION
Improvements mainly for local builds:

1. Use manual build stamping to force final binary linking even when no source files changed. This is needed to always make the version reported by Envoy match the SHA of the git repository, as required for Cilium Envoy version check. Modify make targets to also depend on the generated `SOURCE_VERSION`
2. Fix references to build archives also in Makefiles to mirror the change for version independent references on GH action workflows.
3. Remove unused docker cache references by default. Trying to fetch the non-existing cache took some valuable build time.
4. Add ~/go/bin to PATH so that API build works as expected. 
5.  Speed up builds by using the default docker syntax. This avoids the check/pull of docker/dockerfile:1.2 in the beginning of the build, saving 10-30 seconds in the beginning of the build.

