### PR TITLE
gha: Add ENVOY_MINOR_RELEASE for build task

### DIFF
--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -127,7 +127,7 @@ jobs:
       - name: Prep for build
         run: |
           echo "${{ github.sha }}" >SOURCE_VERSION
-          echo "ENVOY_VERSION=$(cat ENVOY_VERSION)" >> $GITHUB_ENV
+          echo "ENVOY_MINOR_RELEASE=$(cat ENVOY_VERSION | sed 's/envoy-\([0-9]\+\.[0-9]\+\)\..*/v\1/')" >> $GITHUB_ENV
           echo "BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
           echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
 


### PR DESCRIPTION
This was missed in previous PR, hence there is failure in master branch.

Fixes: 5268dd06fa156599cc20ca509fa64313cb013c3e

```
ERROR: invalid tag "quay.io/cilium/cilium-envoy:-5268dd06fa156599cc20ca509fa64313cb013c3e": invalid reference format
```