### PR TITLE
cilium integ test: fix repo name

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           echo "PROXY_IMAGE=quay.io/cilium/cilium-envoy" >> $GITHUB_ENV
           echo "PROXY_TAG=${{ github.sha }}" >> $GITHUB_ENV
-          echo "PROXY_GITHUB_REPO=github.com/cilium/cilium" >> $GITHUB_ENV
+          echo "PROXY_GITHUB_REPO=github.com/cilium/proxy" >> $GITHUB_ENV
 
       - name: Prepare variables for PR
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'


### PR DESCRIPTION
#342 introduced a wrong github repo for the proxy

-> `cilium/cilium` instead of `cilium/proxy`

This commit fixes this.