### PR TITLE
cilium-integtest: adapt cilium installation to Cilium CLI helm mode

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -153,23 +153,28 @@ jobs:
             quay.io/cilium/cilium:${{ env.CILIUM_IMAGE_TAG }}
 
       - name: Install Cilium
+        timeout-minutes: 10
         shell: bash
         run: |
           cilium install \
             --chart-directory install/kubernetes/cilium \
-            --config monitor-aggregation=none \
+            --helm-set bpf.monitorAggregation=none \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \
-            --agent-image=quay.io/cilium/cilium:${{ env.CILIUM_IMAGE_TAG }} \
-            --operator-image=quay.io/cilium/operator-generic:${{ env.CILIUM_IMAGE_TAG }} \
+            --helm-set image.repository=quay.io/cilium/cilium \
+            --helm-set image.tag=${{ env.CILIUM_IMAGE_TAG }} \
+            --helm-set image.useDigest=false \
             --helm-set image.pullPolicy=Never \
+            --helm-set operator.image.repository=quay.io/cilium/operator \
+            --helm-set operator.image.suffix= \
+            --helm-set operator.image.tag=${{ env.CILIUM_IMAGE_TAG }} \
+            --helm-set operator.image.useDigest=false \
             --helm-set operator.image.pullPolicy=Never \
-            --config debug=true \
-            --config debug-verbose=envoy
+            --helm-set debug.enabled=true \
+            --helm-set debug.verbose=envoy
 
-          cilium hubble enable \
-            --chart-directory install/kubernetes/cilium
-
+          cilium hubble enable
+          cilium status --wait
           cilium hubble port-forward&
 
       - name: Execute Cilium L7 Connectivity Tests


### PR DESCRIPTION
With [Cilium CLI v0.15.0](https://github.com/cilium/cilium-cli/releases/tag/v0.15.0), helm has become the new default installation mode.

This commit adapts this changes in the Cilium integration tests by replacing the usages of removed flags (`--config`, `--agent-image` & `--operator-image`) with `--helm-set`.

Otherwise, tests are failing with `unknown flag: --config`