### PR TITLE
image: push release image with envoy patch version

### DIFF
--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -199,6 +199,7 @@ jobs:
             quay.io/${{ github.repository_owner }}/cilium-envoy:latest
             quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }}
             quay.io/${{ github.repository_owner }}/cilium-envoy:${{ env.ENVOY_MINOR_RELEASE }}-${{ github.sha }}
+            quay.io/${{ github.repository_owner }}/cilium-envoy:${{ env.ENVOY_PATCH_RELEASE }}-${{ github.sha }}
 
       - name: Envoy binary version check
         shell: bash
@@ -214,3 +215,4 @@ jobs:
           echo "Digests:"
           echo "quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }}@${{ steps.docker_build_cd.outputs.digest }}"
           echo "quay.io/${{ github.repository_owner }}/cilium-envoy:${{ env.ENVOY_MINOR_RELEASE }}-${{ github.sha }}@${{ steps.docker_build_cd.outputs.digest }}"
+          echo "quay.io/${{ github.repository_owner }}/cilium-envoy:${{ env.ENVOY_PATCH_RELEASE }}-${{ github.sha }}@${{ steps.docker_build_cd.outputs.digest }}"


### PR DESCRIPTION
Currently, an image of a release gets tagged and pushed with `latest`, `<SHA>` & `<envoy-minor-version>-<SHA>`.

In addition, this commit adds the format `<envoy-patch-version>-<SHA>` which then can be used in the cilium envoy daemonset.