### PR TITLE
ci: get PR head SHA from PR URL in case of event type issue_comment

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -44,7 +44,7 @@ jobs:
         if: github.event_name == 'issue_comment'
         run: |
           echo "PROXY_IMAGE=quay.io/cilium/cilium-envoy-dev" >> $GITHUB_ENV
-          echo "PROXY_TAG=${{ github.event.issue.pull_request.head.sha }}" >> $GITHUB_ENV
+          echo "PROXY_TAG=$(curl -s ${{ github.event.issue.pull_request.url }} | jq -r '.head.sha')" >> $GITHUB_ENV
 
           commentBody="${{ github.event.comment.body }}"
 


### PR DESCRIPTION
Event type payload "issue_comment" doesn't contain the head SHA of the PR of the comment directly. This results in the issue in the cilium integration tests, that `PROXY_TAG` isn't evaluated and the wait for the docker image times out.

This commit resolves the head SHA of the PR from the PR URL which solves the issue.