### PR TITLE
gha: Add jobs for bazel builder image

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,0 +1,54 @@
+name: CI Build & Push Builder Image
+on:
+  pull_request_target:
+    types: [ opened, synchronize, reopened ]
+    paths:
+    - Dockerfile.builder
+    - .bazelversion
+
+jobs:
+  build-and-push-builder:
+    timeout-minutes: 30
+    name: Build and push multi-arch builder images
+    runs-on: ubuntu-latest
+    environment: release-base-images
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+      with:
+        version: v0.9.1
+    - name: Cache Docker layers
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12
+      with:
+        path: /tmp/buildx-cache
+        key: docker-cache-${{ github.head_ref }}
+        restore-keys: docker-cache-builder-master
+    - name: Login to quay.io
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_ENVOY_USERNAME }}
+        password: ${{ secrets.QUAY_ENVOY_PASSWORD }}
+    - name: Checkout PR
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Prep for build
+      run: |
+        echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
+        echo "ENVOY_VERSION=$(cat ENVOY_VERSION)" >> $GITHUB_ENV
+        echo "BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
+    - name: PR Multi-arch build & push of cilium-envoy-builder
+      uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
+      id: docker_build_builder_ci
+      with:
+        context: .
+        file: ./Dockerfile.builder
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.BAZEL_VERSION }}
+    - name: CI Image Digest
+      shell: bash
+      run: |
+        echo "Digests:"
+        echo "quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.BAZEL_VERSION }}@${{ steps.docker_build_builder_ci.outputs.digest }}"


### PR DESCRIPTION
Currently, we need to manually build and push images if there is change in bazel version or builder Dockerfile. This is to avoid such manual step.

Signed-off-by: Tam Mach <tam.mach@cilium.io>