### PR TITLE
Fix local docker tests

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -66,8 +66,10 @@ ARG V
 ARG BAZEL_BUILD_OPTS
 ARG BUILDARCH
 ARG TARGETARCH
+ARG NO_CACHE
 ENV TARGETARCH=$TARGETARCH
 
+RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private if [ -n "$NO_CACHE" ]; then rm -rf /root/.cache/*; fi
 RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private \
     --mount=target=/tmp/bazel-cache,source=/tmp/bazel-cache,from=archive-cache,rw \
     if [ "$TARGETARCH" != "$BUILDARCH" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifdef BAZEL_REMOTE_CACHE
   BAZEL_BUILD_OPTS += --remote_cache=$(BAZEL_REMOTE_CACHE)
 endif
 
-BAZEL_TEST_OPTS ?= --test_timeout=300
+BAZEL_TEST_OPTS ?= --jobs=HOST_RAM*.0003 --test_timeout=300
 BAZEL_TEST_OPTS += --test_output=errors
 
 BUILDARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -38,11 +38,11 @@ envoy-default: $(COMPILER_DEP) SOURCE_VERSION install-bazel
 
 debug: envoy-debug
 
-envoy-debug: $(COMPILER_DEP) SOURCE_VERSION
+envoy-debug: $(COMPILER_DEP) SOURCE_VERSION install-bazel
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) -c dbg //:cilium-envoy $(BAZEL_FILTER)
 
-$(CHECK_FORMAT): force-non-root SOURCE_VERSION
+$(CHECK_FORMAT): force-non-root SOURCE_VERSION install-bazel
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:check_format.py
 
 veryclean: force-non-root clean
@@ -71,10 +71,10 @@ proxylib/libcilium.so:
 	fi
 
 # Run tests without debug by default.
-tests: proxylib/libcilium.so force-non-root SOURCE_VERSION
+tests:  $(COMPILER_DEP) proxylib/libcilium.so force-non-root SOURCE_VERSION install-bazel
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) //:envoy_binary_test $(BAZEL_FILTER)
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
 
-debug-tests: proxylib/libcilium.so force-non-root SOURCE_VERSION
+debug-tests:  $(COMPILER_DEP) proxylib/libcilium.so force-non-root SOURCE_VERSION install-bazel
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) -c dbg $(BAZEL_TEST_OPTS) //:envoy_binary_test $(BAZEL_FILTER)
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) -c dbg $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -76,5 +76,5 @@ tests: proxylib/libcilium.so force-non-root SOURCE_VERSION
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
 
 debug-tests: proxylib/libcilium.so force-non-root SOURCE_VERSION
-	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) -c debug $(BAZEL_TEST_OPTS) //:envoy_binary_test $(BAZEL_FILTER)
-	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) -c debug $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
+	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) -c dbg $(BAZEL_TEST_OPTS) //:envoy_binary_test $(BAZEL_FILTER)
+	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) -c dbg $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -80,7 +80,6 @@ ENVOY_VERSION := $(shell cat ENVOY_VERSION)
 BAZEL_VERSION := $(shell cat .bazelversion)
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
 BRANCH_TAG := $(shell echo $(BRANCH_NAME) | tr -c '[:alnum:]_.\n-' '-')
-ARCHIVE_IMAGE_OPTS ?=
 
 # target for builder archive
 BUILDER_ARCHIVE_TAG ?= master-archive-latest
@@ -89,9 +88,12 @@ TESTS_ARCHIVE_TAG ?= test-master-archive-latest
 BUILDER_DOCKER_HASH=$(shell git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $$3 }')
 TEST_BUILDER_DOCKER_HASH=$(shell git ls-tree --full-tree HEAD -- ./Dockerfile.builder.tests | awk '{ print $$3 }')
 BUILDER_BASE_TAG ?= $(BAZEL_VERSION)-$(BUILDER_DOCKER_HASH)
-TESTS_BUILDER_BASE_TAG ?= $(BAZEL_VERSION)-$(TEST_BUILDER_DOCKER_HASH)
+TESTS_BUILDER_BASE_TAG ?= test-$(BAZEL_VERSION)-$(TEST_BUILDER_DOCKER_HASH)
 BUILDER_BASE ?= $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_BASE_TAG)
 TESTS_BUILDER_BASE ?= $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_BUILDER_BASE_TAG)
+
+BUILD_IMAGE_OPTS := --build-arg BUILDER_BASE="$(BUILDER_BASE)"
+TESTS_IMAGE_OPTS := --build-arg BUILDER_BASE="$(TESTS_BUILDER_BASE)"
 
 ifndef NO_CACHE
   ifndef ARCHIVE_IMAGE
@@ -109,8 +111,9 @@ else
 endif
 
 ifdef ARCHIVE_IMAGE
-  ARCHIVE_IMAGE_OPTS += --build-arg ARCHIVE_IMAGE=$(ARCHIVE_IMAGE)
+  BUILD_IMAGE_OPTS += --build-arg ARCHIVE_IMAGE=$(ARCHIVE_IMAGE)
 endif
+
 ifdef TESTS_ARCHIVE_IMAGE
   TESTS_IMAGE_OPTS += --build-arg ARCHIVE_IMAGE=$(TESTS_ARCHIVE_IMAGE)
 endif
@@ -175,7 +178,7 @@ docker-image-builder-tests: Dockerfile.builder.tests SOURCE_VERSION Dockerfile.b
 
 .PHONY: docker-builder-archive
 docker-builder-archive: Dockerfile SOURCE_VERSION Dockerfile.dockerignore
-	$(DOCKER) build --target builder-archive $(DOCKER_BUILD_OPTS) $(DOCKER_CACHE_OPTS) $(ARCHIVE_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" --build-arg COPY_CACHE_EXT=.new -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_ARCHIVE_TAG) .
+	$(DOCKER) build --target builder-archive $(DOCKER_BUILD_OPTS) $(DOCKER_CACHE_OPTS) $(BUILD_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" --build-arg COPY_CACHE_EXT=.new -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_ARCHIVE_TAG) .
 
 .PHONY: empty-docker-builder-archive
 empty-docker-builder-archive: Dockerfile Dockerfile.dockerignore
@@ -187,7 +190,7 @@ docker-tests-archive: Dockerfile.tests SOURCE_VERSION Dockerfile.tests.dockerign
 
 .PHONY: empty-docker-tests-archive
 empty-docker-tests-archive: Dockerfile.tests Dockerfile.tests.dockerignore
-	$(DOCKER) build --target empty-builder-archive $(DOCKER_BUILD_OPTS) -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_ARCHIVE_TAG) .
+	$(DOCKER) build --target empty-builder-archive $(DOCKER_BUILD_OPTS) --build-arg BUILDER_BASE="$(TESTS_BUILDER_BASE)" -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_ARCHIVE_TAG) .
 
 ifeq ($(BRANCH_TAG),"master")
   DOCKER_TESTS_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:latest$(IMAGE_ARCH)-testlogs
@@ -210,7 +213,7 @@ endif
 .PHONY: docker-image-envoy
 docker-image-envoy: Dockerfile SOURCE_VERSION Dockerfile.dockerignore
 	@$(ECHO_GEN) docker-image-envoy
-	$(DOCKER) build $(DOCKER_BUILD_OPTS) $(DOCKER_CACHE_OPTS) $(ARCHIVE_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" $(DOCKER_IMAGE_ENVOY_TAGS) .
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) $(DOCKER_CACHE_OPTS) $(BUILD_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" $(DOCKER_IMAGE_ENVOY_TAGS) .
 
 docker-istio-proxy: Dockerfile.istio_proxy envoy_bootstrap_tmpl.json
 	@$(ECHO_GEN) docker-istio-proxy

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -95,7 +95,7 @@ TESTS_BUILDER_BASE ?= $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_BUILDER
 BUILD_IMAGE_OPTS := --build-arg BUILDER_BASE="$(BUILDER_BASE)"
 TESTS_IMAGE_OPTS := --build-arg BUILDER_BASE="$(TESTS_BUILDER_BASE)"
 
-ifndef NO_CACHE
+ifndef NO_ARCHIVE
   ifndef ARCHIVE_IMAGE
     # Default builder refresh image ref
     ARCHIVE_IMAGE := $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(BUILDER_ARCHIVE_TAG)
@@ -103,7 +103,9 @@ ifndef NO_CACHE
   else
     TESTS_ARCHIVE_IMAGE := $(ARCHIVE_IMAGE)
   endif
-else
+endif
+
+ifdef NO_CACHE
   DOCKER_CACHE_OPTS += --build-arg NO_CACHE=$(NO_CACHE)
   ifeq ($(NO_CACHE),2)
     DOCKER_CACHE_OPTS += --no-cache

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ ARCH=multi ARCHIVE_IMAGE=docker.io/me/cilium-envoy-archive make docker-image-env
 > builds. For now the image ref shown above is for builds on amd64
 > only (native amd64, cross-compiled arm64).
 
-Define `NO_CACHE=1` to build from scratch, but be warned that this can
-take several hours.
+Define `NO_CACHE=1` to clear the local build cache before the build, and `NO_ARCHIVE=1` to build
+from scratch, but be warned that this can take a long time.
 
 ### Docker caching
 
@@ -108,8 +108,7 @@ this with our own build cache, which you can also update with the
 ARCH=multi CACHE_REF=docker.io/me/cilium-proxy:cache CACHE_PUSH=1 make docker-image-envoy
 ```
 
-`NO_CACHE=1` can be used to disable docker cache pulling, but it also
-disables use of pre-built Bazel artifacts.`
+`NO_CACHE=1` can be used to disable docker cache pulling.
 
 In a CI environment it might be a good idea to push a new cache image
 after each main branch commit.
@@ -133,10 +132,10 @@ can override the first two parts of this by defining
 Pre-compiled Envoy dependencies need to be updated only when Envoy
 version is updated or patched enough to increase compilation time
 significantly. To do this you should update Envoy version in
-`ENVOY_VERSION` and supply `NO_CACHE=1` on the make line, e.g.:
+`ENVOY_VERSION` and supply `NO_CACHE=1` and `NO_ARCHIVE=1` on the make line, e.g.:
 
 ```
-ARCH=multi NO_CACHE=1 BUILDER_ARCHIVE_TAG=master-archive-latest make docker-builder-archive
+ARCH=multi NO_CACHE=1 NO_ARCHIVE=1 BUILDER_ARCHIVE_TAG=master-archive-latest make docker-builder-archive
 ```
 
 
@@ -147,7 +146,7 @@ another. To create a new builder image first update the required Bazel
 version at `.bazelversion` and then run:
 
 ```
-ARCH=multi NO_CACHE=1 make docker-image-builder
+ARCH=multi NO_CACHE=1 NO_ARCHIVE=1 make docker-image-builder
 ```
 
 The builder can not be cross-compiled as native build tools are needed
@@ -176,7 +175,7 @@ make docker-tests
 This runs the integration tests after loading Bazel build cache for
 Envoy dependencies from
 `quay.io/cilium/cilium-envoy-builder:test-master-archive-latest`. Define
-`NO_CACHE=1` to compile tests from scratch.
+`NO_ARCHIVE=1` and `NO_CACHE=1` to compile tests from scratch.
 
 This command fails if any of the integration tests fail, printing the
 failing test logs on console.
@@ -204,10 +203,11 @@ can override the first two parts of this by defining
 Pre-compiled Envoy test dependencies need to be updated only when
 Envoy version is updated or patched enough to increase compilation
 time significantly. To do this you should update Envoy version
-in `ENVOY_VERSION` and supply `NO_CACHE=1` on the make line, e.g.:
+in `ENVOY_VERSION` and supply `NO_ARCHIVE=1` and `NO_CACHE=1` on
+the make line, e.g.:
 
 ```
-ARCH=amd64 NO_CACHE=1 make docker-tests-archive
+ARCH=amd64 NO_ARCHIVE=1 NO_CACHE=1 make docker-tests-archive
 ```
 
 


### PR DESCRIPTION
Use correct archive image also for local docker tests launched via `make`.

Pass `NO_CACHE` to docker tests so that build cache can be cleared if it becomes corrupted.

Reintroduce jobs limit for local testing based on system memory. It appears that also with clang compiling some of the test sources takes a lot of memory, and the build was killed as too many parallel jobs exhausted system memory.

Finally, check that bazel and clang-15 are installed, and pull them automatically if needed when running `make`. This streamlines local building and testing on a fresh VM.