### PR TITLE
CI: revert docker/build-push-action to v4.1.1

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -48,7 +48,7 @@ jobs:
         fi
 
     - name: PR Multi-arch build & push of Builder image (dev)
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       if: steps.cilium-builder-tag-in-repositories.outputs.exists == 'false'
       id: docker_build_builder_ci
       with:
@@ -78,7 +78,7 @@ jobs:
         fi
 
     - name: PR Multi-arch build & push of cilium-envoy
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       id: docker_build_ci
       with:
         provenance: false

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -51,7 +51,7 @@ jobs:
         fi
 
     - name: PR Multi-arch build & push of Builder image (test)
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       if: steps.cilium-builder-test-tag-in-repositories.outputs.exists == 'false'
       id: docker_build_builder_test
       with:
@@ -65,7 +65,7 @@ jobs:
           quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BAZEL_VERSION }}-latest
 
     - name: Multi-arch update integration test archive
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       id: docker_tests_ci_build
       with:
         context: .
@@ -90,7 +90,7 @@ jobs:
       run: rm -rf /tmp/buildx-cache/*
 
     - name: Run integration tests on amd64 to update docker cache
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       id: docker_tests_ci_cache_update
       with:
         provenance: false
@@ -139,7 +139,7 @@ jobs:
         fi
 
     - name: PR Multi-arch build & push of Builder image
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       if: steps.cilium-builder-tag-in-repositories.outputs.exists == 'false'
       id: docker_build_builder
       with:
@@ -152,7 +152,7 @@ jobs:
           quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
           quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.BAZEL_VERSION }}-latest
     - name: Multi-arch build & push of build artifact archive
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       with:
         context: .
         file: ./Dockerfile
@@ -178,7 +178,7 @@ jobs:
         docker buildx prune -f
 
     - name: Multi-arch build & push ${{ github.ref_name }} latest
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       id: docker_build_cd
       with:
         provenance: false

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -60,7 +60,7 @@ jobs:
         fi
 
     - name: PR Multi-arch build & push of Builder image (dev)
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       if: steps.cilium-builder-tests-tag-in-repositories.outputs.exists == 'false'
       id: docker_build_builder_tests_ci
       with:
@@ -83,7 +83,7 @@ jobs:
         fi
 
     - name: Run integration tests on amd64
-      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
       id: docker_tests_ci
       with:
         provenance: false


### PR DESCRIPTION
Curently, CI on v1.24 fails due to some issues that are related to the update of `docker/build-push-action` to v4.2.1 in combination with the bazel version.

This commit reverts the version to v4.1.1.