### PR TITLE
ci: disable automated renovate updates for major & minor envoy versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,6 +58,17 @@
       "matchDepNames": [
         "envoyproxy/envoy"
       ]
+    },
+    {
+      // Disable major & minor updates of Envoy
+      "enabled": false,
+      "matchDepNames": [
+        "envoyproxy/envoy"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+      ]
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
Currently, renovate tries to update envoy for all version types.

In most of the cases automated major & minor updates need some manual interaction anyway. Therefore, we start with patch releasese only - and disable major & minor ones.