### PR TITLE
github: Pull proxylib from stable for tests

### DIFF
--- a/.github/workflows/cache-build.yaml
+++ b/.github/workflows/cache-build.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Pull proxylib/libcilium.so
         run: |
-          docker create -ti --name cilium-proxylib quay.io/cilium/cilium-ci:latest bash
+          docker create -ti --name cilium-proxylib quay.io/cilium/cilium:stable bash
           docker cp -L cilium-proxylib:/usr/lib/libcilium.so proxylib/libcilium.so
           docker rm -fv cilium-proxylib
       - name: Prep for build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Pull proxylib/libcilium.so
         run: |
-          docker create -ti --name cilium-proxylib quay.io/cilium/cilium-ci:latest bash
+          docker create -ti --name cilium-proxylib quay.io/cilium/cilium:stable bash
           docker cp -L cilium-proxylib:/usr/lib/libcilium.so proxylib/libcilium.so
           docker rm -fv cilium-proxylib
       - name: Prep for build


### PR DESCRIPTION
Cilium master currently has a breaking change that causes proxylib built
from there not work on Ubuntu 20.04:

"cilium.network: Cannot load go module 'proxylib/libcilium.so': /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by proxylib/libcilium.so)"

Revert to pulling proxylib from latest stable release instead. This
will make tests fail if they depend on any updates on proxylib.so since
the latest stable release. This happens rarely, though, and we can
revisit this issue at that time.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>