### PR TITLE
build: Fix locally build docker images name on main branch

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -194,7 +194,7 @@ docker-tests-archive: Dockerfile.tests SOURCE_VERSION Dockerfile.tests.dockerign
 empty-docker-tests-archive: Dockerfile.tests Dockerfile.tests.dockerignore
 	$(DOCKER) build --target empty-builder-archive $(DOCKER_BUILD_OPTS) --build-arg BUILDER_BASE="$(TESTS_BUILDER_BASE)" -f $< -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-builder:$(TESTS_ARCHIVE_TAG) .
 
-ifeq ($(BRANCH_TAG),"main")
+ifeq ($(BRANCH_TAG),main)
   DOCKER_TESTS_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:latest$(IMAGE_ARCH)$(DEBUG_TAG)-testlogs
 else
   DOCKER_TESTS_TAGS ?= -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy-dev:$(BRANCH_TAG)$(IMAGE_ARCH)$(DEBUG_TAG)-testlogs
@@ -204,7 +204,7 @@ endif
 docker-tests: Dockerfile.tests SOURCE_VERSION Dockerfile.tests.dockerignore
 	$(DOCKER) build --progress=plain $(subst --push,--load,$(DOCKER_BUILD_OPTS)) $(DOCKER_CACHE_OPTS) $(TESTS_IMAGE_OPTS) --build-arg BAZEL_BUILD_OPTS="$(EXTRA_BAZEL_BUILD_OPTS)" --build-arg BAZEL_TEST_OPTS="$(BAZEL_TEST_OPTS)" -f $< $(DOCKER_TESTS_TAGS) .
 
-ifeq ($(BRANCH_TAG),"main")
+ifeq ($(BRANCH_TAG),main)
   DOCKER_IMAGE_ENVOY_TAGS := -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:$(SOURCE_VERSION)$(IMAGE_ARCH)$(DEBUG_TAG)
   DOCKER_IMAGE_ENVOY_TAGS += -t $(DOCKER_DEV_ACCOUNT)/cilium-envoy:latest$(IMAGE_ARCH)$(DEBUG_TAG)
 else


### PR DESCRIPTION
$(BRANCH_TAG) is not a string variable, it doesn't have double quotation marks (" ").

So main branch image name will be:
	EPOSITORY              TAG                                              IMAGE ID       CREATED         SIZE
	cilium-envoy-dev       8067d6fc81a0c311e7f7d231df94f8d1e21b13b8-amd64   305681f66b7b   6 minutes ago   134MB
	cilium-envoy-dev       main-amd64                                       305681f66b7b   6 minutes ago   134MB

But the design should be:
	REPOSITORY             TAG                                              IMAGE ID       CREATED         SIZE
	cilium-envoy           8067d6fc81a0c311e7f7d231df94f8d1e21b13b8-amd64   305681f66b7b   7 minutes ago   134MB
	cilium-envoy           latest-amd64                                     305681f66b7b   7 minutes ago   134MB