### PR TITLE
tests: Fix integration tests due to glibc

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -76,7 +76,8 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            BUILDER_IMAGE=quay.io/cilium/cilium-envoy-builder-dev:${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
+            BUILDER_BASE=quay.io/cilium/cilium-envoy-builder-dev:${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
+            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:master-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
           cache-from: type=local,src=/tmp/buildx-cache
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -38,6 +38,30 @@ jobs:
         run: |
           echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
           echo "ENVOY_VERSION=$(cat ENVOY_VERSION)" >> $GITHUB_ENV
+          echo "BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
+          echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder.tests | awk '{ print $3 }')" >> $GITHUB_ENV
+
+      - name: Checking if cilium-envoy-builder image exists
+        id: cilium-builder-tests-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: PR Multi-arch build & push of Builder image (dev)
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        if: steps.cilium-builder-tests-tag-in-repositories.outputs.exists == 'false'
+        id: docker_build_builder_tests_ci
+        with:
+          provenance: false
+          context: .
+          file: ./Dockerfile.builder.tests
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
 
       - name: Multi-arch update integration test archive
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
@@ -48,6 +72,7 @@ jobs:
           target: builder-archive
           platforms: linux/amd64,linux/arm64
           build-args: |
+            BUILDER_BASE=quay.io/cilium/cilium-envoy-builder:tests-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
             COPY_CACHE_EXT=.new
             BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.75"
           push: true
@@ -71,6 +96,7 @@ jobs:
           file: ./Dockerfile.tests
           platforms: linux/amd64
           build-args: |
+            BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:tests-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
             BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -1,6 +1,6 @@
 name: CI run integration tests
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -11,6 +11,13 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # v2.4.1
+
+      - name: Login to quay.io
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ENVOY_USERNAME_DEV }}
+          password: ${{ secrets.QUAY_ENVOY_PASSWORD_DEV }}
 
       - name: Enable Docker IPv6
         run: |
@@ -38,13 +45,29 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
           echo "ENVOY_VERSION=$(cat ENVOY_VERSION)" >> $GITHUB_ENV
           echo "BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
-          echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
+          echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder.tests | awk '{ print $3 }')" >> $GITHUB_ENV
 
-      - name: Wait for images to be available
-        timeout-minutes: 30
+      - name: Checking if cilium-envoy-builder image exists
+        id: cilium-builder-tests-tag-in-repositories
         shell: bash
         run: |
-          until docker manifest inspect quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }} &> /dev/null; do sleep 45s; done
+          if docker buildx imagetools inspect quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: PR Multi-arch build & push of Builder image (dev)
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        if: steps.cilium-builder-tests-tag-in-repositories.outputs.exists == 'false'
+        id: docker_build_builder_tests_ci
+        with:
+          provenance: false
+          context: .
+          file: ./Dockerfile.builder.tests
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
 
       - name: Run integration tests on amd64
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
@@ -55,7 +78,8 @@ jobs:
           file: ./Dockerfile.tests
           platforms: linux/amd64
           build-args: |
-            BUILDER_BASE=quay.io/cilium/cilium-envoy-builder-dev:${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
+            BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
+            BUILDER_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
           cache-from: type=local,src=/tmp/buildx-cache
           push: false

--- a/Dockerfile.builder.tests
+++ b/Dockerfile.builder.tests
@@ -1,0 +1,46 @@
+
+#
+# Builder dependencies. This takes a long time to build from scratch!
+# Also note that if build fails due to C++ internal error or similar,
+# it is possible that the image build needs more RAM than available by
+# default on non-Linux docker installs.
+#
+# This shoould be the same as Dockerfile.builder except the below:
+# - Ubuntu version is bumped to 22.04
+# - LLVM apt repo is from apt.llvm.org/jammy/ instead of apt.llvm.org/focal/
+FROM docker.io/library/ubuntu:22.04@sha256:9a0bdde4188b896a372804be2384015e90e3f84906b750c1a53539b585fbbe7f as base
+LABEL maintainer="maintainer@cilium.io"
+ARG TARGETARCH
+# Setup TimeZone to prevent tzdata package asking for it interactively
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      # Multi-arch cross-compilation packages
+      gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross binutils-aarch64-linux-gnu \
+      gcc-x86-64-linux-gnu g++-x86-64-linux-gnu libc6-dev-amd64-cross binutils-x86-64-linux-gnu \
+      libc6-dev \
+      # Envoy Build dependencies
+      autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
+      python3 python-is-python3 unzip virtualenv wget zip && \
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \
+    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      clang-15 clang-tools-15 lldb-15 lld-15 clang-format-15 libc++-15-dev libc++abi-15-dev && \
+    apt-get purge --auto-remove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /cilium/proxy
+COPY .bazelversion ./
+#
+# Install Bazel
+#
+RUN export BAZEL_VERSION=$(cat .bazelversion) \
+	&& ARCH=$TARGETARCH && [ "$ARCH" != "amd64" ] || ARCH="x86_64" \
+	&& curl -sfL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${ARCH} -o /usr/bin/bazel \
+	&& chmod +x /usr/bin/bazel

--- a/Dockerfile.builder.tests.dockerignore
+++ b/Dockerfile.builder.tests.dockerignore
@@ -1,0 +1,2 @@
+*
+!/.bazelversion

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -78,7 +78,6 @@ SOURCE_VERSION: force
 
 ENVOY_VERSION := $(shell cat ENVOY_VERSION)
 BAZEL_VERSION := $(shell cat .bazelversion)
-BUILDER_BASE_TAG ?= bazel-$(BAZEL_VERSION)$(IMAGE_ARCH)
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
 BRANCH_TAG := $(shell echo $(BRANCH_NAME) | tr -c '[:alnum:]_.\n-' '-')
 BUILDER_IMAGE_OPTS ?=
@@ -86,6 +85,13 @@ BUILDER_IMAGE_OPTS ?=
 # target for builder archive
 BUILDER_ARCHIVE_TAG ?= master-archive-latest
 TESTS_ARCHIVE_TAG ?= test-master-archive-latest
+
+BUILDER_DOCKER_HASH=$(shell git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $$3 }')
+TEST_BUILDER_DOCKER_HASH=$(shell git ls-tree --full-tree HEAD -- ./Dockerfile.builder.tests | awk '{ print $$3 }')
+BUILDER_BASE_TAG ?= $(BAZEL_VERSION)-$(BUILDER_DOCKER_HASH)
+TESTS_BUILDER_BASE_TAG ?= $(BAZEL_VERSION)-$(TEST_BUILDER_DOCKER_HASH)
+BUILDER_BASE ?= $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_BASE_TAG)
+TESTS_BUILDER_BASE ?= $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_BUILDER_BASE_TAG)
 
 ifndef NO_CACHE
   ifndef BUILDER_IMAGE
@@ -161,11 +167,11 @@ GIT_IGNORE_FILES := $(shell find -H . -not -path "./_build*" -not -path "./vendo
 
 .PHONY: docker-image-builder
 docker-image-builder: Dockerfile.builder SOURCE_VERSION Dockerfile.builder.dockerignore
-	$(DOCKER) build $(DOCKER_BUILD_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_BASE_TAG) .
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" --build-arg BUILDER_BASE="$(BUILDER_BASE)" -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_BASE_TAG) .
 
 .PHONY: docker-image-builder-tests
 docker-image-builder-tests: Dockerfile.builder.tests SOURCE_VERSION Dockerfile.builder.tests.dockerignore
-	$(DOCKER) build $(DOCKER_BUILD_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:test-$(BUILDER_BASE_TAG) .
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" --build-arg BUILDER_BASE="$(TESTS_BUILDER_BASE)" -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_BUILDER_BASE_TAG) .
 
 .PHONY: docker-builder-archive
 docker-builder-archive: Dockerfile SOURCE_VERSION Dockerfile.dockerignore

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -114,6 +114,11 @@ Dockerfile.builder.dockerignore:
 	echo "*" >$@
 	echo "!/.bazelversion" >>$@
 
+# Builder image for tests consists only of build tools, so it only needs .bazelversion
+Dockerfile.builder.tests.dockerignore:
+	echo "*" >$@
+	echo "!/.bazelversion" >>$@
+
 # Release does not need Go API or test files
 Dockerfile.dockerignore: .dockerignore Makefile.docker
 	cp $< $@
@@ -157,6 +162,10 @@ GIT_IGNORE_FILES := $(shell find -H . -not -path "./_build*" -not -path "./vendo
 .PHONY: docker-image-builder
 docker-image-builder: Dockerfile.builder SOURCE_VERSION Dockerfile.builder.dockerignore
 	$(DOCKER) build $(DOCKER_BUILD_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_BASE_TAG) .
+
+.PHONY: docker-image-builder-tests
+docker-image-builder-tests: Dockerfile.builder.tests SOURCE_VERSION Dockerfile.builder.tests.dockerignore
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:test-$(BUILDER_BASE_TAG) .
 
 .PHONY: docker-builder-archive
 docker-builder-archive: Dockerfile SOURCE_VERSION Dockerfile.dockerignore


### PR DESCRIPTION
### Description

As cilium 1.13 is released today, the cilium/cilium:stable tag is moved to 1.13 as well. This will cause below issue for proxylib due glibc version. So we need to bump ubuntu version to 22.04 for test image, kindly note that the main cilium-envoy is still built with ubuntu 20.04 for backward compatibility of old cilium releases.

```
[external/envoy/source/common/config/filesystem_subscription_impl.cc:60] Filesystem config update rejected: Error adding/updating listener(s) tcp_proxy: cilium.network: Cannot load go module 'proxylib/libcilium.so': /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by proxylib/libcilium.so)
```

Fixes: https://github.com/cilium/proxy/issues/120
Fixes: https://github.com/cilium/proxy/issues/88

### Testing

Testing with the temp commit (i.e. pull_request instead of pull_request_target), please find below the successfull runs for Build and Test jobs

[CI Build and Push](https://github.com/cilium/proxy/actions/runs/4193798532/jobs/7271140878)
[Integration Test](https://github.com/cilium/proxy/actions/runs/4193798525/jobs/7271140701)

```
#14 340.6 //tests:accesslog_test                                                   PASSED in 0.2s
#14 340.6 //tests:cilium_http_integration_test                                     PASSED in 10.8s
#14 340.6 //tests:cilium_tcp_integration_test                                      PASSED in 6.9s
#14 340.6 //tests:cilium_tls_http_integration_test                                 PASSED in 4.7s
#14 340.6 //tests:cilium_tls_tcp_integration_test                                  PASSED in 6.8s
#14 340.6 //tests:cilium_websocket_codec_integration_test                          PASSED in 4.4s
#14 340.6 //tests:cilium_websocket_decap_integration_test                          PASSED in 0.9s
#14 340.6 //tests:cilium_websocket_encap_integration_test                          PASSED in 4.3s
```
