### PR TITLE
gh: Reuse bazel archive on main merges

### DIFF
--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -168,6 +168,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.BAZEL_VERSION }}-${{ env.BUILDER_DOCKER_HASH }}
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:main-archive-latest
             COPY_CACHE_EXT=.new
             BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.75"
           push: true

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -23,6 +23,7 @@
 /.vagrant
 /proxylib/libcilium.so*
 /proxylib/_obj*
+/BUILD_DEP_HASHES
 /.gitignore
 /Dockerfile*
 /Makefile.dev


### PR DESCRIPTION
Keep using the existing bazel archive as a basis as long as critical build dependencies have not changed.