### PR TITLE
make: Fix 'make api' for Gnu make 4.3

### DIFF
--- a/Makefile.api
+++ b/Makefile.api
@@ -74,8 +74,8 @@ RAW_GO_MAPPINGS += opentelemetry/proto/common/v1/common.proto=github.com/open-te
 
 # Add mapping separators and remove the trailing slash
 # but first create "/ " and ",M"
-file_sep := /
-file_sep +=
+E = 
+file_sep := / $E
 map_sep := ,M
 GO_MAPPINGS := $(patsubst %/,%,$(map_sep)$(subst $(file_sep),$(map_sep),$(RAW_GO_MAPPINGS)))
 


### PR DESCRIPTION
Ubuntu 22.04 ships with Gnu make 4.3, which broke 'make api'.

Change the method of adding a space to a make variable to be compatible with Gnu make 4.3, which introduced this breaking change:

* WARNING: Backward-incompatibility! Previously appending using '+=' to an empty variable would result in a value starting with a space.  Now the initial space is only added if the variable already contains some value.  Similarly, appending an empty string does not add a trailing space.

Previously we relied on appending an empty string adding a trailing space. Now we use an empty variable as a delimiter to the same effect. Verified to work on both Gnu make 4.3 and Gnu make 4.2.1, which ships with Ubuntu 20.04.