### PR TITLE
gha: Add envoy minor version tag in docker

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Prep for build
         run: |
           echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
-          echo "ENVOY_VERSION=$(cat ENVOY_VERSION)" >> $GITHUB_ENV
+          echo "ENVOY_MINOR_RELEASE=$(cat ENVOY_VERSION | sed 's/envoy-\([0-9]\+\.[0-9]\+\)\..*/v\1/')" >> $GITHUB_ENV
           echo "BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
           echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
 
@@ -91,8 +91,9 @@ jobs:
           docker cp cilium-envoy:/usr/bin/cilium-envoy ./cilium-envoy
           docker rm -fv cilium-envoy
           envoy_version=$(./cilium-envoy --version)
+          expected_ersion=$(echo ${{ env.ENVOY_MINOR_RELEASE }} | sed 's/^v//')
           echo ${envoy_version}
-          [[ "${envoy_version}" == *"${{ github.event.pull_request.head.sha }}"* ]]
+          [[ "${envoy_version}" == *"${{ github.event.pull_request.head.sha }}/$expected_ersion"* ]]
 
       - name: CI Image Digest
         shell: bash

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -77,6 +77,7 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
             COPY_CACHE_EXT=.new
             BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.75"
+            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
 
@@ -101,6 +102,7 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
+            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy:latest-testlogs

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Prep for build
         run: |
           echo "${{ github.sha }}" >SOURCE_VERSION
-          echo "ENVOY_VERSION=$(cat ENVOY_VERSION)" >> $GITHUB_ENV
+          echo "ENVOY_MINOR_RELEASE=$(cat ENVOY_VERSION | sed 's/envoy-\([0-9]\+\.[0-9]\+\)\..*/v\1/')" >> $GITHUB_ENV
           echo "BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
           echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder.tests | awk '{ print $3 }')" >> $GITHUB_ENV
 
@@ -195,7 +195,7 @@ jobs:
           push: true
           tags: |
             quay.io/${{ github.repository_owner }}/cilium-envoy:latest
-            quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }}
+            quay.io/${{ github.repository_owner }}/cilium-envoy:${{ env.ENVOY_MINOR_RELEASE }}-${{ github.sha }}
 
       - name: Envoy binary version check
         shell: bash
@@ -204,11 +204,13 @@ jobs:
           docker cp cilium-envoy:/usr/bin/cilium-envoy ./cilium-envoy
           docker rm -fv cilium-envoy
           envoy_version=$(./cilium-envoy --version)
+          expected_ersion=$(echo ${{ env.ENVOY_MINOR_RELEASE }} | sed 's/^v//')
           echo ${envoy_version}
-          [[ "${envoy_version}" == *"${{ github.sha }}"* ]]
+          [[ "${envoy_version}" == *"${{ github.sha }}/$expected_ersion"* ]]
 
       - name: Release Image Digest
         shell: bash
         run: |
           echo "Digests:"
           echo "quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }}@${{ steps.docker_build_cd.outputs.digest }}"
+          echo "quay.io/${{ github.repository_owner }}/cilium-envoy:${{ env.ENVOY_MINOR_RELEASE }}-${{ github.sha }}@${{ steps.docker_build_cd.outputs.digest }}"

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -84,5 +84,6 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-master-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
+            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1
           cache-from: type=local,src=/tmp/buildx-cache
           push: false

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -66,6 +66,7 @@ COPY . ./
 COPY --from=proxylib /usr/lib/libcilium.so proxylib/libcilium.so
 ARG V
 ARG BAZEL_BUILD_OPTS
+ARG BAZEL_TEST_OPTS
 ARG DEBUG
 ARG BUILDARCH
 ARG TARGETARCH
@@ -87,7 +88,7 @@ RUN --mount=target=/root/.cache,type=cache,id=$TARGETARCH,sharing=private \
         ln -s /usr/aarch64-linux-gnu/lib /usr/cilium-cross-compat/lib; \
       fi; \
     fi && \
-    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DEBUG=$DEBUG make envoy-tests && \
+    BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" BAZEL_TEST_OPTS="${BAZEL_TEST_OPTS}" PKG_BUILD=1 V=$V DEBUG=$DEBUG make envoy-tests && \
     cp -Lr /cilium/proxy/bazel-testlogs testlogs
 
 FROM scratch as empty-builder-archive


### PR DESCRIPTION
This is to add one more tag for docker artifact, following the below convention.

```
quay.io/cilium/cilium-envoy:v1.24-<commit-sha>
```