### PR TITLE
ci: cilium integration test supports stable version of cilium cli

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -16,7 +16,7 @@ on:
 env:
   KIND_VERSION: v0.18.0
   CILIUM_REPO_REF: master
-  CILIUM_CLI_TAG: latest
+  CILIUM_CLI_REF: latest
 
 jobs:
   cilium-connectivity-tests:
@@ -63,11 +63,11 @@ jobs:
           fi
           echo "CILIUM_REPO_REF=${ciliumRef}" >> $GITHUB_ENV
 
-          ciliumCliTag=${CILIUM_CLI_TAG}
+          ciliumCliRef=${CILIUM_CLI_REF}
           if [[ "$commentBody" == *" ciliumCli="* ]]; then
-            ciliumCliTag=$(echo "$commentBody" | sed -E 's|.* ciliumCli=([^ ]*).*|\1|g')
+            ciliumCliRef=$(echo "$commentBody" | sed -E 's|.* ciliumCli=([^ ]*).*|\1|g')
           fi
-          echo "CILIUM_CLI_TAG=${ciliumCliTag}" >> $GITHUB_ENV
+          echo "CILIUM_CLI_REF=${ciliumCliRef}" >> $GITHUB_ENV
 
       - name: Reporting start to issue comment
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
@@ -96,11 +96,19 @@ jobs:
           repository: cilium/cilium # Be aware that this is the Cilium repository and not the one of the proxy itself!
           ref: ${{ env.CILIUM_REPO_REF }}
 
-      - name: Install Cilium CLI ${{ env.CILIUM_CLI_TAG }}
+      - name: Install Cilium CLI ${{ env.CILIUM_CLI_REF }}
         run: |
-          cid=$(docker create quay.io/cilium/cilium-cli-ci:${{ env.CILIUM_CLI_TAG }} ls)
-          sudo docker cp $cid:/usr/local/bin/cilium /usr/local/bin
-          docker rm $cid
+          versionPattern="^v[0-9]+\.[0-9]+\.[0-9]+$"
+          if [[ ${{ env.CILIUM_CLI_REF }} =~ $versionPattern ]]; then
+            curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.CILIUM_CLI_REF }}/cilium-linux-amd64.tar.gz{,.sha256sum}
+            sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+            sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
+            rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          else
+            cid=$(docker create quay.io/cilium/cilium-cli-ci:${{ env.CILIUM_CLI_REF }} ls)
+            sudo docker cp $cid:/usr/local/bin/cilium /usr/local/bin
+            docker rm $cid
+          fi
           cilium version
 
       - name: Create kind cluster


### PR DESCRIPTION
Currently, the Cilium Integration test is installing Cilium CLI via Docker Image to support any given build of the CLI. The tar.gz only exist for actual CLI releases.

However, this comes with the drawback that referencing a stable release isn't that easy, because this needs knowledge of the actual GIT commit hash of the release.

Therefore, this commit installs the Cilium CLI via tar.gz when the Cilium CLI reference is a version (vx.x.x).