### PR TITLE
gh: Increase number of Bazel jobs by 50%

### DIFF
--- a/.github/workflows/cache-build.yaml
+++ b/.github/workflows/cache-build.yaml
@@ -46,7 +46,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             COPY_CACHE_EXT=.new
-            BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.5"
+            BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.75"
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
       - name: Cache Docker layers
@@ -99,7 +99,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             COPY_CACHE_EXT=.new
-            BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.5"
+            BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.75"
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:master-archive-latest
       - name: Cache Docker layers


### PR DESCRIPTION
Currently we run one job per core on bazel builds, half for amd64 build and the second half for arm64 build. This is 50% slower than when testing with double the number of Bazel build jobs. Try to get closer to optimum by increasing the number of jobs by 50%.

Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>