### PR TITLE
ci: fix sysdump collection path

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -199,7 +199,7 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: cilium-integration-test-sysdump
-          path: cilium-integration-test-sysdump-*.zip
+          path: cilium-integration-test-sysdump.zip
           retention-days: 5
 
       - name: Reporting failure to issue comment


### PR DESCRIPTION
This commit fixes the sysdump path when uploading the sysdump in case of a failure after the cilium integration tests.

Without this fix, the sysdump gets collected but not uploaded.