### PR TITLE
ci: Trigger Cilium Integration Tests via comment only by known users

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -23,7 +23,16 @@ jobs:
     timeout-minutes: 360
     name: Cilium Connectivity Tests
     if: |
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/test-cilium-integration')) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/test-cilium-integration') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR' ||
+          github.event.comment.author_association == 'MEMBER'
+        )
+      ) ||
       github.event_name == 'push' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cilium Integration Tests via comment should only be triggered if the author of the comment is owner, collaborator or member.