### PR TITLE
renovate: Add config for v1.24

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,8 +20,7 @@
   "pruneStaleBranches": true,
   "baseBranches": [
     "main",
-    "v1.23",
-    "v1.22"
+    "v1.24",
   ],
   "labels": [
     "kind/enhancement",
@@ -78,8 +77,7 @@
       "allowedVersions": "20.04",
       "matchBaseBranches": [
         "main",
-        "v1.23",
-        "v1.22"
+        "v1.24",
       ]
     },
     {
@@ -93,23 +91,13 @@
       ]
     },
     {
-      "groupName": "envoy 1.23.x",
+      "groupName": "envoy 1.24.x",
       "matchDepNames": [
         "envoyproxy/envoy"
       ],
-      "allowedVersions": "<=1.23",
+      "allowedVersions": "<=1.24",
       "matchBaseBranches": [
-        "v1.23"
-      ]
-    },
-    {
-      "groupName": "envoy 1.22.x",
-      "matchDepNames": [
-        "envoyproxy/envoy"
-      ],
-      "allowedVersions": "<=1.22",
-      "matchBaseBranches": [
-        "v1.22"
+        "v1.24"
       ]
     }
   ],


### PR DESCRIPTION
The branch v1.24 was cut recently for all cilium releases v1.11, v1.12 and v1.13. This commit is to update renovate for the same, also to clean up old release branches (v1.23 and v1.22).

Relates: https://github.com/cilium/proxy/pull/242
Relates: https://github.com/cilium/cilium/pull/26329
Relates: https://github.com/cilium/cilium/pull/26328
Relates: https://github.com/cilium/cilium/pull/26309