### PR TITLE
tools: improve bazel version check

### DIFF
--- a/tools/install_bazel.sh
+++ b/tools/install_bazel.sh
@@ -8,19 +8,19 @@ else
 fi
 
 echo "Checking if Bazel ${BAZEL_VERSION} needs to be installed..."
-if [[ $(command -v bazel) && "$(bazel version | grep 'label' | cut -d ' ' -f 3)" =~ ${BAZEL_VERSION} ]]; then
+if [[ $(command -v bazel) && "$(bazel version | grep 'label' | cut -d ' ' -f 3)" = "${BAZEL_VERSION}" ]]; then
     echo "Bazel ${BAZEL_VERSION} already installed, skipping fetch."
 else
     BAZEL=$(command -v bazel)
     if [ -n "${BAZEL}" ] ; then
-	echo "Removing old Bazel version at ${BAZEL}"
-	${SUDO} rm ${BAZEL}
+        echo "Removing old Bazel version at ${BAZEL}"
+        ${SUDO} rm "${BAZEL}"
     else
-	BAZEL=/usr/local/bin/bazel
+        BAZEL=/usr/local/bin/bazel
     fi
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
     ARCH=$(uname -m) && [ "$ARCH" != "aarch64" ] || ARCH="arm64"
     echo "Downloading bazel-${BAZEL_VERSION}-${OS}-${ARCH} to ${BAZEL}"
-    ${SUDO} curl -sfL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-${OS}-${ARCH} -o ${BAZEL}
+    ${SUDO} curl -sfL "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-${OS}-${ARCH}" -o ${BAZEL}
     ${SUDO} chmod +x ${BAZEL}
 fi


### PR DESCRIPTION
Currently, when checking whether bazel needs to be installed or upgraded, the currently installed bazel version needs to have the expected version included.

This prevents automated updates to a stable release version when coming from a bazel pre-release (e.g. `6.0.0-pre.20220421.3` -> `6.0.0`) because the pre-release version already contains the stable release version.