### PR TITLE
ci: only execute L7 Connectivity tests when testing Cilium Integration

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -153,9 +153,9 @@ jobs:
 
           cilium hubble port-forward&
 
-      - name: Execute Cilium Connectivity Tests
+      - name: Execute Cilium L7 Connectivity Tests
         shell: bash
-        run: cilium connectivity test
+        run: cilium connectivity test --test=l7
 
       - name: Reporting success to issue comment
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1


### PR DESCRIPTION
Currently all Cilium Connectivity tests are executed when testing the Cilium Integration.

In the context of the Cilium Proxy, only the L7 tests are actually interesting. Therefore, this commit adds the necessary flag `--test=l7`.