### PR TITLE
build: Remove extra whitespace from extensions build config

### DIFF
--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -65,13 +65,12 @@ EXTENSIONS = {
     # "envoy.health_checkers.tcp":                        "//source/extensions/health_checkers/tcp:health_checker_lib",
     # "envoy.health_checkers.http":                       "//source/extensions/health_checkers/http:health_checker_lib",
     # "envoy.health_checkers.grpc":                       "//source/extensions/health_checkers/grpc:health_checker_lib",
- 
+
     #
     # Health check event sinks
     #
 
     "envoy.health_check.event_sinks.file":              "//source/extensions/health_check/event_sinks/file:file_sink_lib",
-
 
     #
     # Input Matchers


### PR DESCRIPTION
After this, and replacing out "commented out" (`sed 's/# "/"/g'`) the diff from this to upstream is:
```
190d189
<     "envoy.filters.network.client_ssl_auth":                      "//contrib/client_ssl_auth/filters/network/source:config",
199d197
<     "envoy.filters.network.mysql_proxy":                          "//contrib/mysql_proxy/filters/network/source:config",
472,476c470,472
< EXTENSION_CONFIG_VISIBILITY = ["//visibility:public"]
< EXTENSION_PACKAGE_VISIBILITY = ["//visibility:public"]
< CONTRIB_EXTENSION_PACKAGE_VISIBILITY = ["//visibility:public"]
<
< # We don't want to build for mobile, so just make the visibility private.
---
> EXTENSION_CONFIG_VISIBILITY = ["//:extension_config", "//:contrib_library", "//:examples_library", "//:mobile_library"]
> EXTENSION_PACKAGE_VISIBILITY = ["//:extension_library", "//:contrib_library", "//:examples_library", "//:mobile_library"]
> CONTRIB_EXTENSION_PACKAGE_VISIBILITY = ["//:contrib_library"]
```
These are intentional differences.