### PR TITLE
renovate: pin minor go version in GitHub actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,6 +111,34 @@
       "matchBaseBranches": [
         "v1.25"
       ]
+    },
+    {
+      "groupName": "go 1.20.x",
+      "matchFiles": [
+        ".github/workflow/**",
+      ],
+      "matchPackageNames": [
+        "go"
+      ],
+      "allowedVersions": "<=1.20",
+      "matchBaseBranches": [
+        "main",
+        "v1.25",
+      ]
+    },
+    // Pin go version of cilium integration tests to go version of cilium/cilium
+    {
+      "groupName": "cilium integration test go 1.21.x"
+      "matchFiles": [
+        ".github/workflow/cilium-integration-tests.yaml",
+      ],
+      "matchPackageNames": [
+        "go"
+      ],
+      "allowedVersions": "<=1.21",
+      "matchBaseBranches": [
+        "main",
+      ]
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
integration tests (cilium/cilium) -> pinned to 1.21.x
cilium/proxy (proxylib) -> pinned to 1.20.x

-> once we move the proxylib (cilium/proxy) to go v1.21.x - we should enable go version upgrades in the `go.mod` file too.

