### PR TITLE
ci: set explicit permissions in github action workflows

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Prep for build
         run: |

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Checkout PR
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          persist-credentials: false
 
       - name: Prep for build
         run: |

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -3,6 +3,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# By specifying the access of one of the scopes, all of those that are not specified are set to 'none'.
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+
 jobs:
   proxylib:
     timeout-minutes: 360
@@ -59,6 +64,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Prep for build
         run: |

--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -13,6 +13,14 @@ on:
   issue_comment:
     types:
       - created
+
+# By specifying the access of one of the scopes, all of those that are not specified are set to 'none'.
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow writing PR comments and setting emojis
+  pull-requests: write
+
 env:
   KIND_VERSION: v0.18.0
   CILIUM_REPO_OWNER: cilium
@@ -98,6 +106,7 @@ jobs:
         with:
           repository: ${{ env.CILIUM_REPO_OWNER }}/cilium # Be aware that this is the Cilium repository and not the one of the proxy itself!
           ref: ${{ env.CILIUM_REPO_REF }}
+          persist-credentials: false
 
       - name: Extracting Cilium version
         run: |


### PR DESCRIPTION
If a GitHub Action workflow doesn't define explicit permissions, the token passed to the jobs can access all GitHub APIs.

Therefore, this commit introduces explicit permissions in all jobs.