### PR TITLE
gha: Keep old tag with commit sha

### DIFF
--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -195,6 +195,7 @@ jobs:
           push: true
           tags: |
             quay.io/${{ github.repository_owner }}/cilium-envoy:latest
+            quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }}
             quay.io/${{ github.repository_owner }}/cilium-envoy:${{ env.ENVOY_MINOR_RELEASE }}-${{ github.sha }}
 
       - name: Envoy binary version check


### PR DESCRIPTION
This is to make sure that consumer of this image can still use old format.

Fixes: 5268dd06fa156599cc20ca509fa64313cb013c3e