### PR TITLE
renovate: prevent updates of quay.io/cilium/cilium-envoy-builder

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,16 @@
       ]
     },
     {
+      // Do not allow any updates/pinning of image quay.io/cilium/cilium-envoy-builder
+      "enabled": false,
+      "matchFiles": [
+        "Dockerfile",
+      ],
+      "matchPackageNames": [
+        "quay.io/cilium/cilium-envoy-builder"
+      ]
+    },
+    {
       "matchFiles": [
         "Dockerfile.builder",
       ],


### PR DESCRIPTION
This commit prevents renovate from updating or pinning `quay.io/cilium/cilium-envoy-builder` within the `Dockerfile`.