### PR TITLE
docker: Detect default "desktop-linux" builder

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -37,7 +37,7 @@ else ifeq ($(ARCH),multi)
 endif
 DOCKER_BUILDER := $(shell docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1)
 ifdef DOCKER_PLATFORMS
-  ifeq ($(DOCKER_BUILDER),default)
+  ifneq (,$(filter $(DOCKER_BUILDER),default desktop-linux))
     DOCKER_BUILDKIT_DRIVER :=
     ifdef DOCKER_BUILDKIT_IMAGE
       DOCKER_BUILDKIT_DRIVER := --driver docker-container --driver-opt image=$(DOCKER_BUILDKIT_IMAGE)


### PR DESCRIPTION
New Docker desktop may have a default builder with name "desktop-linux" that is not buildx capable. Detect that name as well as the old "default" for the need to create a new buildx builder.

This is the same change we already did for `cilium/cilium` in https://github.com/cilium/cilium/pull/25908.