### PR TITLE
ci: fix agent dockerfile patch during Cilium Integration Test

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -128,8 +128,12 @@ jobs:
       - name: Patch Cilium Agent Dockerfile
         shell: bash
         run: |
-          sed -i -E 's|(FROM )(quay\.io\/cilium\/cilium-envoy:)([0-9a-z]*)(@sha256:[0-9a-z]*)( as cilium-envoy)|\1${{ env.PROXY_IMAGE }}:${{ env.PROXY_TAG }}\5|' ./images/cilium/Dockerfile
+          sed -i -E 's|(FROM )(quay\.io\/cilium\/cilium-envoy:)(.*)(@sha256:[0-9a-z]*)( as cilium-envoy)|\1${{ env.PROXY_IMAGE }}:${{ env.PROXY_TAG }}\5|' ./images/cilium/Dockerfile
           cat ./images/cilium/Dockerfile
+          if git diff --exit-code ./images/cilium/Dockerfile; then
+            echo "Dockerfile not modified"
+            exit 1
+          fi
 
       - name: Wait for Cilium Proxy image to be available
         timeout-minutes: 30


### PR DESCRIPTION
Currently, the sed command which patches the Envoy image within the CIlium Agent File is no longer working. Therefore, the test doesn't get executed with the image of the current build.

This commit fixes the sed command and introduces a check - which fails if the Dockerfile doesn't get changed at all.