### PR TITLE
Automated Envoy version updates with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,9 @@
   ],
   "includePaths": [
     ".github/workflows/**",
-    "Dockerfile.builder"
+    "Dockerfile.builder",
+    "WORKSPACE",
+    "ENVOY_VERSION"
   ],
   "pinDigests": true,
   "ignorePresets": [":prHourlyLimit2"],
@@ -48,6 +50,42 @@
       "allowedVersions": "20.04",
       "matchBaseBranches": [
         "master"
+      ]
+    },
+    {
+      // Group envoy updates
+      "groupName": "envoy",
+      "matchDepNames": [
+        "envoyproxy/envoy"
+      ]
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^WORKSPACE$",
+      ],
+      // These regexes manage version and digest strings in shell scripts,
+      // similar to the examples shown here:
+      //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION = \"(?<currentValue>.*)\"",
+        // The digestVersion in this regex is required for Renovate to be able
+        // to match the digest to the pinned version. It will not work without it.
+        // Note that for GitHub release artifact digests, you likely want to use
+        // github-release-attachments as the datasource here.
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_SHA = \"(?<currentDigest>.*)\""
+      ]
+    },
+    {
+      "fileMatch": [
+        "^ENVOY_VERSION$"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "envoyproxy/envoy",
+      "extractVersionTemplate": "^v?(?<version>.+)$",
+      "matchStrings": [
+        "envoy-(?<currentValue>.*)"
       ]
     }
   ]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,7 @@ ENVOY_REPO = "envoy"
 #
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
+# renovate: datasource=github-releases depName=envoyproxy/envoy digestVersion=v1.25.5
 ENVOY_SHA = "4b5f5474f35763423684c0fe25c99cc7b2a01fcf"
 
 # // clang-format off: unexpected @bazel_tools reference, please indirect via a definition in //bazel

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,11 @@ workspace(name = "cilium")
 
 register_toolchains("//bazel/toolchains:all")
 
+ENVOY_PROJECT = "envoyproxy"
+
+ENVOY_REPO = "envoy"
+
+# Envoy GIT commit SHA of release
 #
 # We grep for the following line to generate SOURCE_VERSION file for non-git
 # distribution builds. This line must start with the string ENVOY_SHA followed by
@@ -9,19 +14,10 @@ register_toolchains("//bazel/toolchains:all")
 #
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
-ENVOY_PROJECT = "envoyproxy"
-
-ENVOY_REPO = "envoy"
-
-# https://github.com/envoyproxy/envoy/tree/v1.25.5
-# NOTE: Update version number to file 'ENVOY_VERSION' to keep test and build docker images
-# for different versions.
 ENVOY_SHA = "4b5f5474f35763423684c0fe25c99cc7b2a01fcf"
 
-ENVOY_SHA256 = "00191a1e702040ec8f92ba18344b001e862e55cc6e24a60509db450bdeb8c0ee"
-
 # // clang-format off: unexpected @bazel_tools reference, please indirect via a definition in //bazel
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # // clang-format on
 
 local_repository(
@@ -29,8 +25,12 @@ local_repository(
     path = "envoy_build_config",
 )
 
-http_archive(
+git_repository(
     name = "envoy",
+    # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
+    remote = "https://github.com/envoyproxy/envoy.git",
+    # // clang-format on
+    commit = ENVOY_SHA,
     patch_args = ["apply"],
     patch_tool = "git",
     patches = [
@@ -40,11 +40,6 @@ http_archive(
         "@//patches:0004-tcp_proxy-Add-filter-state-proxy_read_before_connect.patch",
         "@//patches:0005-router-Do-not-set-SNI-or-SAN-due-to-auto_sni-or-auto.patch",
     ],
-    sha256 = ENVOY_SHA256,
-    strip_prefix = ENVOY_REPO + "-" + ENVOY_SHA,
-    # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
-    url = "https://github.com/" + ENVOY_PROJECT + "/" + ENVOY_REPO + "/archive/" + ENVOY_SHA + ".tar.gz",
-    # // clang-format on
 )
 
 #

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -76,6 +76,7 @@ paths:
   # @envoyproxy/dependency-shepherds.
   build_urls:
     include:
+    - api/bazel/envoy_git_repository.bzl
     - api/bazel/envoy_http_archive.bzl
     - api/bazel/repository_locations.bzl
     - bazel/external/cargo/crates.bzl


### PR DESCRIPTION
This commit introduces automated Envoy version updates with Renovate on the master branch.

In addition, Envoy source code gets fetched via GIT clone instead of downloading the source archive.

Example Renovate PR Envoy `1.25.4` -> `1.25.5` (after a manual downgrade): https://github.com/mhofstetter/proxy/pull/2

-> updates on `v1.22` & `v1.23` release branches will be handled in a separate PR