### PR TITLE
ci: adapt renamed default branch of cilium in integration tests

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -16,7 +16,7 @@ on:
 env:
   KIND_VERSION: v0.18.0
   CILIUM_REPO_OWNER: cilium
-  CILIUM_REPO_REF: master
+  CILIUM_REPO_REF: main
   CILIUM_CLI_REF: latest
 
 jobs:


### PR DESCRIPTION
The new default branch `main` should be used in the cilium integration tests when cloning the cilium repository.