### PR TITLE
image: use ubuntu-22 as base image instead of scratch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,7 @@
   ],
   "includePaths": [
     ".github/workflows/**",
+    "Dockerfile",
     "Dockerfile.builder",
     "WORKSPACE",
     "ENVOY_VERSION"
@@ -44,6 +45,21 @@
       ]
     },
     {
+      "matchFiles": [
+        "Dockerfile",
+      ],
+      "matchPackageNames": [
+        "docker.io/library/ubuntu"
+      ],
+      "allowedVersions": "22.04",
+      "matchBaseBranches": [
+        "main"
+      ]
+    },
+    {
+      "matchFiles": [
+        "Dockerfile.builder",
+      ],
       "matchPackageNames": [
         "docker.io/library/ubuntu"
       ],

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,6 @@ COPY --from=builder /tmp/bazel-cache${COPY_CACHE_EXT}/ /tmp/bazel-cache/
 #
 # Extract installed cilium-envoy binaries to an otherwise empty image
 #
-FROM scratch
+FROM docker.io/library/ubuntu:22.04@sha256:67211c14fa74f070d27cc59d69a7fa9aeff8e28ea118ef3babc295a0428a6d21
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /


### PR DESCRIPTION
Currently, the docker image quay.io/cilium/cilium-envoy builds on top of plain scratch and only contains the cilium-envoy binary. It's only used for "transport" purposes.

With the introduction of a dedicated DaemonSet for Envoy in the context of Cilium, it becomes necessary to add a "runtime" to the cilium envoy docker image. This commit starts off by using Ubuntu. In a next step, we might try to use a smaller base image.