### PR TITLE
ipcache: Sync map value definition with cilium main

### DIFF
--- a/cilium/ipcache.cc
+++ b/cilium/ipcache.cc
@@ -40,6 +40,7 @@ PACKED_STRUCT(struct ipcache_key {
 struct remote_endpoint_info {
   __u32 sec_label;
   __u32 tunnel_endpoint;
+  __u16 pad;
   __u8 key;
 };
 


### PR DESCRIPTION
Sync ipcache map value definition with cilium main. Only the first member is used, so this should have no functional difference.