### PR TITLE
tests: Always have test environment with LD_LIBRARY_PATH defined

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,3 +26,7 @@ build:release --fission=dbg
 # Manual link stamping, forces link to include current git SHA even if binary is otherwise
 # upto-date
 build --define manual_stamp=manual_stamp
+
+# Always have LD_LIBRARY_PATH=/usr/cross-compat/lib defined in the test environment.
+# The path does not need to exist, but can be created when needed for running tests.
+build --test_env=LD_LIBRARY_PATH=/usr/cilium-cross-compat/lib

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -77,16 +77,14 @@ RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private \
         # Allow running x86_64 test binaries via qemu \
         ln -s /usr/x86_64-linux-gnu/lib/ld-linux-x86-64.so.* /lib; \
         ln -s /lib /lib64; \
-        LD_LIBRARY_PATH=/usr/x86_64-linux-gnu/lib; \
+        ln -s /usr/x86_64-linux-gnu/lib /usr/cilium-cross-compat/lib; \
       elif [ "$TARGETARCH" = "arm64" ]; then \
         # Allow running aarch64 test binaries via qemu \
         ln -s /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.* /lib; \
-        LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib; \
+        ln -s /usr/aarch64-linux-gnu/lib /usr/cilium-cross-compat/lib; \
       fi; \
     fi && \
-    echo "using LD_LIBRARY_PATH=${LD_LIBRARY_PATH} for running tests" && \
-    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache --test_env=LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
-    PKG_BUILD=1 V=$V make envoy-tests && \
+    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V make envoy-tests && \
     cp -Lr /cilium/proxy/bazel-testlogs testlogs
 
 FROM scratch as empty-builder-archive


### PR DESCRIPTION
Changes in LD_LIBRARY_PATH value invalidate remote and disk caching. Currently we only set LD_LIBRARY_PATH to a specific value and in specific situations (for running cross-compiled tests). This causes archived test artefacts be ignored and rebuilt.

Typical scenario where this happened was CI cross-compiled artefacts for arm64 being ignored for local test runs on arm64.

Allow cached builds to be used in all test scenarios by always defining LD_LIBRARY_PATH=/usr/cilium-cross-compat/lib in the test environment. The path does not need to exist, but can be created (as a symlink) when needed for running cross-compiled tests.