### PR TITLE
Enable debug builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /cilium/proxy
 COPY . ./
 ARG V
 ARG BAZEL_BUILD_OPTS
+ARG DEBUG
 ARG BUILDARCH
 ARG TARGETARCH
 ARG NO_CACHE
@@ -31,7 +32,7 @@ RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private if [ "
 #
 # Build dependencies
 #
-RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DESTDIR=/tmp/install make bazel-bin/cilium-envoy
+RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DEBUG=$DEBUG DESTDIR=/tmp/install make bazel-bin/cilium-envoy
 
 # By default this stage picks up the result of the build above, but ARCHIVE_IMAGE can be
 # overridden to point to a saved image of an earlier run of that stage.
@@ -51,13 +52,14 @@ COPY . ./
 ARG V
 ARG COPY_CACHE_EXT
 ARG BAZEL_BUILD_OPTS
+ARG DEBUG
 ARG BUILDARCH
 ARG TARGETARCH
 ENV TARGETARCH=$TARGETARCH
 RUN ./bazel/get_workspace_status
 RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private \
     --mount=target=/tmp/bazel-cache,source=/tmp/bazel-cache,from=builder-cache,rw \
-    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DESTDIR=/tmp/install make install && \
+    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DEBUG=$DEBUG DESTDIR=/tmp/install make install && \
     if [ -n "${COPY_CACHE_EXT}" ]; then cp -ra /tmp/bazel-cache /tmp/bazel-cache${COPY_CACHE_EXT}; fi
 
 FROM scratch as empty-builder-archive

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -18,6 +18,8 @@
 /envoy_bootstrap*.json
 /clang.bazelrc
 /.dockerignore
+/.clwb
+/.vagrant
 /.gitignore
 /Dockerfile*
 /Makefile.dev

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -26,6 +26,7 @@ COPY . ./
 COPY --from=proxylib /usr/lib/libcilium.so proxylib/libcilium.so
 ARG V
 ARG BAZEL_BUILD_OPTS
+ARG DEBUG
 ARG BUILDARCH
 ARG TARGETARCH
 ARG NO_CACHE
@@ -34,7 +35,7 @@ ENV TARGETARCH=$TARGETARCH
 #
 # Build dependencies
 #
-RUN BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V make envoy-test-deps
+RUN BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DEBUG=$DEBUG make envoy-test-deps
 
 # By default this stage picks up the result of the build above, but ARCHIVE_IMAGE can be
 # overridden to point to a saved image of an earlier run of that stage.
@@ -48,13 +49,14 @@ COPY --from=proxylib /usr/lib/libcilium.so proxylib/libcilium.so
 ARG V
 ARG COPY_CACHE_EXT
 ARG BAZEL_BUILD_OPTS
+ARG DEBUG
 ARG TARGETARCH
 ENV TARGETARCH=$TARGETARCH
 
 # Clear runner's cache when building deps
 RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private rm -rf /root/.cache/*
 RUN --mount=target=/tmp/bazel-cache,source=/tmp/bazel-cache,from=archive-cache,rw \
-    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V make envoy-test-deps && \
+    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DEBUG=$DEBUG make envoy-test-deps && \
     if [ -n "${COPY_CACHE_EXT}" ]; then cp -ra /tmp/bazel-cache /tmp/bazel-cache${COPY_CACHE_EXT}; fi
 
 FROM --platform=$BUILDPLATFORM $BUILDER_BASE as runner
@@ -64,6 +66,7 @@ COPY . ./
 COPY --from=proxylib /usr/lib/libcilium.so proxylib/libcilium.so
 ARG V
 ARG BAZEL_BUILD_OPTS
+ARG DEBUG
 ARG BUILDARCH
 ARG TARGETARCH
 ARG NO_CACHE
@@ -84,7 +87,7 @@ RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private \
         ln -s /usr/aarch64-linux-gnu/lib /usr/cilium-cross-compat/lib; \
       fi; \
     fi && \
-    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V make envoy-tests && \
+    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DEBUG=$DEBUG make envoy-tests && \
     cp -Lr /cilium/proxy/bazel-testlogs testlogs
 
 FROM scratch as empty-builder-archive

--- a/Dockerfile.tests.dockerignore
+++ b/Dockerfile.tests.dockerignore
@@ -18,6 +18,8 @@
 /envoy_bootstrap*.json
 /clang.bazelrc
 /.dockerignore
+/.clwb
+/.vagrant
 /.gitignore
 /Dockerfile*
 /Makefile.dev

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ BAZEL_PLATFORM := //bazel:linux_$(subst amd64,x86_64,$(subst arm64,aarch64,$(TAR
 $(info BUILDING on $(BUILDARCH) for $(TARGETARCH) using $(BAZEL_PLATFORM))
 BAZEL_BUILD_OPTS += --platforms=$(BAZEL_PLATFORM)
 
+ifdef DEBUG
+  BAZEL_BUILD_OPTS += -c dbg
+else
+  BAZEL_BUILD_OPTS += --config=release
+endif
+
 ifdef PKG_BUILD
   all: cilium-envoy
 else
@@ -93,7 +99,7 @@ clang.bazelrc: bazel/setup_clang.sh /usr/lib/llvm-15
 
 bazel-bin/cilium-envoy: $(COMPILER_DEP) SOURCE_VERSION
 	@$(ECHO_BAZEL)
-	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) --config=release //:cilium-envoy $(BAZEL_FILTER)
+	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:cilium-envoy $(BAZEL_FILTER)
 
 cilium-envoy: bazel-bin/cilium-envoy
 	mv $< $@
@@ -128,12 +134,12 @@ clean: force
 .PHONY: envoy-test-deps
 envoy-test-deps: $(COMPILER_DEP) proxylib/libcilium.so SOURCE_VERSION
 	@$(ECHO_BAZEL)
-	$(BAZEL) $(BAZEL_OPTS) build --build_tests_only $(BAZEL_BUILD_OPTS) --config=release -c fastbuild $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
+	$(BAZEL) $(BAZEL_OPTS) build --build_tests_only -c fastbuild $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
 
 .PHONY: envoy-tests
 envoy-tests: $(COMPILER_DEP) proxylib/libcilium.so SOURCE_VERSION
 	@$(ECHO_BAZEL)
-	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) --config=release -c fastbuild $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
+	$(BAZEL) $(BAZEL_OPTS) test  -c fastbuild $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
 
 .PHONY: \
 	install \

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -112,6 +112,11 @@ ifdef NO_CACHE
   endif
 endif
 
+ifdef DEBUG
+  DOCKER_BUILD_OPTS += --build-arg DEBUG=$(DEBUG)
+  DEBUG_TAG := -debug
+endif
+
 ifdef ARCHIVE_IMAGE
   BUILD_IMAGE_OPTS += --build-arg ARCHIVE_IMAGE=$(ARCHIVE_IMAGE)
 endif
@@ -195,9 +200,9 @@ empty-docker-tests-archive: Dockerfile.tests Dockerfile.tests.dockerignore
 	$(DOCKER) build --target empty-builder-archive $(DOCKER_BUILD_OPTS) --build-arg BUILDER_BASE="$(TESTS_BUILDER_BASE)" -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_ARCHIVE_TAG) .
 
 ifeq ($(BRANCH_TAG),"master")
-  DOCKER_TESTS_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:latest$(IMAGE_ARCH)-testlogs
+  DOCKER_TESTS_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:latest$(IMAGE_ARCH)$(DEBUG_TAG)-testlogs
 else
-  DOCKER_TESTS_TAGS ?= -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(BRANCH_TAG)$(IMAGE_ARCH)-testlogs
+  DOCKER_TESTS_TAGS ?= -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(BRANCH_TAG)$(IMAGE_ARCH)$(DEBUG_TAG)-testlogs
 endif
 
 .PHONY: docker-tests
@@ -205,11 +210,11 @@ docker-tests: Dockerfile.tests SOURCE_VERSION Dockerfile.tests.dockerignore
 	$(DOCKER) build --progress=plain $(subst --push,--load,$(DOCKER_BUILD_OPTS)) $(DOCKER_CACHE_OPTS) $(TESTS_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" -f $< $(DOCKER_TESTS_TAGS) .
 
 ifeq ($(BRANCH_TAG),"master")
-  DOCKER_IMAGE_ENVOY_TAGS := -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:$(SOURCE_VERSION)$(IMAGE_ARCH)
-  DOCKER_IMAHE_ENVOY_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:latest$(IMAGE_ARCH)
+  DOCKER_IMAGE_ENVOY_TAGS := -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:$(SOURCE_VERSION)$(IMAGE_ARCH)$(DEBUG_TAG)
+  DOCKER_IMAHE_ENVOY_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:latest$(IMAGE_ARCH)$(DEBUG_TAG)
 else
-  DOCKER_IMAGE_ENVOY_TAGS ?= -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(BRANCH_TAG)$(IMAGE_ARCH)
-  DOCKER_IMAGE_ENVOY_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(SOURCE_VERSION)$(IMAGE_ARCH)
+  DOCKER_IMAGE_ENVOY_TAGS ?= -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(BRANCH_TAG)$(IMAGE_ARCH)$(DEBUG_TAG)
+  DOCKER_IMAGE_ENVOY_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(SOURCE_VERSION)$(IMAGE_ARCH)$(DEBUG_TAG)
 endif
 
 .PHONY: docker-image-envoy


### PR DESCRIPTION
Build with debug symbols if DEBUG is defined, both in local bazel targets as well as docker targets.

This makes Envoy backtraces more meaningful which is nice when chasing a crashing bug.
