### PR TITLE
ci: fix envoy version check issue

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Envoy binary version check
         shell: bash
         run: |
-          envoy_version=$(docker run -it --rm quay.io/${{ github.repository_owner }}/cilium-envoy-dev:${{ github.event.pull_request.head.sha }} cilium-envoy --version)
+          envoy_version=$(docker run --rm quay.io/${{ github.repository_owner }}/cilium-envoy-dev:${{ github.event.pull_request.head.sha }} cilium-envoy --version)
           expected_version=$(echo ${{ env.ENVOY_PATCH_RELEASE }} | sed 's/^v//')
           echo ${envoy_version}
           [[ "${envoy_version}" == *"${{ github.event.pull_request.head.sha }}/$expected_version"* ]]

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -203,7 +203,7 @@ jobs:
       - name: Envoy binary version check
         shell: bash
         run: |
-          envoy_version=$(docker run -it --rm quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }} cilium-envoy --version)
+          envoy_version=$(docker run --rm quay.io/${{ github.repository_owner }}/cilium-envoy:${{ github.sha }} cilium-envoy --version)
           expected_version=$(echo ${{ env.ENVOY_PATCH_RELEASE }} | sed 's/^v//')
           echo ${envoy_version}
           [[ "${envoy_version}" == *"${{ github.sha }}/$expected_version"* ]]


### PR DESCRIPTION
This commit removes the interactive flag when executing the envoy version check to prevent the error `The input device is not a TTY`.

fixes: https://github.com/cilium/proxy/pull/190