### PR TITLE
build: Use apt-add-repository

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -21,10 +21,9 @@ RUN apt-get update && \
       autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
 	python3 python-is-python3 unzip virtualenv wget zip \
       # Cilium-envoy build dependencies
-      libcap-dev && \
+      libcap-dev software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-    echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main" >> /etc/apt/sources.list && \
-    echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main" >> /etc/apt/sources.list && \
+    apt-add-repository -y "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       clang-15 clang-tools-15 lldb-15 lld-15 clang-format-15 libc++-15-dev libc++abi-15-dev && \

--- a/Dockerfile.builder.tests
+++ b/Dockerfile.builder.tests
@@ -26,10 +26,9 @@ RUN apt-get update && \
       autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
       python3 python-is-python3 unzip virtualenv wget zip \
       # Cilium-envoy build dependencies
-      libcap-dev && \
+      libcap-dev software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \
-    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \
+    apt-add-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       clang-15 clang-tools-15 lldb-15 lld-15 clang-format-15 libc++-15-dev libc++abi-15-dev && \

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,7 @@ define add_clang_apt_source
 	  $(SUDO) wget -q -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key; \
 	fi
 	apt_source="deb http://apt.llvm.org/$(1)/ llvm-toolchain-$(1)-15 main" && \
-	grep $${apt_source} /etc/apt/sources.list || echo $${apt_source} | $(SUDO) tee -a /etc/apt/sources.list
-	apt_source="deb-src http://apt.llvm.org/$(1)/ llvm-toolchain-$(1)-15 main" && \
-	grep $${apt_source} /etc/apt/sources.list || echo $${apt_source} | $(SUDO) tee -a /etc/apt/sources.list
+	$(SUDO) apt-add-repository -y "$${apt_source}" && \
 	$(SUDO) apt update
 endef
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,10 +30,9 @@ apt-get update && \
       libc6-dev \
       autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
       python3 python-is-python3 unzip virtualenv wget zip \
-      libcap-dev && \
+      libcap-dev software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \
-    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list && \
+    apt-add-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       clang-15 clang-tools-15 lldb-15 lld-15 clang-format-15 libc++-15-dev libc++abi-15-dev && \


### PR DESCRIPTION
Use apt-add-repository instead of directly editing apt sources files, as this is less error prone.

Without this I had the makefile adding multiple lines in a fresh VM where llvm install got into a
weird state. With this change the llvm source will appear at most once in the sources list.