### PR TITLE
GH actions: build from scratch and persist test logs for successful test runs

### DIFF
--- a/.github/workflows/cache-build.yaml
+++ b/.github/workflows/cache-build.yaml
@@ -67,7 +67,8 @@ jobs:
             BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max
-          push: false
+          push: true
+          tags: quay.io/${{ github.repository_owner }}/cilium-envoy:latest-testlogs
   build-cache-and-push-images:
     timeout-minutes: 360
     name: Build cache and push images

--- a/.github/workflows/cache-build.yaml
+++ b/.github/workflows/cache-build.yaml
@@ -46,7 +46,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             COPY_CACHE_EXT=.new
-            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
+            BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.5"
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
       - name: Cache Docker layers
@@ -99,7 +99,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             COPY_CACHE_EXT=.new
-            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:master-archive-latest
+            BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.5"
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:master-archive-latest
       - name: Cache Docker layers

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,13 @@ RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private \
     BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DESTDIR=/tmp/install make install && \
     if [ -n "${COPY_CACHE_EXT}" ]; then cp -ra /tmp/bazel-cache /tmp/bazel-cache${COPY_CACHE_EXT}; fi
 
+FROM scratch as empty-builder-archive
+LABEL maintainer="maintainer@cilium.io"
+WORKDIR /tmp/bazel-cache
+
 # This stage retains only the build caches from the previous step. This is used as the target for persisting
 # Bazel build caches for later re-use.
-FROM scratch as builder-archive
-LABEL maintainer="maintainer@cilium.io"
+FROM empty-builder-archive as builder-archive
 ARG COPY_CACHE_EXT
 COPY --from=builder /tmp/bazel-cache${COPY_CACHE_EXT}/ /tmp/bazel-cache/
 

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -87,10 +87,13 @@ RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private \
     PKG_BUILD=1 V=$V make envoy-tests && \
     cp -Lr /cilium/proxy/bazel-testlogs testlogs
 
+FROM scratch as empty-builder-archive
+LABEL maintainer="maintainer@cilium.io"
+WORKDIR /tmp/bazel-cache
+
 # This stage retains only the build caches from the builder stage.
 # This is used as the target for persisting Bazel build caches for later re-use.
-FROM scratch as builder-archive
-LABEL maintainer="maintainer@cilium.io"
+FROM empty-builder-archive as builder-archive
 ARG COPY_CACHE_EXT
 COPY --from=builder /tmp/bazel-cache${COPY_CACHE_EXT}/ /tmp/bazel-cache/
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -162,9 +162,17 @@ docker-image-builder: Dockerfile.builder SOURCE_VERSION Dockerfile.builder.docke
 docker-builder-archive: Dockerfile SOURCE_VERSION Dockerfile.dockerignore
 	$(DOCKER) build --target builder-archive $(DOCKER_BUILD_OPTS) $(DOCKER_CACHE_OPTS) $(BUILDER_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" --build-arg COPY_CACHE_EXT=.new -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_ARCHIVE_TAG) .
 
+.PHONY: empty-docker-builder-archive
+empty-docker-builder-archive: Dockerfile Dockerfile.dockerignore
+	$(DOCKER) build --target empty-builder-archive $(DOCKER_BUILD_OPTS) -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_ARCHIVE_TAG) .
+
 .PHONY: docker-tests-archive
 docker-tests-archive: Dockerfile.tests SOURCE_VERSION Dockerfile.tests.dockerignore
 	$(DOCKER) build --target builder-archive $(DOCKER_BUILD_OPTS) $(DOCKER_CACHE_OPTS) $(TESTS_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" --build-arg COPY_CACHE_EXT=.new -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_ARCHIVE_TAG) .
+
+.PHONY: empty-docker-tests-archive
+empty-docker-tests-archive: Dockerfile.tests Dockerfile.tests.dockerignore
+	$(DOCKER) build --target empty-builder-archive $(DOCKER_BUILD_OPTS) -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_ARCHIVE_TAG) .
 
 .PHONY: docker-tests
 docker-tests: Dockerfile.tests SOURCE_VERSION Dockerfile.tests.dockerignore

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -174,9 +174,15 @@ docker-tests-archive: Dockerfile.tests SOURCE_VERSION Dockerfile.tests.dockerign
 empty-docker-tests-archive: Dockerfile.tests Dockerfile.tests.dockerignore
 	$(DOCKER) build --target empty-builder-archive $(DOCKER_BUILD_OPTS) -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_ARCHIVE_TAG) .
 
+ifeq ($(BRANCH_TAG),"master")
+  DOCKER_TESTS_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:latest$(IMAGE_ARCH)-testlogs
+else
+  DOCKER_TESTS_TAGS ?= -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(BRANCH_TAG)$(IMAGE_ARCH)-testlogs
+endif
+
 .PHONY: docker-tests
 docker-tests: Dockerfile.tests SOURCE_VERSION Dockerfile.tests.dockerignore
-	$(DOCKER) build $(subst --push,,$(DOCKER_BUILD_OPTS)) $(DOCKER_CACHE_OPTS) $(TESTS_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" -f $< .
+	$(DOCKER) build --progress=plain $(subst --push,--load,$(DOCKER_BUILD_OPTS)) $(DOCKER_CACHE_OPTS) $(TESTS_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" -f $< $(DOCKER_TESTS_TAGS) .
 
 ifeq ($(BRANCH_TAG),"master")
   DOCKER_IMAGE_ENVOY_TAGS := -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:$(SOURCE_VERSION)$(IMAGE_ARCH)


### PR DESCRIPTION
Build test and build archives from scratch on master push to avoid accumulating unused files in the build caches.
This is now possible due to the large runners and more efficient compiling with clang.

Also push test logs on successful test runs for reference. Failing runs will not complete the docker build step, so no test logs will be pushed, but those can be observed from the build logs on Github.