### PR TITLE
test: Limit number of jobs running test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifdef BAZEL_REMOTE_CACHE
   BAZEL_BUILD_OPTS += --remote_cache=$(BAZEL_REMOTE_CACHE)
 endif
 
-BAZEL_TEST_OPTS ?= --jobs=HOST_RAM*.0003 --test_timeout=300
+BAZEL_TEST_OPTS ?= --jobs=HOST_RAM*.0003 --test_timeout=300 --local_test_jobs=1
 BAZEL_TEST_OPTS += --test_output=errors
 
 BUILDARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))


### PR DESCRIPTION
This is to add local_test_jobs flag in BAZEL_TEST_OPTS for below points:

- Build is still running in parallel
- Test is running with limited local_test_jobs to avoid any potential issue mentioned in #139.

Fixes: #139