### PR TITLE
dockerignore: Add the missed file when make docker-builder-archive

### DIFF
--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -20,6 +20,7 @@
 /.dockerignore
 /.clwb
 /.vagrant
+/proxylib/libcilium.so*
 /proxylib/_obj*
 /.gitignore
 /Dockerfile*


### PR DESCRIPTION
When run `make docker-builder-archive` to update the pre-compiled Envoy dependencies, the dockerignore file is automatically updated with item '/proxylib/libcilium.so*'.

The commit 6c702baceef6 ("proxylib: Move proxylib from cilium to proxy repo") has added the '/proxylib/libcilium.so*' git ignore file name pattern.