### PR TITLE
renovate: enable renovate updates on release branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,7 +19,9 @@
   "separateMinorPatch": true,
   "pruneStaleBranches": true,
   "baseBranches": [
-    "main"
+    "main",
+    "v1.23",
+    "v1.22"
   ],
   "labels": [
     "kind/enhancement",
@@ -65,25 +67,39 @@
       ],
       "allowedVersions": "20.04",
       "matchBaseBranches": [
+        "main",
+        "v1.23",
+        "v1.22"
+      ]
+    },
+    {
+      "groupName": "envoy 1.25.x",
+      "matchDepNames": [
+        "envoyproxy/envoy"
+      ],
+      "allowedVersions": "<=1.25",
+      "matchBaseBranches": [
         "main"
       ]
     },
     {
-      // Group envoy updates
-      "groupName": "envoy",
-      "matchDepNames": [
-        "envoyproxy/envoy"
-      ]
-    },
-    {
-      // Disable major & minor updates of Envoy
-      "enabled": false,
+      "groupName": "envoy 1.23.x",
       "matchDepNames": [
         "envoyproxy/envoy"
       ],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
+      "allowedVersions": "<=1.23",
+      "matchBaseBranches": [
+        "v1.23"
+      ]
+    },
+    {
+      "groupName": "envoy 1.22.x",
+      "matchDepNames": [
+        "envoyproxy/envoy"
+      ],
+      "allowedVersions": "<=1.22",
+      "matchBaseBranches": [
+        "v1.22"
       ]
     }
   ],


### PR DESCRIPTION
This commit enables renovate updates on release branches (currently v1.22 & v1.23).

* GitHub Actions -> should be ok
* Dockerfile.Builder -> mainly ubuntu -> which will stay on version 20.04
* Dockerfile -> scratch anyway
* envoy version -> configured to keep the envoy version on the corresponding minor versions.