### PR TITLE
gh: build fresh bazel archive without caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@
 
 /proxylib/libcilium.so*
 /proxylib/_obj*
+
+/BUILD_DEP_HASHES

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ COMPILER_DEP := clang.bazelrc
 ENVOY_BINS = cilium-envoy bazel-bin/cilium-envoy cilium-envoy-starter bazel-bin/cilium-envoy-starter
 ENVOY_TESTS = bazel-bin/tests/*_test
 
+BUILD_DEP_FILES = ENVOY_VERSION WORKSPACE .bazelrc envoy.bazelrc bazel/toolchains/BUILD bazel/toolchains/cc_toolchain_config.bzl
+
 SHELL=/bin/bash -o pipefail
 BAZEL ?= $(QUIET) bazel
 BAZEL_FILTER ?=
@@ -71,6 +73,9 @@ else
   install-bazel:
 	tools/install_bazel.sh `cat .bazelversion`
 endif
+
+BUILD_DEP_HASHES: $(BUILD_DEP_FILES)
+	sha256sum $^ >$@
 
 SUDO=
 ifneq ($(shell whoami),root)


### PR DESCRIPTION
If the build environment happens to have anything in the cache, it will not be built and does not get to the new bazel archive, so build a fresh archive without any caches.

Add a permissions check before the build to make sure /tmp/bazel-archive is accessible.

Prepare for incremental bazel archive updates by clearing the cache if critical build files have changed:
- define make target for BUILD_DEP_HASHES
- store this in bazel archive during archive build
- regenerate BUILD_DEP_HASHES when rebuilding bazel archive and clear the (old) bazel archive if there is any difference with the one stored in the archive.