### PR TITLE
build: Add libcap-dev also for tests and vagrant

### DIFF
--- a/Dockerfile.builder.tests
+++ b/Dockerfile.builder.tests
@@ -24,7 +24,9 @@ RUN apt-get update && \
       libc6-dev \
       # Envoy Build dependencies
       autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
-      python3 python-is-python3 unzip virtualenv wget zip && \
+      python3 python-is-python3 unzip virtualenv wget zip \
+      # Cilium-envoy build dependencies
+      libcap-dev && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
     echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \
     echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,8 @@ apt-get update && \
       gcc-x86-64-linux-gnu g++-x86-64-linux-gnu libc6-dev-amd64-cross binutils-x86-64-linux-gnu \
       libc6-dev \
       autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
-      python3 python-is-python3 unzip virtualenv wget zip && \
+      python3 python-is-python3 unzip virtualenv wget zip \
+      libcap-dev && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
     echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \
     echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \


### PR DESCRIPTION
Add libcap-dev also in Dockerfile.builder.tests and Vagrantfile.

libcap is needed for the <sys/capability.h> header, the library is not linked in,
as there are no cross-compiled packages for it.