### PR TITLE
Automated Envoy version updates with Renovate on v1.23

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,12 @@ workspace(name = "cilium")
 
 register_toolchains("//bazel/toolchains:all")
 
+ENVOY_PROJECT = "envoyproxy"
+
+ENVOY_REPO = "envoy"
+
+#
+# Envoy GIT commit SHA of release
 #
 # We grep for the following line to generate SOURCE_VERSION file for non-git
 # distribution builds. This line must start with the string ENVOY_SHA followed by
@@ -9,18 +15,10 @@ register_toolchains("//bazel/toolchains:all")
 #
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
-ENVOY_PROJECT = "envoyproxy"
-
-ENVOY_REPO = "envoy"
-
-# https://github.com/envoyproxy/envoy/tree/v1.23.8
-# Note that this branch is only for envoy v1.23.x
 ENVOY_SHA = "ae7ea959ac468ef21da6eb85e2892c8101a6eb54"
 
-ENVOY_SHA256 = "237ee7e686bbcaa8d5952743cfe3587baf0812e870cf574faaee9b9820b996d5"
-
 # // clang-format off: unexpected @bazel_tools reference, please indirect via a definition in //bazel
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # // clang-format on
 
 local_repository(
@@ -28,8 +26,12 @@ local_repository(
     path = "envoy_build_config",
 )
 
-http_archive(
+git_repository(
     name = "envoy",
+    # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
+    remote = "https://github.com/envoyproxy/envoy.git",
+    # // clang-format on
+    commit = ENVOY_SHA,
     patch_args = ["apply"],
     patch_tool = "git",
     patches = [
@@ -39,11 +41,6 @@ http_archive(
         "@//patches:0004-tcp_proxy-Add-filter-state-proxy_read_before_connect.patch",
         "@//patches:0005-router-Do-not-set-SNI-or-SAN-due-to-auto_sni-or-auto.patch",
     ],
-    sha256 = ENVOY_SHA256,
-    strip_prefix = ENVOY_REPO + "-" + ENVOY_SHA,
-    # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
-    url = "https://github.com/" + ENVOY_PROJECT + "/" + ENVOY_REPO + "/archive/" + ENVOY_SHA + ".tar.gz",
-    # // clang-format on
 )
 
 #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,7 @@ ENVOY_REPO = "envoy"
 #
 # No other line in this file may have ENVOY_SHA followed by an equals sign!
 #
+# renovate: datasource=github-releases depName=envoyproxy/envoy digestVersion=v1.23.8
 ENVOY_SHA = "ae7ea959ac468ef21da6eb85e2892c8101a6eb54"
 
 # // clang-format off: unexpected @bazel_tools reference, please indirect via a definition in //bazel


### PR DESCRIPTION
This PR prepares and enables automated envoy version updates on the release branch v.1.23.

The renovate configuration on main branch ensures that the Envoy version will stay on v1.23.x (https://github.com/cilium/proxy/pull/193)