### PR TITLE
Dockerfile: Install ca-certificates package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,10 @@ COPY --from=builder /tmp/bazel-cache${COPY_CACHE_EXT}/ /tmp/bazel-cache/
 #
 FROM docker.io/library/ubuntu:22.04@sha256:dfd64a3b4296d8c9b62aa3309984f8620b98d87e47492599ee20739e8eb54fbf
 LABEL maintainer="maintainer@cilium.io"
+# install ca-certificates package
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install --no-install-recommends -y ca-certificates \
+    && apt-get autoremove -y && apt-get clean \
+    && rm -rf /tmp/* /var/tmp/* \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /tmp/install /


### PR DESCRIPTION
CA certificates may be needed for certificate validation. When they are installed, Envoy can be told to use the CA certs in the file system by creating a file-based Envoy secret:
```
  secrets:
  - name: validation_context
    validation_context:
      trusted_ca:
        filename: /etc/ssl/certs/ca-certificates.crt
```

This can then be referred to in TLS config:
```
  transport_socket:
    name: envoy.transport_sockets.tls
    typed_config:
      "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
      common_tls_context:
        validation_context_sds_secret_config:
          name: validation_context
```