### PR TITLE
cilium integtest: fix cilium/proxy module update on forked repos

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -153,10 +153,19 @@ jobs:
           # renovate: datasource=golang-version depName=go
           go-version: 1.21.1
 
-      - name: Get new proxy API
+      - name: Redirect proxy module
+        shell: bash
+        if: env.PROXY_GITHUB_REPO != 'github.com/cilium/proxy'
+        run: echo "replace github.com/cilium/proxy => ${{ env.PROXY_GITHUB_REPO }} ${{ env.PROXY_TAG }}" >> go.mod
+
+      - name: Update proxy module
+        shell: bash
+        if: env.PROXY_GITHUB_REPO == 'github.com/cilium/proxy'
+        run: go get ${{ env.PROXY_GITHUB_REPO }}@${{ env.PROXY_TAG }}
+
+      - name: Vendor proxy module
         shell: bash
         run: |
-          go get ${{ env.PROXY_GITHUB_REPO }}@${{ env.PROXY_TAG }} && \
           go mod tidy && \
           go mod verify && \
           go mod vendor


### PR DESCRIPTION
If a PR is based on a forked github repository - updating the dependency fails with the following error.

```
go: github.com/mhofstetter/proxy@d904deb0a043a9d03889b801d6b81d3117f8ab7a (v0.0.0-20230911092536-d904deb0a043) requires github.com/mhofstetter/proxy@v0.0.0-20230911092536-d904deb0a043: parsing go.mod:
	module declares its path as: github.com/cilium/proxy
	        but was required as: github.com/mhofstetter/proxy
```

In this case, a replacement needs to be placed in the go.mod file.