### PR TITLE
Fix policy update crash

### DIFF
--- a/cilium/grpc_subscription.cc
+++ b/cilium/grpc_subscription.cc
@@ -98,10 +98,11 @@ const Protobuf::MethodDescriptor& sotwGrpcMethod(absl::string_view type_url) {
 // Note: No rate-limit settings are used, consider if needed.
 envoy::config::core::v3::ConfigSource getCiliumXDSAPIConfig() {
   auto config_source = envoy::config::core::v3::ConfigSource();
-  /* config_source.initial_fetch_timeout left at default 15 seconds.
+  /* config_source.initial_fetch_timeout is set to 5 seconds.
    * This applies only to SDS Secrets for now, as for NPDS and NPHDS we explicitly set the timeout
    * as 0 (no timeout).
    */
+  config_source.mutable_initial_fetch_timeout()->set_seconds(5);
   config_source.set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
   auto api_config_source = config_source.mutable_api_config_source();
   api_config_source->set_set_node_on_first_message_only(true);

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -215,7 +215,6 @@ protected:
             if (header_value.result().has_value())
               logRejected(log_entry, header_value.result().value());
             // Set the expected value
-            ENVOY_LOG(debug, "secret replacing header {}={}", name_, *match_value);
             headers.setCopy(name_, *match_value);
             // Log the expected value as missing
             logMissing(log_entry, *match_value);

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -76,8 +76,14 @@ using PolicyInstanceConstSharedPtr = std::shared_ptr<const PolicyInstance>;
 
 class PolicyInstanceImpl;
 
-struct ThreadLocalPolicyMap : public ThreadLocal::ThreadLocalObject {
+class ThreadLocalPolicyMap : public ThreadLocal::ThreadLocalObject,
+                             public Logger::Loggable<Logger::Id::config> {
+public:
   std::map<std::string, std::shared_ptr<const PolicyInstanceImpl>> policies_;
+
+  void Update(std::vector<std::shared_ptr<PolicyInstanceImpl>>& added,
+              std::vector<std::string>& deleted,
+              const std::string& version_info);
 };
 
 class NetworkPolicyDecoder : public Envoy::Config::OpaqueResourceDecoder {

--- a/cilium/secret_watcher.cc
+++ b/cilium/secret_watcher.cc
@@ -27,6 +27,7 @@ secretProvider(Server::Configuration::TransportSocketFactoryContext& context,
 
 getSDSConfigFunc getSDSConfig = &getCiliumSDSConfig;
 void setSDSConfigFunc(getSDSConfigFunc func) { getSDSConfig = func; }
+void resetSDSConfigFunc() { getSDSConfig = &getCiliumSDSConfig; }
 
 SecretWatcher::SecretWatcher(const NetworkPolicyMap& parent, const std::string& sds_name)
     : parent_(parent), name_(sds_name),

--- a/cilium/secret_watcher.h
+++ b/cilium/secret_watcher.h
@@ -17,6 +17,7 @@ namespace Cilium {
 typedef envoy::config::core::v3::ConfigSource (*getSDSConfigFunc)(const std::string& name);
 extern getSDSConfigFunc getSDSConfig;
 void setSDSConfigFunc(getSDSConfigFunc);
+void resetSDSConfigFunc();
 
 class SecretWatcher : public Logger::Loggable<Logger::Id::config> {
 public:

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -20,6 +20,7 @@ Network::Address::InstanceConstSharedPtr original_dst_address;
 std::shared_ptr<const Cilium::NetworkPolicyMap> npmap{nullptr}; // Keep reference to singleton
 
 std::string policy_config = "version_info: \"0\"";
+std::string policy_path = "";
 
 std::vector<std::pair<std::string, std::string>> sds_configs{};
 
@@ -73,17 +74,17 @@ createPolicyMap(const std::string& config,
               });
         }
         // File subscription.
-        std::string path = TestEnvironment::writeStringToFileForTest("network_policy.yaml", config);
+        policy_path = TestEnvironment::writeStringToFileForTest("network_policy.yaml", config);
         ENVOY_LOG_MISC(debug,
                        "Loading Cilium Network Policy from file \'{}\' instead "
                        "of using gRPC",
-                       path);
-        Envoy::Config::Utility::checkFilesystemSubscriptionBackingPath(path, context.api());
+                       policy_path);
+        Envoy::Config::Utility::checkFilesystemSubscriptionBackingPath(policy_path, context.api());
         Envoy::Config::SubscriptionStats stats =
             Envoy::Config::Utility::generateStats(context.scope());
         auto map = std::make_shared<Cilium::NetworkPolicyMap>(context);
         auto subscription = std::make_unique<Envoy::Config::FilesystemSubscriptionImpl>(
-            context.mainThreadDispatcher(), Envoy::Config::makePathConfigSource(path), *map,
+            context.mainThreadDispatcher(), Envoy::Config::makePathConfigSource(policy_path), *map,
             std::make_shared<Cilium::NetworkPolicyDecoder>(), stats,
             ProtobufMessage::getNullValidationVisitor(), context.api());
         map->startSubscription(std::move(subscription));

--- a/tests/bpf_metadata.h
+++ b/tests/bpf_metadata.h
@@ -23,6 +23,7 @@ extern Network::Address::InstanceConstSharedPtr original_dst_address;
 extern std::shared_ptr<const Cilium::NetworkPolicyMap> npmap;
 
 extern std::string policy_config;
+extern std::string policy_path;
 extern std::vector<std::pair<std::string, std::string>> sds_configs;
 
 extern void initTestMaps(Server::Configuration::ListenerFactoryContext& context);


### PR DESCRIPTION
Recently introduced SDS support for secrets in Cilium network policies causes an Envoy crash no assert failure due to a resource being freed on a different thread than where it was allocated. Fix this by processing policy updates on the main thread after all the worker threads have been updated. This was the last reference to an old policy is freed on the main thread, where all the policy objects are allocated.

Also limit the SDS initial fetch timeout to 5 seconds from the default 15 seconds.