### PR TITLE
proxylib: Parse depcerated 64-bit remote policy IDs

### DIFF
--- a/proxylib/proxylib/policymap.go
+++ b/proxylib/proxylib/policymap.go
@@ -58,6 +58,13 @@ func newPortNetworkPolicyRule(config *cilium.PortNetworkPolicyRule) (PortNetwork
 		}
 		rule.AllowedRemotes[remote] = struct{}{}
 	}
+	// TODO: Remove when Cilium 1.14 is no longer supported:
+	for _, remote := range config.GetDeprecatedRemotePolicies_64() {
+		if flowdebug.Enabled() {
+			logrus.Debugf("NPDS::PortNetworkPolicyRule: Allowing remote %d", remote)
+		}
+		rule.AllowedRemotes[uint32(remote)] = struct{}{}
+	}
 
 	// Each parser registers a parsing function to parse it's L7 rules
 	// The registered name must match 'l7_proto', if included in the message,


### PR DESCRIPTION
Parse deprecated 64-bit remote policy IDs also in proxylib.

Without this fix any old Cilium agent that has not been recompiled will fail to install proxylib (e.g., Kafka) policies correctly.

Fixes: #309