### PR TITLE
ci: Rerun flaky tests also in CI

### DIFF
--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -81,7 +81,7 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
             COPY_CACHE_EXT=.new
             BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.75"
-            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1
+            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
 
@@ -106,7 +106,7 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
-            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1
+            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy:latest-testlogs

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -107,6 +107,6 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:test-${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
-            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1
+            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
           cache-from: type=local,src=/tmp/buildx-cache
           push: false


### PR DESCRIPTION
We already added the --flaky_test_attempts=3 option to Makefile, in commit a1e0f93ca5 but failed to add this to GH workflows.

Fixes: #268