### PR TITLE
Use `cilium-envoy-starter` to run Envoy without privileges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /bazel-*
 
 /cilium-envoy
+/cilium-envoy-starter
 /Dockerfile.istio_proxy
 /Dockerfile.builder-refresh
 

--- a/BUILD
+++ b/BUILD
@@ -14,6 +14,13 @@ exports_files([
     "linux/type_mapper.h",
 ])
 
+cc_binary(
+    name = "cilium-envoy-starter",
+    deps = [
+        "//starter:main_entry_lib",
+    ],
+)
+
 envoy_cc_binary(
     name = "cilium-envoy",
     repository = "@envoy",

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN --mount=mode=0777,uid=1337,gid=1337,target=/cilium/proxy/.cache,type=cache,i
 #
 # Build dependencies
 #
-RUN --mount=mode=0777,uid=1337,gid=1337,target=/cilium/proxy/.cache,type=cache,id=$TARGETARCH,sharing=private BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DEBUG=$DEBUG DESTDIR=/tmp/install make bazel-bin/cilium-envoy
+RUN --mount=mode=0777,uid=1337,gid=1337,target=/cilium/proxy/.cache,type=cache,id=$TARGETARCH,sharing=private BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DEBUG=$DEBUG DESTDIR=/tmp/install make bazel-bin/cilium-envoy-starter bazel-bin/cilium-envoy
 
 # By default this stage picks up the result of the build above, but ARCHIVE_IMAGE can be
 # overridden to point to a saved image of an earlier run of that stage.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -21,7 +21,7 @@ RUN apt-get update && \
       autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
 	python3 python-is-python3 unzip virtualenv wget zip \
       # Cilium-envoy build dependencies
-      libcap-dev software-properties-common && \
+      software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
     apt-add-repository -y "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main" && \
     apt-get update && \

--- a/Dockerfile.builder.tests
+++ b/Dockerfile.builder.tests
@@ -26,7 +26,7 @@ RUN apt-get update && \
       autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
       python3 python-is-python3 unzip virtualenv wget zip \
       # Cilium-envoy build dependencies
-      libcap-dev software-properties-common && \
+      software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
     apt-add-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" && \
     apt-get update && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ apt-get update && \
       libc6-dev \
       autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
       python3 python-is-python3 unzip virtualenv wget zip \
-      libcap-dev software-properties-common && \
+      software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
     apt-add-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" && \
     apt-get update && \

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,6 +38,7 @@ git_repository(
         "@//patches:0001-network-Add-callback-for-upstream-authorization.patch",
         "@//patches:0002-upstream-Add-callback-for-upstream-authorization.patch",
         "@//patches:0003-tcp_proxy-Add-filter-state-proxy_read_before_connect.patch",
+        "@//patches:0004-listener-add-socket-options.patch",
     ],
 )
 

--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -175,6 +175,7 @@ envoy_cc_library(
     ],
     repository = "@envoy",
     deps = [
+        "privileged_service_client_lib",
         "@envoy//source/common/common:logger_lib",
         "@envoy//source/common/common:utility_lib",
     ],
@@ -296,5 +297,17 @@ envoy_cc_library(
         "@envoy//source/common/common:logger_lib",
         "@envoy//source/common/network:address_lib",
         "@envoy//source/common/router:config_utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "privileged_service_client_lib",
+    hdrs = ["privileged_service_client.h"],
+    srcs = ["privileged_service_client.cc"],
+    repository = "@envoy",
+    deps = [
+        "//starter:privileged_service_protocol",
+        "@envoy//envoy/api:os_sys_calls_interface",
+        "@envoy//source/common/singleton:threadsafe_singleton",
     ],
 )

--- a/cilium/bpf.h
+++ b/cilium/bpf.h
@@ -47,39 +47,6 @@ public:
   bool open(const std::string& path);
 
   /**
-   * Create a new bpf map.
-   * @param max_entries the maximum capacity of the bpf map to be created. For
-   * many map types memory for this number of entries is allocated when the map
-   * is created.
-   * @param flags the required flags for the map type. Typically 0.
-   * @returns boolean for success of the operation.
-   */
-  bool create(uint32_t max_entries, uint32_t flags);
-
-  /**
-   * Pin the map to a file system path.
-   * @param path the file system path where to pin the bpf map.
-   * @returns boolean for success of the operation.
-   */
-  bool pin(const std::string& path);
-
-  /**
-   * Insert an entry with value and identified with the key to the map.
-   * @param key pointer to the key identifying the new entry to be inserted.
-   * @param value pointer to the value to be stored in the new entry to be
-   * inserted.
-   * @returns boolean for success of the operation.
-   */
-  bool insert(const void* key, const void* value);
-
-  /**
-   * Delete the entry identified with the key from the map, if it exists.
-   * @param key pointer to the key identifying the new entry to be inserted.
-   * @returns boolean for success of the operation.
-   */
-  bool remove(const void* key);
-
-  /**
    * Lookup an entry from the bpf map identified with the key, storing the found
    * value, if any.
    * @param key pointer to the key identifying the entry to be found.
@@ -87,9 +54,6 @@ public:
    * @returns boolean for success of the operation.
    */
   bool lookup(const void* key, void* value);
-
-private:
-  int bpfSyscall(int cmd, union bpf_attr* attr);
 
 protected:
   int fd_;

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -37,6 +37,14 @@ public:
         MessageUtil::downcastAndValidate<const ::cilium::BpfMetadata&>(
             proto_config, context.messageValidationVisitor()),
         context);
+    // Set the socket mark option for the listen socket.
+    // Can use identity 0 on the listen socket option, as the bpf datapath is only interested
+    // in whether the proxy is ingress, egress, or if there is no proxy at all.
+    std::shared_ptr<Envoy::Network::Socket::Options> options = std::make_shared<Envoy::Network::Socket::Options>();
+    uint32_t mark = (config->is_ingress_) ? 0x0A00 : 0x0B00;
+    options->push_back(std::make_shared<Cilium::SocketMarkOption>(mark, 0));
+    context.addListenSocketOptions(options);
+
     return [listener_filter_matcher,
             config](Network::ListenerFilterManager& filter_manager) mutable -> void {
       filter_manager.addAcceptFilter(listener_filter_matcher,
@@ -317,12 +325,6 @@ bool Config::getMetadata(Network::ConnectionSocket& socket) {
                destination_identity != Cilium::ID::WORLD && !npmap_->exists(other_ip))) {
     // Original source address is not used
     src_address = nullptr;
-  }
-
-  // Add transparent options if either original or explicitly set source address is used
-  if (src_address || ipv4_source_address || ipv6_source_address) {
-    socket.addOptions(Network::SocketOptionFactory::buildIpTransparentOptions());
-    socket.addOptions(Network::SocketOptionFactory::buildReusePortOptions());
   }
 
   // Add metadata for policy based listener filter chain matching.

--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -107,7 +107,7 @@ Network::FilterStatus Instance::onNewConnection() {
 
   // Pass metadata from tls_inspector to the filterstate, if any & not already
   // set via upstream cluster config, but not in a sidecar, which have no mark
-  if (sni != "" && option->mark_ != 0) {
+  if (sni != "" && !option->isSidecar()) {
     auto filterState = conn.streamInfo().filterState();
     auto have_sni =
         filterState->hasData<Network::UpstreamServerName>(Network::UpstreamServerName::key());

--- a/cilium/privileged_service_client.cc
+++ b/cilium/privileged_service_client.cc
@@ -1,0 +1,131 @@
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
+#include "cilium/privileged_service_client.h"
+
+namespace Envoy {
+namespace Cilium {
+namespace PrivilegedService {
+
+ProtocolClient::ProtocolClient() :
+  Protocol(CILIUM_PRIVILEGED_SERVICE_FD),
+  call_mutex_(PTHREAD_MUTEX_INITIALIZER),
+  seq_(0) {
+  RELEASE_ASSERT(get_capabilities(CAP_EFFECTIVE) == 0 && get_capabilities(CAP_PERMITTED) == 0,
+		 "cilium-envoy running with privileges, exiting");
+
+  if (!check_privileged_service()) {
+    // No Cilium privileged service detected
+    close();
+  }
+
+  // Validate that direct SO_MARK is now prohibited
+  int sockfd = ::socket(AF_INET, SOCK_STREAM, 0);
+  RELEASE_ASSERT(sockfd >= 0, "socket failed");
+
+  uint32_t mark = 12345;
+  int rc = ::setsockopt(sockfd, SOL_SOCKET, SO_MARK, &mark, sizeof(mark));
+  RELEASE_ASSERT(rc == -1, "setsockopt");
+  RELEASE_ASSERT(errno == EPERM, "setsockopt");
+
+  ::close(sockfd);
+}
+
+ssize_t ProtocolClient::transact(MessageHeader& req, size_t req_len, const void *data, size_t data_len, int *fd, Response& resp, void *buf, size_t bufsize, bool assert) {
+  uint32_t expected_response_type = resp.hdr_.msg_type_;
+
+  // Serialize calls to cilium privileged service
+  int rc = pthread_mutex_lock(&call_mutex_);
+  RELEASE_ASSERT(rc == 0, "pthread_mutex_lock");
+
+  req.msg_seq_ = ++seq_;
+  ssize_t size = send_fd_msg(&req, req_len, data, data_len, *fd);
+  if (!assert && size_t(size) != req_len + data_len) {
+    goto out;
+  }
+  RELEASE_ASSERT(size != 0, "Cilium privileged service closed pipe");
+  RELEASE_ASSERT(size > 0, "Cilium privileged service send failed");
+
+  size = recv_fd_msg(&resp, sizeof(resp), buf, bufsize, fd);
+  if (!assert && size_t(size) < sizeof(resp)) {
+    goto out;
+  }
+  RELEASE_ASSERT(size != 0, "Cilium privileged service closed pipe");
+  RELEASE_ASSERT(size < 0 || size_t(size) >= sizeof(resp), "Cilium privileged service truncated response");
+  RELEASE_ASSERT(resp.hdr_.msg_seq_ == req.msg_seq_, "Cilium privileged service response out of sequence");
+  RELEASE_ASSERT(resp.hdr_.msg_type_ == expected_response_type,
+		 "Cilium privileged service unexpected response type");
+
+ out:
+  rc = pthread_mutex_unlock(&call_mutex_);
+  RELEASE_ASSERT(rc == 0, "pthread_mutex_unlock");
+  return size;
+}
+
+bool ProtocolClient::check_privileged_service() {
+  // Dump the effective capabilities of the privileged service process
+  DumpRequest req;
+  Response resp;
+  uint8_t buf[1024];
+  int fd = -1;
+  ssize_t size = transact(req.hdr_, sizeof(req), nullptr, 0, &fd, resp, buf, sizeof(buf), false);
+  if (size < ssize_t(sizeof(resp))) {
+    return false;
+  }
+  std::string str(reinterpret_cast<char *>(buf), size - sizeof(resp));
+  ENVOY_LOG_MISC(debug, "Cilium privileged service detected with following capabilities: {}", str);
+  return true;
+}
+
+Envoy::Api::SysCallIntResult ProtocolClient::bpf_open(const char *path) {
+  if (!have_cilium_privileged_service()) {
+      return {-1, EPERM};
+  }
+
+  BpfOpenRequest req;
+  Response resp;
+  size_t path_len = strlen(path);
+  RELEASE_ASSERT(path_len <= PATH_MAX, "bpf open path too long");
+  int fd = -1;
+  ssize_t size = transact(req.hdr_, sizeof(req), path, path_len, &fd, resp);
+  RELEASE_ASSERT(size == ssize_t(sizeof(resp)), "invalid received response size");
+  if (resp.return_value_ == INT_MAX) {
+    resp.return_value_ = fd;
+  }
+  return Envoy::Api::SysCallIntResult{resp.return_value_, resp.errno_};
+}
+
+Envoy::Api::SysCallIntResult ProtocolClient::bpf_lookup(int fd, const void *key,
+							uint32_t key_size, void* value,
+							uint32_t value_size) {
+  if (!have_cilium_privileged_service()) {
+      return {-1, EPERM};
+  }
+
+  BpfLookupRequest req(value_size);
+  Response resp;
+  ssize_t size = transact(req.hdr_, sizeof(req), key, key_size, &fd, resp, value, value_size);
+  RELEASE_ASSERT((size == ssize_t(sizeof(resp)) && resp.return_value_ == -1)
+                 || size == ssize_t(sizeof(resp) + value_size),
+                 "invalid received bpf lookup value size");
+  return Envoy::Api::SysCallIntResult{resp.return_value_, resp.errno_};
+}
+
+Envoy::Api::SysCallIntResult ProtocolClient::setsockopt(int sockfd, int level, int optname,
+							const void *optval,
+							socklen_t optlen) {
+  if (!have_cilium_privileged_service()) {
+      return {-1, EPERM};
+  }
+
+  SetSockOptRequest req(level, optname, optval, optlen);
+  Response resp;
+  ssize_t size = transact(req.hdr_, sizeof(req), nullptr, 0, &sockfd, resp);
+  RELEASE_ASSERT(size == ssize_t(sizeof(resp)), "invalid received response size");
+  return Envoy::Api::SysCallIntResult{resp.return_value_, resp.errno_};
+}
+
+} // namespace PrivilegedService
+} // namespace Cilium
+} // namespace Envoy

--- a/cilium/privileged_service_client.h
+++ b/cilium/privileged_service_client.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
+#include "source/common/common/assert.h"
+#include "source/common/singleton/threadsafe_singleton.h"
+
+#include "starter/privileged_service_protocol.h"
+
+#include "envoy/api/os_sys_calls_common.h"
+
+namespace Envoy {
+namespace Cilium {
+
+class Bpf;
+class SocketMarkOption;
+
+namespace PrivilegedService {
+
+// ProtocolClient implements the client logic for communicating with the privileged service.
+class ProtocolClient : public Protocol {
+public:
+  ProtocolClient();
+
+  // allow access to the classes that need it
+  friend class Envoy::Cilium::Bpf;
+  friend class Envoy::Cilium::SocketMarkOption;
+
+protected:
+  // Read-only bpf syscalls
+  Envoy::Api::SysCallIntResult bpf_open(const char *path);
+  Envoy::Api::SysCallIntResult bpf_lookup(int fd, const void *key, uint32_t key_size, void* value,
+					  uint32_t value_size);
+
+  // Set a socket option
+  Envoy::Api::SysCallIntResult setsockopt(int sockfd, int level, int optname, const void *optval,
+					  socklen_t optlen);
+
+private:
+  bool check_privileged_service();
+  bool have_cilium_privileged_service() const { return is_open(); }
+
+  ssize_t transact(MessageHeader& req, size_t req_len, const void *data, size_t datalen, int *fd, Response& resp, void *buf = nullptr, size_t bufsize = 0, bool assert = true);
+
+  pthread_mutex_t call_mutex_;
+  uint32_t seq_;
+};
+
+using Singleton = Envoy::ThreadSafeSingleton<ProtocolClient>;
+
+} // namespace PrivilegedService
+} // namespace Cilium
+} // namespace Envoy

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -6,7 +6,8 @@
 #include "source/common/common/logger.h"
 #include "source/common/common/utility.h"
 
-#include "conntrack.h"
+#include "cilium/conntrack.h"
+#include "cilium/privileged_service_client.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -25,11 +26,11 @@ public:
 class SocketMarkOption : public Network::Socket::Option,
                          public Logger::Loggable<Logger::Id::filter> {
 public:
-  SocketMarkOption(uint32_t mark, uint32_t identity, bool ingress, bool l7lb,
-                   Network::Address::InstanceConstSharedPtr original_source_address,
-                   Network::Address::InstanceConstSharedPtr ipv4_source_address,
-                   Network::Address::InstanceConstSharedPtr ipv6_source_address)
-      : identity_(identity), mark_(mark), ingress_(ingress), is_l7lb_(l7lb),
+  SocketMarkOption(uint32_t mark, uint32_t identity,
+                   Network::Address::InstanceConstSharedPtr original_source_address = nullptr,
+                   Network::Address::InstanceConstSharedPtr ipv4_source_address = nullptr,
+                   Network::Address::InstanceConstSharedPtr ipv6_source_address = nullptr)
+      : identity_(identity), mark_(mark),
         original_source_address_(std::move(original_source_address)),
         ipv4_source_address_(std::move(ipv4_source_address)),
         ipv6_source_address_(std::move(ipv6_source_address)) {}
@@ -52,7 +53,8 @@ public:
                 socket.ioHandle().fdDoNotUse());
       return true;
     }
-    auto status = socket.setSocketOption(SOL_SOCKET, SO_MARK, &mark_, sizeof(mark_));
+    auto& cilium_calls = PrivilegedService::Singleton::get();
+    auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_SOCKET, SO_MARK, &mark_, sizeof(mark_));
     if (status.return_value_ < 0) {
       if (status.errno_ == EPERM) {
         // Do not assert out in this case so that we can run tests without
@@ -68,29 +70,72 @@ public:
       }
     }
 
+    auto ipVersion = socket.ipVersion();
+    if (!ipVersion.has_value()) {
+      ENVOY_LOG(critical,
+                "Socket address family is not available, can not choose source address");
+      return false;
+    }
     Network::Address::InstanceConstSharedPtr source_address = original_source_address_;
     if (!source_address && (ipv4_source_address_ || ipv6_source_address_)) {
       // Select source address based on the socket address family
-      auto ipVersion = socket.ipVersion();
-      if (!ipVersion.has_value()) {
-        ENVOY_LOG(critical,
-                  "Socket address family is not available, can not choose source address");
-        return false;
-      }
       source_address = ipv6_source_address_;
       if (*ipVersion == Network::Address::IpVersion::v4) {
         source_address = ipv4_source_address_;
       }
     }
-    if (source_address) {
+    // identity is zero for the listener socket itself, set transparent and reuse options also for
+    // the listener socket.
+    if (source_address || identity_ == 0) {
       // Allow reuse of the original source address. This may by needed for
       // retries to not fail on "address already in use" when using a specific
       // source address and port.
-
       uint32_t one = 1;
+
+      // Set ip transparent option based on the socket address family
+      if (*ipVersion == Network::Address::IpVersion::v4) {
+	auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_IP, IP_TRANSPARENT, &one, sizeof(one));
+	if (status.return_value_ < 0) {
+	  if (status.errno_ == EPERM) {
+	    // Do not assert out in this case so that we can run tests without
+	    // CAP_NET_ADMIN.
+	    ENVOY_LOG(critical,
+		      "Failed to set socket option IP_TRANSPARENT, capability "
+		      "CAP_NET_ADMIN needed: {}",
+		      Envoy::errorDetails(status.errno_));
+	  } else {
+	    ENVOY_LOG(critical, "Socket option failure. Failed to set IP_TRANSPARENT: {}",
+		      Envoy::errorDetails(status.errno_));
+	    return false;
+	  }
+	}
+      } else if (*ipVersion == Network::Address::IpVersion::v6) {
+	auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_IPV6, IPV6_TRANSPARENT, &one, sizeof(one));
+	if (status.return_value_ < 0) {
+	  if (status.errno_ == EPERM) {
+	    // Do not assert out in this case so that we can run tests without
+	    // CAP_NET_ADMIN.
+	    ENVOY_LOG(critical,
+		      "Failed to set socket option IPV6_TRANSPARENT, capability "
+		      "CAP_NET_ADMIN needed: {}",
+		      Envoy::errorDetails(status.errno_));
+	  } else {
+	    ENVOY_LOG(critical, "Socket option failure. Failed to set IPV6_TRANSPARENT: {}",
+		      Envoy::errorDetails(status.errno_));
+	    return false;
+	  }
+	}	
+      }
+
       auto status = socket.setSocketOption(SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
       if (status.return_value_ < 0) {
         ENVOY_LOG(critical, "Failed to set socket option SO_REUSEADDR: {}",
+                  Envoy::errorDetails(status.errno_));
+        return false;
+      }
+      status = socket.setSocketOption(SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
+      if (status.return_value_ < 0) {
+        ENVOY_LOG(critical, "Failed to set socket option SO_REUSEPORT: {}",
                   Envoy::errorDetails(status.errno_));
         return false;
       }
@@ -142,14 +187,10 @@ public:
 
   bool isSupported() const override { return true; }
 
-  // policyUseUpstreamDestinationAddress returns 'true' if policy enforcement should be done on the
-  // basis of the upstream destination address.
-  bool policyUseUpstreamDestinationAddress() const { return is_l7lb_; }
+  bool isSidecar() const { return mark_ == 0; }
 
   uint32_t identity_;
   uint32_t mark_;
-  bool ingress_;
-  bool is_l7lb_;
   Network::Address::InstanceConstSharedPtr original_source_address_;
   // Version specific source addresses are only used if original source address is not used.
   // Selection is made based on the socket domain, which is selected based on the destination
@@ -167,10 +208,10 @@ public:
                Network::Address::InstanceConstSharedPtr ipv4_source_address,
                Network::Address::InstanceConstSharedPtr ipv6_source_address,
                const std::shared_ptr<PolicyResolver>& policy_id_resolver)
-      : SocketMarkOption(mark, source_identity, ingress, l7lb, original_source_address,
+      : SocketMarkOption(mark, source_identity, original_source_address,
                          ipv4_source_address, ipv6_source_address),
-        initial_policy_(policy), port_(port), pod_ip_(std::move(pod_ip)),
-        policy_id_resolver_(policy_id_resolver) {
+        initial_policy_(policy), ingress_(ingress), is_l7lb_(l7lb), port_(port),
+	pod_ip_(std::move(pod_ip)), policy_id_resolver_(policy_id_resolver) {
     ENVOY_LOG(debug,
               "Cilium SocketOption(): source_identity: {}, "
               "ingress: {}, port: {}, pod_ip: {}, source_addresses: {}/{}/{}, mark: {:x} (magic "
@@ -191,7 +232,13 @@ public:
     return policy_id_resolver_->getPolicy(pod_ip_);
   }
 
+  // policyUseUpstreamDestinationAddress returns 'true' if policy enforcement should be done on the
+  // basis of the upstream destination address.
+  bool policyUseUpstreamDestinationAddress() const { return is_l7lb_; }
+
   const PolicyInstanceConstSharedPtr initial_policy_; // Never NULL
+  bool ingress_;
+  bool is_l7lb_;
   uint16_t port_;
   std::string pod_ip_;
 

--- a/patches/0004-listener-add-socket-options.patch
+++ b/patches/0004-listener-add-socket-options.patch
@@ -1,0 +1,91 @@
+From 6a019393de48e83654a850dfb2de4f68f12a2fc8 Mon Sep 17 00:00:00 2001
+From: Jarno Rajahalme <jarno@isovalent.com>
+Date: Mon, 14 Aug 2023 10:01:21 +0300
+Subject: [PATCH 4/4] Revert "listener: keep ListenerFactoryContext small
+ (#7528)"
+
+This reverts commit 170c89eb0b2afb7a39d44d0f8dfb77444ffc038f.
+
+diff --git a/envoy/server/factory_context.h b/envoy/server/factory_context.h
+index 6384230c57..ec9c6aec4f 100644
+--- a/envoy/server/factory_context.h
++++ b/envoy/server/factory_context.h
+@@ -309,6 +309,11 @@ public:
+  */
+ class ListenerFactoryContext : public virtual FactoryContext {
+ public:
++  /**
++   * Store socket options to be set on the listen socket before listening.
++   */
++  virtual void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) PURE;
++
+   /**
+    * Give access to the listener configuration
+    */
+diff --git a/source/extensions/listener_managers/listener_manager/listener_impl.cc b/source/extensions/listener_managers/listener_manager/listener_impl.cc
+index 51b42225f5..420699c42a 100644
+--- a/source/extensions/listener_managers/listener_manager/listener_impl.cc
++++ b/source/extensions/listener_managers/listener_manager/listener_impl.cc
+@@ -912,6 +912,9 @@ envoy::config::core::v3::TrafficDirection PerListenerFactoryContextImpl::directi
+   return listener_factory_context_base_->direction();
+ };
+ TimeSource& PerListenerFactoryContextImpl::timeSource() { return api().timeSource(); }
++void PerListenerFactoryContextImpl::addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) {
++  listener_impl_.addListenSocketOptions(options);
++}
+ const Network::ListenerConfig& PerListenerFactoryContextImpl::listenerConfig() const {
+   return *listener_config_;
+ }
+diff --git a/source/extensions/listener_managers/listener_manager/listener_impl.h b/source/extensions/listener_managers/listener_manager/listener_impl.h
+index e19db92d4c..b26af02403 100644
+--- a/source/extensions/listener_managers/listener_manager/listener_impl.h
++++ b/source/extensions/listener_managers/listener_manager/listener_impl.h
+@@ -241,6 +241,7 @@ public:
+   bool isQuicListener() const override;
+ 
+   // ListenerFactoryContext
++  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) override;
+   const Network::ListenerConfig& listenerConfig() const override;
+ 
+   ListenerFactoryContextBaseImpl& parentFactoryContext() { return *listener_factory_context_base_; }
+@@ -386,6 +387,13 @@ public:
+     return config().traffic_direction();
+   }
+ 
++  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& append_options) {
++    for (std::vector<Network::Address::InstanceConstSharedPtr>::size_type i = 0;
++         i < addresses_.size(); i++) {
++      addListenSocketOptions(listen_socket_options_list_[i], append_options);
++    }
++  }
++
+   void ensureSocketOptions(Network::Socket::OptionsSharedPtr& options) {
+     if (options == nullptr) {
+       options = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
+diff --git a/test/mocks/server/factory_context.h b/test/mocks/server/factory_context.h
+index e1327228eb..db110d263e 100644
+--- a/test/mocks/server/factory_context.h
++++ b/test/mocks/server/factory_context.h
+@@ -46,6 +46,7 @@ public:
+   MOCK_METHOD(envoy::config::core::v3::TrafficDirection, direction, (), (const));
+   MOCK_METHOD(TimeSource&, timeSource, ());
+ 
++  MOCK_METHOD(void, addListenSocketOptions, (const Network::Socket::OptionsSharedPtr&));
+   MOCK_METHOD(const Network::ListenerConfig&, listenerConfig, (), (const));
+ 
+   Event::TestTimeSystem& timeSystem() { return time_system_; }
+diff --git a/test/mocks/server/listener_factory_context.h b/test/mocks/server/listener_factory_context.h
+index 5341b517d1..924b8cb0b1 100644
+--- a/test/mocks/server/listener_factory_context.h
++++ b/test/mocks/server/listener_factory_context.h
+@@ -20,6 +20,7 @@ public:
+   MockListenerFactoryContext();
+   ~MockListenerFactoryContext() override;
+ 
++  MOCK_METHOD(void, addListenSocketOptions, (const Network::Socket::OptionsSharedPtr&));
+   const Network::ListenerConfig& listenerConfig() const override { return listener_config_; }
+   MOCK_METHOD(const Network::ListenerConfig&, listenerConfig_, (), (const));
+   MOCK_METHOD(ServerFactoryContext&, getServerFactoryContext, (), (const));
+-- 
+2.41.0
+

--- a/starter/BUILD
+++ b/starter/BUILD
@@ -1,0 +1,26 @@
+licenses(["notice"])  # Apache 2
+
+cc_library(
+    name = "main_entry_lib",
+    srcs = ["main.cc"],
+    deps = [
+        "privileged_service_server_lib",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "privileged_service_protocol",
+    srcs = ["privileged_service_protocol.cc"],
+    hdrs = ["privileged_service_protocol.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "privileged_service_server_lib",
+    hdrs = ["privileged_service_server.h"],
+    srcs = ["privileged_service_server.cc"],
+    deps = [
+        "privileged_service_protocol",
+    ],
+)

--- a/starter/main.cc
+++ b/starter/main.cc
@@ -1,0 +1,108 @@
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
+#include <errno.h>
+#include <syscall.h>
+#include <unistd.h>
+
+#include <sys/prctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "starter/privileged_service_server.h"
+
+// NOLINT(namespace-envoy)
+
+#define STARTER_SUFFIX "-starter"
+#define STARTER_SUFFIX_LEN (sizeof(STARTER_SUFFIX) - 1)
+
+int main(int /* argc */, char** argv) {
+  // Check that we have the required capabilities
+  uint64_t caps = Envoy::Cilium::PrivilegedService::get_capabilities(CAP_EFFECTIVE);
+  if ((caps & (1UL << CAP_NET_ADMIN)) == 0 ||
+      (caps & (1UL << CAP_SYS_ADMIN | 1UL << CAP_BPF)) == 0) {
+    fprintf(stderr, "CAP_NET_ADMIN and either CAP_SYS_ADMIN or CAP_BPF capabilities are needed for Cilium datapath integration.\n");
+    exit(1);
+  }
+
+  // Get the path we're running from
+  char *path = new char[PATH_MAX];
+  constexpr size_t path_size = PATH_MAX;
+  int path_len = readlink("/proc/self/exe", path, path_size);
+  if (path_len < 0 || path_len >= int(path_size)) {
+    fprintf(stderr, "could not get path of the current executable: %s\n", strerror(errno));
+    exit(1);
+  }
+
+  // Remove the trailing "-starter" suffix.
+  // Check first that the executable name ends in the suffix
+  // and is not just the suffix.
+  if (size_t(path_len) > STARTER_SUFFIX_LEN && // more than suffix in path
+      strncmp(path + path_len - STARTER_SUFFIX_LEN, STARTER_SUFFIX, STARTER_SUFFIX_LEN) == 0 &&
+      path[path_len - STARTER_SUFFIX_LEN - 1] != '/' // slash not the last before suffix
+      ) {
+    path_len -= STARTER_SUFFIX_LEN;
+    path[path_len] = '\0';
+  } else {
+    fprintf(stderr, "Executable name must end in \"" STARTER_SUFFIX "\" and not be empty without it: \"%s\"\n", path);
+    exit(1);
+  }
+
+  int fds[2];
+  int rc = socketpair(AF_LOCAL, SOCK_SEQPACKET, 0, fds);
+  RELEASE_ASSERT(rc == 0, "socketpair failed");
+
+  int pid = fork();
+  RELEASE_ASSERT(pid != -1, "fork failed");
+
+  if (pid == 0) {
+    // in child process, close the parent end of the pipe
+    close(fds[0]);
+
+    // Unconditionally drop all capabilities
+    struct __user_cap_header_struct hdr{_LINUX_CAPABILITY_VERSION_3, 0};
+    struct __user_cap_data_struct data[2];
+    memset(&data, 0, sizeof(data));
+    if (::syscall(SYS_capset, &hdr, &data, sizeof(data)) != 0) {
+      perror("capset");
+      exit(1);
+    }
+
+    // Drop bounding set to prevent regaining dropped capabilities
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+      perror("prctl(PR_SET_NO_NEW_PRIVS)");
+      exit(1);
+    }
+
+    RELEASE_ASSERT(Envoy::Cilium::PrivilegedService::get_capabilities(CAP_EFFECTIVE) == 0 &&
+		   Envoy::Cilium::PrivilegedService::get_capabilities(CAP_PERMITTED) == 0 &&
+		   Envoy::Cilium::PrivilegedService::get_capabilities(CAP_INHERITABLE) == 0,
+		   "Failed dropping privileges");
+
+    // Dup the client end to CILIUM_PRIVILEGED_SERVICE_FD
+    if (fds[1] != CILIUM_PRIVILEGED_SERVICE_FD) {
+      if (dup2(fds[1], CILIUM_PRIVILEGED_SERVICE_FD) < 0) {
+	perror("dup2");
+	exit(1);
+      }
+      close(fds[1]);
+    }
+    
+    // Exec cilium-envoy process
+    execv(path, argv);
+    perror("execv");
+    exit(1);
+  }
+  delete[] path;
+
+  // in parent, close the child end of the pipe
+  close(fds[1]);
+
+  // Make sure the child process started
+  RELEASE_ASSERT(::waitpid(pid, nullptr, WNOHANG) == 0, "Child process did not start!");
+
+  Envoy::Cilium::PrivilegedService::ProtocolServer server(pid, fds[0]);
+  server.serve();
+  return 0;
+}

--- a/starter/privileged_service_protocol.cc
+++ b/starter/privileged_service_protocol.cc
@@ -1,0 +1,228 @@
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
+#include <errno.h>
+
+#include <sys/unistd.h>
+#include <sys/syscall.h>
+
+#include "starter/privileged_service_protocol.h"
+
+namespace Envoy {
+namespace Cilium {
+namespace PrivilegedService {
+
+// Capabiilty names used in DumpCapabilites responses.
+static const char* cap_names[64] = {
+  "CAP_CHOWN",              //  0
+  "CAP_DAC_OVERRIDE",       //  1
+  "CAP_DAC_READ_SEARCH",    //  2
+  "CAP_FOWNER",             //  3
+  "CAP_FSETID",             //  4 
+  "CAP_KILL",               //  5
+  "CAP_SETGID",             //  6
+  "CAP_SETUID",             //  7 
+  "CAP_SETPCAP",            //  8 
+  "CAP_LINUX_IMMUTABLE",    //  9
+  "CAP_NET_BIND_SERVICE",   // 10
+  "CAP_NET_BROADCAST",      // 11
+  "CAP_NET_ADMIN",          // 12
+  "CAP_NET_RAW",            // 13
+  "CAP_IPC_LOCK",           // 14
+  "CAP_IPC_OWNER",          // 15
+  "CAP_SYS_MODULE",         // 16
+  "CAP_SYS_RAWIO",          // 17
+  "CAP_SYS_CHROOT",         // 18
+  "CAP_SYS_PTRACE",         // 19
+  "CAP_SYS_PACCT",          // 20
+  "CAP_SYS_ADMIN",          // 21
+  "CAP_SYS_BOOT",           // 22
+  "CAP_SYS_NICE",           // 23
+  "CAP_SYS_RESOURCE",       // 24
+  "CAP_SYS_TIME",           // 25
+  "CAP_SYS_TTY_CONFIG",     // 26
+  "CAP_MKNOD",              // 27
+  "CAP_LEASE",              // 28
+  "CAP_AUDIT_WRITE",        // 29
+  "CAP_AUDIT_CONTROL",      // 30
+  "CAP_SETFCAP",            // 31
+  "CAP_MAC_OVERRIDE",       // 32
+  "CAP_MAC_ADMIN",          // 33
+  "CAP_SYSLOG",             // 34
+  "CAP_WAKE_ALARM",         // 35
+  "CAP_BLOCK_SUSPEND",      // 36
+  "CAP_AUDIT_READ",         // 37
+  "CAP_PERFMON",            // 38 
+  "CAP_BPF",                // 39
+  "CAP_CHECKPOINT_RESTORE", // 40
+  "CAP_41",
+  "CAP_42",
+  "CAP_43",
+  "CAP_44",
+  "CAP_45",
+  "CAP_46",
+  "CAP_47",
+  "CAP_48",
+  "CAP_49",
+  "CAP_50",
+  "CAP_51",
+  "CAP_52",
+  "CAP_53",
+  "CAP_54",
+  "CAP_55",
+  "CAP_56",
+  "CAP_57",
+  "CAP_58",
+  "CAP_59",
+  "CAP_60",
+  "CAP_61",
+  "CAP_62",
+  "CAP_63",
+};
+
+// Get a 64-bit set of capabilities of the given kind
+uint64_t get_capabilities(cap_flag_t kind) {
+  struct __user_cap_header_struct hdr{_LINUX_CAPABILITY_VERSION_3, 0};
+  struct __user_cap_data_struct data[2];
+  memset(&data, 0, sizeof(data));
+  int rc = ::syscall(SYS_capget, &hdr, &data, sizeof(data));
+  if (rc != 0) {
+    perror("capget");
+    exit(1);
+  }
+
+  if (kind == CAP_INHERITABLE) {
+    return data[0].inheritable | uint64_t(data[1].inheritable) << 32;
+  }
+  if (kind == CAP_PERMITTED) {
+    return data[0].permitted | uint64_t(data[1].permitted) << 32;
+  }
+  if (kind == CAP_EFFECTIVE) {
+    return data[0].effective | uint64_t(data[1].effective) << 32;
+  }
+  fprintf(stderr, "get_capabilities: invalid kind: %d\n", kind);
+  ::abort();
+  return 0;
+}
+
+// dumpCaps returns the capabilities of the given kind in string form.
+size_t dump_capabilities(cap_flag_t kind, char *buf, size_t buf_size) {
+  size_t remaining = buf_size;
+  uint64_t caps = get_capabilities(kind);
+
+  auto append = [&](const char *str) {
+    auto len = strlen(str);
+    if (len < remaining) {
+      memcpy(buf, str, len);
+      remaining -= len;
+      buf += len;
+    }
+  };
+  
+  for (int i=0, n=0; i < 64; i++) {
+    if (caps & (1UL << i)) {
+      if (n > 0)
+        append(", ");
+      append(cap_names[i]);
+      n++;
+    }
+  }
+
+  return buf_size - remaining;
+}
+
+Protocol::~Protocol() {
+  close();
+}
+
+Protocol::Protocol(int fd) : fd_(fd) {}
+
+void Protocol::close() {
+  if (fd_ != -1) {
+    ::close(fd_);
+  }
+  fd_ = -1;
+}
+
+namespace {
+
+static inline struct msghdr
+init_iov(struct iovec iov[2], const void *header, ssize_t headerlen, const void *data, ssize_t datalen) {
+  struct msghdr msg{};
+  msg.msg_iov = iov;
+  msg.msg_iovlen = 1;
+  iov[0].iov_base = const_cast<void *>(header);
+  iov[0].iov_len = headerlen;
+  if (data && datalen > 0) {
+    msg.msg_iovlen = 2;
+    iov[1].iov_base = const_cast<void *>(data);
+    iov[1].iov_len = datalen;
+  }
+  return msg;
+}
+
+} // namespace
+
+ssize_t Protocol::send_fd_msg(const void *header, ssize_t headerlen, const void *data, ssize_t datalen, int fd) {
+  struct iovec  iov[2];
+  struct msghdr msg = init_iov(iov, header, headerlen, data, datalen);
+  union {
+    struct cmsghdr  cmsghdr;
+    char            control[CMSG_SPACE(sizeof (int))];
+  } cmsgu;
+  struct cmsghdr *cmsg;
+
+  // set up msg control for an fd?
+  if (fd != -1) {
+    msg.msg_control = cmsgu.control;
+    msg.msg_controllen = sizeof(cmsgu.control);
+    cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_len = CMSG_LEN(sizeof (int));
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    *reinterpret_cast<int *>(CMSG_DATA(cmsg)) = fd;
+  }
+  
+  // send the request
+  ssize_t size;
+  do {
+    size = sendmsg(fd_, &msg, 0);
+  } while (size < 0 && errno == EINTR);
+
+  if (size >= 0 && size != headerlen+datalen) {
+    fprintf(stderr, "sendmsg truncated (%zd < %zd)\n", size, headerlen+datalen);
+  }
+  return size;
+}
+
+ssize_t Protocol::recv_fd_msg(const void *header, ssize_t headersize, const void *data, ssize_t datasize, int *fd) {
+  struct iovec  iov[2];
+  struct msghdr msg = init_iov(iov, header, headersize, data, datasize);
+  union {
+    struct cmsghdr cmsghdr;
+    char           control[CMSG_SPACE(sizeof (int))];
+  } cmsgu;
+  msg.msg_control = cmsgu.control;
+  msg.msg_controllen = sizeof(cmsgu.control);
+
+  ssize_t size;
+  do {
+    size = recvmsg(fd_, &msg, 0);
+  } while (size < 0 && errno == EINTR);
+
+  if (size >= 0 && fd) {
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    if (cmsg && cmsg->cmsg_len == CMSG_LEN(sizeof(int)) &&
+        cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+      *fd = *reinterpret_cast<int *>(CMSG_DATA(cmsg));
+    } else {
+      *fd = -1;
+    }
+  }
+  return size;
+}
+
+} // namespace PrivilegedService
+} // namespace Cilium
+} // namespace Envoy

--- a/starter/privileged_service_protocol.h
+++ b/starter/privileged_service_protocol.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <linux/capability.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+// Use Envoy version of this if defined, otherwise roll a simple stderr one without further
+// dependencies
+#ifndef RELEASE_ASSERT
+#define _ASSERT_IMPL(CONDITION, CONDITION_STR, DETAILS)			\
+  do {									\
+    if (!(CONDITION)) {							\
+      fprintf(stderr, "assert failure: %s. Details: %s", CONDITION_STR, (DETAILS)); \
+      ::abort();							\
+    }									\
+  } while (false)
+#define RELEASE_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, DETAILS)
+#endif
+
+// Kernel headers may miss CAP_BPF added in Linux 5.8
+#ifndef CAP_BPF
+#define CAP_BPF                 39
+#endif
+
+#ifndef _SYS_CAPABILITY_H
+// These are normally defined in <sys/capability.h> added in libcap-dev package.  Define these here
+// to avoid that dependency due to complications in cross-compilation for Intel/Arm.
+typedef enum {
+    CAP_EFFECTIVE = 0,                 /* Specifies the effective flag */
+    CAP_PERMITTED = 1,                 /* Specifies the permitted flag */
+    CAP_INHERITABLE = 2                /* Specifies the inheritable flag */
+} cap_flag_t;
+#endif
+
+namespace Envoy {
+namespace Cilium {
+namespace PrivilegedService {
+
+uint64_t get_capabilities(cap_flag_t kind);
+size_t dump_capabilities(cap_flag_t kind, char *buf, size_t buf_size);
+
+#define CILIUM_PRIVILEGED_SERVICE_FD 3
+
+// Communication with the privileged service is performed with a simple message protocol over a Unix
+// domain socket pair using the SOCK_SEQPACKET type, preserving record boundaries without explicitly
+// encoding a length field.
+// Each message starts with a 4-byte type and a 4-byte sequence number, both in the host byte order,
+// which are followed by message type specific variable length data.
+
+// Supported message types
+typedef enum {
+  TYPE_RESPONSE = 1,
+  TYPE_DUMP_REQUEST = 2,
+  TYPE_BPF_OPEN_REQUEST = 3,
+  TYPE_BPF_LOOKUP_REQUEST = 4,
+  TYPE_SETSOCKOPT32_REQUEST = 5,
+} MessageType;
+
+// Common message header
+// Note that C++ inheritance can not be used as all the data members need to be on the same struct
+// definition. This means that we must contain the MessageHeader as the first member of each message
+// definition.
+struct MessageHeader {
+  uint32_t msg_type_ = 0;
+  uint32_t msg_seq_ = 0; // reflected in response
+
+  MessageHeader() {}
+  MessageHeader(MessageType t) : msg_type_(t) {}
+};
+
+// Response passes the return value and errno code from the system call, followed by optional
+// data depending on the request type. Note that file descriptor return value is passed using the
+// message control channel (ref. man 2 recvmsg).
+struct Response {
+  Response() : hdr_(TYPE_RESPONSE) {}
+
+  struct MessageHeader hdr_;
+  int return_value_;
+  int errno_;
+  uint8_t data_[];
+};
+
+
+// Dump requests consists only of the message header, but with the TYPE_DUMP_REQUEST.
+// Response contains the effective capabilitites in a string form.
+struct DumpRequest {
+  DumpRequest() : hdr_(TYPE_DUMP_REQUEST) {}
+
+  struct MessageHeader hdr_;
+};
+
+// BpfOpenRequest has a variable length path after the message header.
+// Path need not be 0-terminated.
+// Response must be a SyscallResponse. The file descriptor is returned in the message control
+// channel (see man 2 recvmsg).
+struct BpfOpenRequest {
+  BpfOpenRequest() : hdr_(TYPE_BPF_OPEN_REQUEST) {}
+
+  struct MessageHeader hdr_;
+  char path_[];
+};
+
+// BpfLookupRequest passes the expected value size and a variable length key.
+// Key size is not explicitly passed, as it is deduced from the message length.
+// In a successful case the response contains the value returned by the bpf map lookup.
+struct BpfLookupRequest {
+  BpfLookupRequest(uint32_t value_size) : hdr_(TYPE_BPF_LOOKUP_REQUEST), value_size_(value_size) {}
+
+  struct MessageHeader hdr_;
+  uint32_t value_size_;
+  uint8_t key_[];
+};
+
+// SetSockOptRequest only supports setting 4-byte options.
+// Response is SyscallResponse.
+struct SetSockOptRequest {
+  SetSockOptRequest(int level, int optname, const void *optval, socklen_t optlen)
+    : hdr_(TYPE_SETSOCKOPT32_REQUEST), level_(level), optname_(optname) {
+    RELEASE_ASSERT(optlen == sizeof(uint32_t), "optlen must be 4 bytes");
+    memcpy(&optval_, optval, optlen);
+  }
+
+  struct MessageHeader hdr_;
+  int level_;
+  int optname_;
+  uint32_t optval_;
+};
+
+// Protocol implements the logic for communicating with the privileged service.
+class Protocol {
+public:
+  Protocol(int fd);
+  ~Protocol();
+
+  void close();
+  bool is_open() const { return fd_ != -1; }
+
+  ssize_t send_fd_msg(const void *header, ssize_t headerlen,
+		      const void *data = nullptr, ssize_t datalen = 0, int fd = -1);
+  ssize_t recv_fd_msg(const void *header, ssize_t headersize,
+		      const void *data = nullptr, ssize_t datasize = 0, int *fd = nullptr);
+
+protected:
+  int fd_;
+};
+
+} // namespace PrivilegedService
+} // namespace Cilium
+} // namespace Envoy

--- a/starter/privileged_service_server.cc
+++ b/starter/privileged_service_server.cc
@@ -1,0 +1,154 @@
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
+#include <algorithm>
+
+#include <errno.h>
+#include <syscall.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <linux/bpf.h>
+
+#include "starter/privileged_service_server.h"
+
+namespace Envoy {
+namespace Cilium {
+namespace PrivilegedService {
+
+ProtocolServer::~ProtocolServer() {
+  // Wait for cilium-envoy to terminate
+  if (pid_ != 0) {
+    int rc;
+    do {
+      rc = ::waitpid(pid_, nullptr, 0);
+    } while (rc == -1 && errno == EINTR);
+  }
+}
+  
+ProtocolServer::ProtocolServer(int pid, int pipe) :
+  Protocol(pipe), pid_(pid) {
+}
+
+void ProtocolServer::serve() {
+  Buffer msg = {};
+
+  while (true) {
+    // wait for message
+    int fd_in;
+    // Leave one byte to the end of the buffer so that we can always zero-terminate string data.
+    ssize_t size = recv_fd_msg(&msg, sizeof(msg) - 1, nullptr, 0, &fd_in);
+    if (size < 0) {
+      perror("recvmsg");
+      if (errno == EPIPE || errno == EPERM) {
+        break;
+      }
+      continue;
+    }
+    if (size == 0) {
+      // pipe shut down, exiting
+      break;
+    }
+    if (size_t(size) < sizeof(msg.hdr)) {
+      fprintf(stderr, "received truncated request (%zd bytes), skipping\n", size);
+      continue;
+    }
+
+    size_t msg_len = size_t(size);
+    // Use the message buffer after request/response for the return value
+    size_t header_size = std::max(msg_len, sizeof(Response));
+    char *buf = msg.buf + header_size;
+    size_t buf_size = sizeof(msg) - header_size;
+    size_t value_len = 0; // set below to the actual length of the value to be returned
+    int rc = 0;
+    int fd_out = -1; // set below when 'rc' is a file descriptor
+
+    switch (msg.hdr.msg_type_) {
+    case TYPE_DUMP_REQUEST: // msg size == header size
+      value_len = dump_capabilities(CAP_EFFECTIVE, buf, buf_size);
+      break;
+    case TYPE_BPF_OPEN_REQUEST: // msg size == header size + path length
+      // zero terminate path name
+      msg.bpf_open_req.path_[msg_len - sizeof(msg.bpf_open_req)] = '\0';
+      {
+	union bpf_attr attr = {};
+	attr.pathname = uintptr_t(msg.bpf_open_req.path_);
+	fd_out = rc = ::syscall(__NR_bpf, BPF_OBJ_GET, &attr, sizeof(attr));
+      }
+      break;
+    case TYPE_BPF_LOOKUP_REQUEST: // key_size = msg_len - sizeof msg.bpf_lookup_req
+      // require at least one byte key
+      if (msg_len < sizeof(msg.bpf_lookup_req) + 1) {
+	fprintf(stderr, "received truncated bpf lookup request (%zd bytes), skipping\n", msg_len);
+	rc = -1;
+	errno = EINVAL;
+	break;
+      }
+      value_len = msg.bpf_lookup_req.value_size_;
+      // Make sure the value fits into available space
+      if (buf_size < value_len) {
+        rc = -1;
+        errno = EINVAL;
+      } else {
+        union bpf_attr attr = {};
+        attr.map_fd = uint32_t(fd_in);
+        attr.key = uintptr_t(msg.bpf_lookup_req.key_);
+        attr.value = uintptr_t(buf);
+        rc = ::syscall(__NR_bpf, BPF_MAP_LOOKUP_ELEM, &attr, sizeof(attr));
+      }
+      if (rc != 0) {
+        value_len = 0;
+      }
+      break;
+    case TYPE_SETSOCKOPT32_REQUEST: // msg_len == sizeof msg.setsockopt_req
+      if (msg_len < sizeof(msg.setsockopt_req)) {
+	fprintf(stderr, "received truncated setsockopt request (%zd bytes), skipping\n", msg_len);
+	rc = -1;
+	errno = EINVAL;
+	break;
+      }
+      rc = ::syscall(__NR_setsockopt, fd_in, msg.setsockopt_req.level_,
+		     msg.setsockopt_req.optname_, &msg.setsockopt_req.optval_,
+		     sizeof(msg.setsockopt_req.optval_));
+      break;
+    default:
+      fprintf(stderr, "Unexpected privileged call type: %d\n", msg.hdr.msg_type_);
+      rc = -1;
+      errno = EINVAL;
+    }
+
+    // Close the received file descriptor
+    if (fd_in != -1) {
+      ::close(fd_in);
+    }
+
+    // Form the response in place
+    msg.response.hdr_.msg_type_ = TYPE_RESPONSE;
+    if (fd_out != -1) {
+      // Pass a poitive but invalid fd in return_value_, to be replaced with the passed
+      // fd by the receiver.
+      msg.response.return_value_ = INT_MAX;
+      msg.response.errno_ = 0;
+    } else {
+      msg.response.return_value_ = rc;
+      msg.response.errno_ = rc != -1 ? 0 : errno;
+    }
+    size = send_fd_msg(&msg, sizeof(msg.response), buf, value_len, fd_out);
+    if (size < ssize_t(sizeof(msg.response) + value_len)) {
+      perror("sendmsg");
+    }
+
+    // Close the sent file descriptor
+    if (fd_out != -1) {
+      ::close(fd_out);
+    }
+  }
+}
+
+} // namespace PrivilegedService
+} // namespace Cilium
+} // namespace Envoy

--- a/starter/privileged_service_server.h
+++ b/starter/privileged_service_server.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#if !defined(__linux__)
+#error "Linux platform file is part of non-Linux build."
+#endif
+
+#include <limits.h>
+
+#include "starter/privileged_service_protocol.h"
+
+namespace Envoy {
+namespace Cilium {
+namespace PrivilegedService {
+
+// ProtocolServer implements the privileged service server.
+class ProtocolServer : public Protocol {
+public:
+  ProtocolServer(int pid, int pipe);
+  ~ProtocolServer();
+
+  void serve();
+
+private:
+  // receive buffer type
+  union Buffer {
+    MessageHeader hdr;
+    DumpRequest dump_req;
+    BpfOpenRequest bpf_open_req;
+    BpfLookupRequest bpf_lookup_req;
+    SetSockOptRequest setsockopt_req;
+      
+    // resposes use the same buffer, so they inherit the message sequence number from the request
+    Response response;
+
+    // make space for the largest possible request
+    char buf[sizeof(BpfOpenRequest) + PATH_MAX + 1];
+  };
+
+  int pid_;  // child pid
+};
+
+} // namespace PrivilegedService
+} // namespace Cilium
+} // namespace Envoy


### PR DESCRIPTION
Introduce a `cilium-envoy-starter` that forks and execs `cilium-envoy`
after having dropped all privileges.

Perform bpf map and privileged socket option operations in
`cilium-envoy-starter`, as requested by Cilium filters running in
`cilium-envoy` via a pipe between the two. Currently the protocol over
this pipe supports only the following operations:

- dump capabilities cilium-envoy-starter is running with
- open bpf maps
- perform bpf map lookups
- set socket options

cilium-envoy-starter fails to start if it does not have adequate
privileges needed for the above operations.

cilium-envoy now exits if it is running with any privileges when Cilium
filters are first configured.

Implementation detail:

- `libcap` is not used, as it would be hard to cross-compile for both arm64
  and amd64. Fortunately we only need to drop capabilities, so using the
  system call interface is not complicated.

- Patch Envoy to support setting socket options from listener filters and
  use them to set privileged options for the listener.

- Remove the unused support for creating and manipulating bpf maps.

- Remove `setrlimit` call that is only needed if the process is creating
  bpf maps.

- Minor cleanup in socket option implementation to move unused fields
  from SocketMarkOption class to SocketOption where they are used.

