### PR TITLE
ci: use dockerimage directly for envoy binary version check

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -35,6 +35,7 @@ jobs:
         run: |
           echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
           echo "ENVOY_MINOR_RELEASE=$(cat ENVOY_VERSION | sed 's/envoy-\([0-9]\+\.[0-9]\+\)\..*/v\1/')" >> $GITHUB_ENV
+          echo "ENVOY_PATCH_RELEASE=$(cat ENVOY_VERSION | sed 's/^envoy-\([0-9]\+\.[0-9]\+\.[0-9]\+$\)/v\1/')" >> $GITHUB_ENV
           echo "BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
           echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
 
@@ -88,7 +89,7 @@ jobs:
         shell: bash
         run: |
           envoy_version=$(docker run -it --rm quay.io/${{ github.repository_owner }}/cilium-envoy-dev:${{ github.event.pull_request.head.sha }} cilium-envoy --version)
-          expected_version=$(echo ${{ env.ENVOY_MINOR_RELEASE }} | sed 's/^v//')
+          expected_version=$(echo ${{ env.ENVOY_PATCH_RELEASE }} | sed 's/^v//')
           echo ${envoy_version}
           [[ "${envoy_version}" == *"${{ github.event.pull_request.head.sha }}/$expected_version"* ]]
 

--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -87,13 +87,10 @@ jobs:
       - name: Envoy binary version check
         shell: bash
         run: |
-          docker create -ti --name cilium-envoy quay.io/${{ github.repository_owner }}/cilium-envoy-dev:${{ github.event.pull_request.head.sha }} bash
-          docker cp cilium-envoy:/usr/bin/cilium-envoy ./cilium-envoy
-          docker rm -fv cilium-envoy
-          envoy_version=$(./cilium-envoy --version)
-          expected_ersion=$(echo ${{ env.ENVOY_MINOR_RELEASE }} | sed 's/^v//')
+          envoy_version=$(docker run -it --rm quay.io/${{ github.repository_owner }}/cilium-envoy-dev:${{ github.event.pull_request.head.sha }} cilium-envoy --version)
+          expected_version=$(echo ${{ env.ENVOY_MINOR_RELEASE }} | sed 's/^v//')
           echo ${envoy_version}
-          [[ "${envoy_version}" == *"${{ github.event.pull_request.head.sha }}/$expected_ersion"* ]]
+          [[ "${envoy_version}" == *"${{ github.event.pull_request.head.sha }}/$expected_version"* ]]
 
       - name: CI Image Digest
         shell: bash

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           echo "${{ github.sha }}" >SOURCE_VERSION
           echo "ENVOY_MINOR_RELEASE=$(cat ENVOY_VERSION | sed 's/envoy-\([0-9]\+\.[0-9]\+\)\..*/v\1/')" >> $GITHUB_ENV
+          echo "ENVOY_PATCH_RELEASE=$(cat ENVOY_VERSION | sed 's/^envoy-\([0-9]\+\.[0-9]\+\.[0-9]\+$\)/v\1/')" >> $GITHUB_ENV
           echo "BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
           echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder.tests | awk '{ print $3 }')" >> $GITHUB_ENV
 
@@ -128,6 +129,7 @@ jobs:
         run: |
           echo "${{ github.sha }}" >SOURCE_VERSION
           echo "ENVOY_MINOR_RELEASE=$(cat ENVOY_VERSION | sed 's/envoy-\([0-9]\+\.[0-9]\+\)\..*/v\1/')" >> $GITHUB_ENV
+          echo "ENVOY_PATCH_RELEASE=$(cat ENVOY_VERSION | sed 's/^envoy-\([0-9]\+\.[0-9]\+\.[0-9]\+$\)/v\1/')" >> $GITHUB_ENV
           echo "BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
           echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
 
@@ -202,7 +204,7 @@ jobs:
         shell: bash
         run: |
           envoy_version=$(docker run -it --rm quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }} cilium-envoy --version)
-          expected_version=$(echo ${{ env.ENVOY_MINOR_RELEASE }} | sed 's/^v//')
+          expected_version=$(echo ${{ env.ENVOY_PATCH_RELEASE }} | sed 's/^v//')
           echo ${envoy_version}
           [[ "${envoy_version}" == *"${{ github.sha }}/$expected_version"* ]]
 

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -201,13 +201,10 @@ jobs:
       - name: Envoy binary version check
         shell: bash
         run: |
-          docker create -ti --name cilium-envoy quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }} bash
-          docker cp cilium-envoy:/usr/bin/cilium-envoy ./cilium-envoy
-          docker rm -fv cilium-envoy
-          envoy_version=$(./cilium-envoy --version)
-          expected_ersion=$(echo ${{ env.ENVOY_MINOR_RELEASE }} | sed 's/^v//')
+          envoy_version=$(docker run -it --rm quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }} cilium-envoy --version)
+          expected_version=$(echo ${{ env.ENVOY_MINOR_RELEASE }} | sed 's/^v//')
           echo ${envoy_version}
-          [[ "${envoy_version}" == *"${{ github.sha }}/$expected_ersion"* ]]
+          [[ "${envoy_version}" == *"${{ github.sha }}/$expected_version"* ]]
 
       - name: Release Image Digest
         shell: bash


### PR DESCRIPTION
Having added ubuntu as runtime to the docker image - it's now possible to retrieve the envoy version directly by executing the command in the docker container instead of copying the binary from a running container.

In addition, Envoy's patch version is used for the check - instead of the minor version.