### PR TITLE
network_filter: Pass SNI before upstream callback

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,6 +35,7 @@ http_archive(
         "@//patches:envoy-upstream-http-auth.patch",
         "@//patches:ishalfcloseenabled.patch",
         "@//patches:tcp-proxy-receive-before-connect.patch",
+        "@//patches:0001-router-Do-not-crash-if-SNI-was-already-set-with-auto.patch",
     ],
     sha256 = ENVOY_SHA256,
     strip_prefix = ENVOY_REPO + "-" + ENVOY_SHA,

--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -80,10 +80,18 @@ class SslSocketWrapper : public Network::TransportSocket {
 
           // Set the callbacks
           ssl_socket_->setTransportSocketCallbacks(callbacks);
-        }
+        } else {
+	  ENVOY_LOG_MISC(warn,
+			 "cilium.tls_wrapper: Could not get {} TLS context for port {}!",
+			 state_ == Extensions::TransportSockets::Tls::InitialState::Client ? "client" : "server", 
+			 destination_port);
+	}
+      } else {
+	ENVOY_LOG_MISC(warn,
+		       "cilium.tls_wrapper: Policy not found for port {}!", destination_port);
       }
     } else if (!option) {
-      ENVOY_LOG_MISC(debug,
+      ENVOY_LOG_MISC(warn,
                      "cilium.tls_wrapper: Cilium socket option not found!");
     }
   }

--- a/patches/0001-router-Do-not-crash-if-SNI-was-already-set-with-auto.patch
+++ b/patches/0001-router-Do-not-crash-if-SNI-was-already-set-with-auto.patch
@@ -1,0 +1,57 @@
+From 7c85b6e57936845f41aa7ac242a90fc09bd22b93 Mon Sep 17 00:00:00 2001
+From: Jarno Rajahalme <jarno@isovalent.com>
+Date: Sat, 26 Nov 2022 13:43:53 +0200
+Subject: [PATCH] router: Do not crash if SNI was already set with auto_sni
+
+Catch the exception thrown due to SNI or SAN already been set, maybe by
+some filter, when processing the auto_sni option to prevent Envoy crash
+due to un-catched exception.
+
+Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
+---
+ source/common/router/router.cc | 26 +++++++++++++++++---------
+ 1 file changed, 17 insertions(+), 9 deletions(-)
+
+diff --git a/source/common/router/router.cc b/source/common/router/router.cc
+index 16a2316c0b..42f7b624dd 100644
+--- a/source/common/router/router.cc
++++ b/source/common/router/router.cc
+@@ -556,18 +556,26 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
+     absl::string_view sni_value = parsed_authority.host_;
+ 
+     if (should_set_sni && upstream_http_protocol_options.value().auto_sni()) {
+-      callbacks_->streamInfo().filterState()->setData(
+-          Network::UpstreamServerName::key(),
+-          std::make_unique<Network::UpstreamServerName>(sni_value),
+-          StreamInfo::FilterState::StateType::Mutable);
++      try {
++        callbacks_->streamInfo().filterState()->setData(
++            Network::UpstreamServerName::key(),
++            std::make_unique<Network::UpstreamServerName>(sni_value),
++            StreamInfo::FilterState::StateType::Mutable);
++      } catch (const EnvoyException& e) {
++        ENVOY_STREAM_LOG(debug, "could not set sni: {}", *callbacks_, e.what());
++      }
+     }
+ 
+     if (upstream_http_protocol_options.value().auto_san_validation()) {
+-      callbacks_->streamInfo().filterState()->setData(
+-          Network::UpstreamSubjectAltNames::key(),
+-          std::make_unique<Network::UpstreamSubjectAltNames>(
+-              std::vector<std::string>{std::string(sni_value)}),
+-          StreamInfo::FilterState::StateType::Mutable);
++      try {
++        callbacks_->streamInfo().filterState()->setData(
++            Network::UpstreamSubjectAltNames::key(),
++            std::make_unique<Network::UpstreamSubjectAltNames>(
++                std::vector<std::string>{std::string(sni_value)}),
++            StreamInfo::FilterState::StateType::Mutable);
++      } catch (const EnvoyException& e) {
++        ENVOY_STREAM_LOG(debug, "could not set subject alt name: {}", *callbacks_, e.what());
++      }
+     }
+   }
+ 
+-- 
+2.36.0
+


### PR DESCRIPTION
TCP proxy filter uses the SNI metadata on initialization before upstream callbacks are called. Thus we need to pass the SNI metadata in onNewConnection(), before the upstream callback gets called. Only set the metadata if not already set.

Apply a patch that prevents Envoy crash if auto_san option is used and metadata is already set, e.g., by Cilium network filter.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>