### PR TITLE
ci: don't skip cilium integration tests on event pull_request_target

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -25,7 +25,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/test-cilium-integration')) ||
       github.event_name == 'push' ||
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Prepare variables for pushes to master
@@ -35,7 +35,7 @@ jobs:
           echo "PROXY_TAG=${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Prepare variables for PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         run: |
           echo "PROXY_IMAGE=quay.io/cilium/cilium-envoy-dev" >> $GITHUB_ENV
           echo "PROXY_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
@@ -55,7 +55,7 @@ jobs:
           echo "CILIUM_REPO_REF=${ciliumRef}" >> $GITHUB_ENV
 
           ciliumCliTag=${CILIUM_CLI_TAG}
-          if [[ "${{ github.event.comment.body }}" == *" ciliumCli="* ]]; then
+          if [[ "$commentBody" == *" ciliumCli="* ]]; then
             ciliumCliTag=$(echo "$commentBody" | sed -E 's|.* ciliumCli=([^ ]*).*|\1|g')
           fi
           echo "CILIUM_CLI_TAG=${ciliumCliTag}" >> $GITHUB_ENV


### PR DESCRIPTION
When switching back to `pull_request_target` from `pull_request` before merging, the other occurances of event_name weren't adapted.

This commit fixes this.