### PR TITLE
dockerfile.tests: add libcilium.so for make envoy-test-deps

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -57,6 +57,8 @@ ENV TARGETARCH=$TARGETARCH
 
 # Clear runner's cache when building deps
 RUN --mount=mode=0777,uid=1337,gid=1337,target=/cilium/proxy/.cache,type=cache,id=$TARGETARCH,sharing=private rm -rf /cilium/proxy/.cache/*
+# Make proxylib available for building the test dependencies by copying it before running the tests
+COPY --from=proxylib /tmp/libcilium.so proxylib/libcilium.so
 RUN --mount=target=/tmp/bazel-cache,source=/tmp/bazel-cache,from=archive-cache,rw \
     BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS} --disk_cache=/tmp/bazel-cache" PKG_BUILD=1 V=$V DEBUG=$DEBUG make envoy-test-deps && \
     if [ -n "${COPY_CACHE_EXT}" ]; then cp -ra /tmp/bazel-cache /tmp/bazel-cache${COPY_CACHE_EXT}; fi


### PR DESCRIPTION
With https://github.com/cilium/proxy/pull/324, the `Dockerfile.tests` has been changed that only the test-`runner` has access to the `libcilium.so` file.

But `make envoy-test-deps` (that is only executed on `main`) needs the file too. see https://github.com/cilium/proxy/actions/runs/6120782331/job/16616360145

Therefore, this commit adds the `libcilium.so` to the test-`builder` too.