### PR TITLE
cilium integration tests: increase "wait-for-images" timeout

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -171,7 +171,7 @@ jobs:
           go mod vendor
 
       - name: Wait for Cilium Proxy image to be available
-        timeout-minutes: 30
+        timeout-minutes: 45
         shell: bash
         run: until docker manifest inspect ${{ env.PROXY_IMAGE }}:${{ env.PROXY_TAG }} &> /dev/null; do sleep 15s; done
 


### PR DESCRIPTION
Cilium Integration Tests often hit the timeout of 30m waiting for the proxy images being available.

This commit increases the wait timeout to 45m.

-> https://github.com/cilium/proxy/commits/main ~ more or less all runs on `main`