### PR TITLE
Fix format

### DIFF
--- a/Makefile.dev
+++ b/Makefile.dev
@@ -63,11 +63,13 @@ precheck: force-non-root
 ~/go/bin/buildozer:
 	go install github.com/bazelbuild/buildtools/buildozer@latest
 
+FORMAT_EXCLUDED_PREFIXES = "./linux/" "./proxylib/" "./starter/"  "./vendor/"
+
 check: $(CHECK_FORMAT) $(BUILDIFIER) $(BUILDOZER) force-non-root
-	CLANG_FORMAT=$(CLANG_FORMAT) BUILDIFIER=$(BUILDIFIER) BUILDOZER=$(BUILDOZER) $(CHECK_FORMAT) --skip_envoy_build_rule_check --add-excluded-prefixes "./linux/" "./proxylib/" --bazel_tools_check_excluded_paths="./" --build_fixer_check_excluded_paths="./" check
+	CLANG_FORMAT=$(CLANG_FORMAT) BUILDIFIER=$(BUILDIFIER) BUILDOZER=$(BUILDOZER) $(CHECK_FORMAT) --skip_envoy_build_rule_check --add-excluded-prefixes $(FORMAT_EXCLUDED_PREFIXES) --bazel_tools_check_excluded_paths="./" --build_fixer_check_excluded_paths="./" check
 
 fix: $(CHECK_FORMAT) $(BUILDIFIER) $(BUILDOZER) force-non-root
-	CLANG_FORMAT=$(CLANG_FORMAT) BUILDIFIER=$(BUILDIFIER) BUILDOZER=$(BUILDOZER) $(CHECK_FORMAT) --skip_envoy_build_rule_check --add-excluded-prefixes "./linux/" "./proxylib/" --bazel_tools_check_excluded_paths="." --build_fixer_check_excluded_paths="./" fix
+	CLANG_FORMAT=$(CLANG_FORMAT) BUILDIFIER=$(BUILDIFIER) BUILDOZER=$(BUILDOZER) $(CHECK_FORMAT) --skip_envoy_build_rule_check --add-excluded-prefixes $(FORMAT_EXCLUDED_PREFIXES) --bazel_tools_check_excluded_paths="." --build_fixer_check_excluded_paths="./" fix
 
 # Run tests without debug by default.
 tests:  $(COMPILER_DEP) force-non-root SOURCE_VERSION install-bazel

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,9 +28,6 @@ local_repository(
 
 git_repository(
     name = "envoy",
-    # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
-    remote = "https://github.com/envoyproxy/envoy.git",
-    # // clang-format on
     commit = ENVOY_SHA,
     patch_args = ["apply"],
     patch_tool = "git",
@@ -40,6 +37,9 @@ git_repository(
         "@//patches:0003-tcp_proxy-Add-filter-state-proxy_read_before_connect.patch",
         "@//patches:0004-listener-add-socket-options.patch",
     ],
+    # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
+    remote = "https://github.com/envoyproxy/envoy.git",
+    # // clang-format on
 )
 
 #

--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -155,8 +155,8 @@ envoy_cc_library(
     ],
     repository = "@envoy",
     deps = [
-        "//cilium/api:accesslog_proto_cc_proto",
         "//cilium:uds_client_lib",
+        "//cilium/api:accesslog_proto_cc_proto",
         "@envoy//envoy/http:header_map_interface",
         "@envoy//envoy/network:connection_interface",
         "@envoy//envoy/router:router_interface",
@@ -320,8 +320,8 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "privileged_service_client_lib",
-    hdrs = ["privileged_service_client.h"],
     srcs = ["privileged_service_client.cc"],
+    hdrs = ["privileged_service_client.h"],
     repository = "@envoy",
     deps = [
         "//starter:privileged_service_protocol",
@@ -337,8 +337,8 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         "//cilium:uds_client_lib",
+        "//cilium/api:health_check_sink_cc_proto",
         "@envoy//envoy/registry",
         "@envoy//envoy/upstream:health_check_event_sink_interface",
-        "//cilium/api:health_check_sink_cc_proto",
     ],
 )

--- a/cilium/accesslog.cc
+++ b/cilium/accesslog.cc
@@ -21,7 +21,7 @@ AccessLogSharedPtr AccessLog::Open(const std::string& path) {
   if (it != logs.end()) {
     auto log = it->second.lock();
     if (log)
-        return log;
+      return log;
     // expired, remove
     logs.erase(path);
   }

--- a/cilium/accesslog.h
+++ b/cilium/accesslog.h
@@ -9,7 +9,6 @@
 #include "envoy/stream_info/stream_info.h"
 
 #include "cilium/api/accesslog.pb.h"
-
 #include "cilium/uds_client.h"
 
 namespace Envoy {
@@ -46,6 +45,7 @@ public:
   };
 
   void Log(Entry& entry, ::cilium::EntryType);
+
 private:
   explicit AccessLog(const std::string& path) : UDSClient(path), path_(path) {}
 

--- a/cilium/api/npds.proto
+++ b/cilium/api/npds.proto
@@ -134,7 +134,7 @@ message PortNetworkPolicyRule {
   // This field is deprecated, use remote_policies instead.
   // TODO: Remove when Cilium 1.14 no longer supported.
   repeated uint64 deprecated_remote_policies_64 = 1;
-  repeated uint32 remote_policies = 7;  
+  repeated uint32 remote_policies = 7;
 
   // Optional downstream TLS context. If present, the incoming connection must
   // be a TLS connection.

--- a/cilium/bpf.cc
+++ b/cilium/bpf.cc
@@ -1,8 +1,8 @@
 #include "cilium/bpf.h"
-#include "cilium/privileged_service_client.h"
 
 #include "source/common/common/utility.h"
 
+#include "cilium/privileged_service_client.h"
 #include "linux/bpf.h"
 
 namespace Envoy {

--- a/cilium/grpc_subscription.cc
+++ b/cilium/grpc_subscription.cc
@@ -4,12 +4,11 @@
 #include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
 
-#include "source/extensions/config_subscription/grpc/grpc_mux_impl.h"
-
 #include "source/common/config/type_to_endpoint.h"
 #include "source/common/config/utility.h"
 #include "source/common/grpc/common.h"
 #include "source/common/protobuf/protobuf.h"
+#include "source/extensions/config_subscription/grpc/grpc_mux_impl.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -145,8 +144,8 @@ subscribe(const std::string& type_url, const LocalInfo::LocalInfo& local_info,
           Config::Utility::parseRateLimitSettings(api_config_source),
           api_config_source.set_node_on_first_message_only(), std::move(nop_config_validators),
           std::make_unique<JitteredExponentialBackOffStrategy>(
-              Config::SubscriptionFactory::RetryInitialDelayMs, Config::SubscriptionFactory::RetryMaxDelayMs,
-              random),
+              Config::SubscriptionFactory::RetryInitialDelayMs,
+              Config::SubscriptionFactory::RetryMaxDelayMs, random),
           absl::nullopt, absl::nullopt, ""),
       callbacks, resource_decoder, stats, type_url, dispatcher, init_fetch_timeout,
       /*is_aggregated*/ false, options);

--- a/cilium/health_check_sink.cc
+++ b/cilium/health_check_sink.cc
@@ -10,7 +10,8 @@ namespace Cilium {
 Thread::MutexBasicLockable HealthCheckEventPipeSink::udss_mutex;
 std::map<std::string, std::weak_ptr<UDSClient>> HealthCheckEventPipeSink::udss;
 
-HealthCheckEventPipeSink::HealthCheckEventPipeSink(const cilium::HealthCheckEventPipeSink& config) : uds_client_(nullptr) {
+HealthCheckEventPipeSink::HealthCheckEventPipeSink(const cilium::HealthCheckEventPipeSink& config)
+    : uds_client_(nullptr) {
   auto path = config.path();
   Thread::LockGuard guard(udss_mutex);
   auto it = udss.find(path);
@@ -29,7 +30,8 @@ HealthCheckEventPipeSink::HealthCheckEventPipeSink(const cilium::HealthCheckEven
 
 void HealthCheckEventPipeSink::log(envoy::data::core::v3::HealthCheckEvent event) {
   if (!uds_client_) {
-    ENVOY_LOG_MISC(warn, "HealthCheckEventPipeSink: no connection, skipping event: {}", event.DebugString());
+    ENVOY_LOG_MISC(warn, "HealthCheckEventPipeSink: no connection, skipping event: {}",
+                   event.DebugString());
     return;
   }
   std::string msg;
@@ -39,8 +41,9 @@ void HealthCheckEventPipeSink::log(envoy::data::core::v3::HealthCheckEvent event
 
 Upstream::HealthCheckEventSinkPtr HealthCheckEventPipeSinkFactory::createHealthCheckEventSink(
     const ProtobufWkt::Any& config, Server::Configuration::HealthCheckerFactoryContext& context) {
-  const auto& validator_config = Envoy::MessageUtil::anyConvertAndValidate<cilium::HealthCheckEventPipeSink>(
-      config, context.messageValidationVisitor());
+  const auto& validator_config =
+      Envoy::MessageUtil::anyConvertAndValidate<cilium::HealthCheckEventPipeSink>(
+          config, context.messageValidationVisitor());
   Upstream::HealthCheckEventSinkPtr uds;
   uds.reset(new HealthCheckEventPipeSink(validator_config));
   return uds;
@@ -48,5 +51,5 @@ Upstream::HealthCheckEventSinkPtr HealthCheckEventPipeSinkFactory::createHealthC
 
 REGISTER_FACTORY(HealthCheckEventPipeSinkFactory, Upstream::HealthCheckEventSinkFactory);
 
-} // namespace Upstream
+} // namespace Cilium
 } // namespace Envoy

--- a/cilium/health_check_sink.h
+++ b/cilium/health_check_sink.h
@@ -42,5 +42,5 @@ public:
   }
 };
 
-} // namespace Upstream
+} // namespace Cilium
 } // namespace Envoy

--- a/cilium/l7policy.cc
+++ b/cilium/l7policy.cc
@@ -129,22 +129,23 @@ Http::FilterHeadersStatus AccessFilter::decodeHeaders(Http::RequestHeaderMap& he
     const auto& policy = option->getPolicy();
     if (!policy) {
       ENVOY_LOG(debug, "cilium.l7policy: No policy found for pod {}, defaulting to DENY",
-		option->pod_ip_);
+                option->pod_ip_);
       return false;
     }
 
     allowed_ = true;
     if (option->ingress_source_identity_ != 0) {
-      allowed_ = policy->Allowed(true, option->port_, option->ingress_source_identity_,
-				 headers, log_entry_);
-      ENVOY_LOG(debug, "cilium.l7policy: Ingress from {} policy lookup for endpoint {} for port {}: {}",
-                option->ingress_source_identity_,
-                option->pod_ip_, option->port_, allowed_ ? "ALLOW" : "DENY");
+      allowed_ = policy->Allowed(true, option->port_, option->ingress_source_identity_, headers,
+                                 log_entry_);
+      ENVOY_LOG(debug,
+                "cilium.l7policy: Ingress from {} policy lookup for endpoint {} for port {}: {}",
+                option->ingress_source_identity_, option->pod_ip_, option->port_,
+                allowed_ ? "ALLOW" : "DENY");
     }
     if (allowed_) {
       allowed_ = policy->Allowed(option->ingress_, destination_port,
-				 option->ingress_ ? option->identity_ : destination_identity,
-				 headers, log_entry_);
+                                 option->ingress_ ? option->identity_ : destination_identity,
+                                 headers, log_entry_);
       ENVOY_LOG(debug, "cilium.l7policy: {} ({}->{}) policy lookup for endpoint {} for port {}: {}",
                 option->ingress_ ? "ingress" : "egress", option->identity_, destination_identity,
                 option->pod_ip_, destination_port, allowed_ ? "ALLOW" : "DENY");

--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -147,8 +147,9 @@ Network::FilterStatus Instance::onNewConnection() {
                                                                option->ingress_source_identity_);
         if (port_policy_ == nullptr ||
             !port_policy_->Matches(sni, option->ingress_source_identity_)) {
-          ENVOY_CONN_LOG(debug, "cilium.network: ingress policy drop for source identity: {} port: {}", conn,
-                         option->ingress_source_identity_, destination_port);
+          ENVOY_CONN_LOG(debug,
+                         "cilium.network: ingress policy drop for source identity: {} port: {}",
+                         conn, option->ingress_source_identity_, destination_port);
           return false;
         }
       }

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -706,9 +706,9 @@ NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& contex
   if (context.admin().has_value()) {
     ENVOY_LOG(debug, "Registering NetworkPolicies to config tracker");
     config_tracker_entry_ = context.admin()->getConfigTracker().add(
-      "networkpolicies", [this](const Matchers::StringMatcher& name_matcher) {
-        return dumpNetworkPolicyConfigs(name_matcher);
-      });
+        "networkpolicies", [this](const Matchers::StringMatcher& name_matcher) {
+          return dumpNetworkPolicyConfigs(name_matcher);
+        });
     RELEASE_ASSERT(config_tracker_entry_, "");
   }
 }
@@ -762,8 +762,7 @@ void ThreadLocalPolicyMap::Update(std::vector<std::shared_ptr<PolicyInstanceImpl
   ENVOY_LOG(trace,
             "Cilium L7 NetworkPolicyMap::onConfigUpdate(): Starting "
             "updates on the {} thread for version {}",
-            Thread::MainThread::isMainThread() ? "main" : "worker",
-            version_info);
+            Thread::MainThread::isMainThread() ? "main" : "worker", version_info);
   for (const auto& policy_name : deleted) {
     ENVOY_LOG(trace, "Cilium deleting removed network policy for endpoint {}", policy_name);
     policies_.erase(policy_name);
@@ -899,10 +898,10 @@ void NetworkPolicyMap::onConfigUpdate(
     // Execute changes on all threads.
     tls_map_.runOnAllThreads(
         [to_be_added, to_be_deleted, version_info](OptRef<ThreadLocalPolicyMap> npmap) {
-	  // Main thread done after the worker threads
-	  if (Thread::MainThread::isMainThread())
-	    return;
-	  
+          // Main thread done after the worker threads
+          if (Thread::MainThread::isMainThread())
+            return;
+
           if (!npmap.has_value()) {
             ENVOY_LOG(debug,
                       "Cilium L7 NetworkPolicyMap::onConfigUpdate(): npmap has no value "
@@ -910,13 +909,13 @@ void NetworkPolicyMap::onConfigUpdate(
                       version_info);
             return;
           }
-	  npmap->Update(*to_be_added, *to_be_deleted, version_info);
+          npmap->Update(*to_be_added, *to_be_deleted, version_info);
         },
         // All threads have executed updates, delete old cts and mark the local init target ready.
         [shared_this, to_be_added, to_be_deleted, version_info, cts_to_be_closed]() {
-	  // Update on the main thread last, so that deletes happen on the same thread as allocs
-	  auto npmap = shared_this->tls_map_.get();
-	  npmap->Update(*to_be_added, *to_be_deleted, version_info);
+          // Update on the main thread last, so that deletes happen on the same thread as allocs
+          auto npmap = shared_this->tls_map_.get();
+          npmap->Update(*to_be_added, *to_be_deleted, version_info);
 
           if (shared_this->ctmap_ && cts_to_be_closed->size() > 0) {
             shared_this->ctmap_->closeMaps(cts_to_be_closed);
@@ -947,7 +946,8 @@ void NetworkPolicyMap::runAfterAllThreads(std::function<void()> cb) const {
                                                                 cb);
 }
 
-ProtobufTypes::MessagePtr NetworkPolicyMap::dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_matcher) {
+ProtobufTypes::MessagePtr
+NetworkPolicyMap::dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_matcher) {
   ENVOY_LOG(debug, "Writing NetworkPolicies to NetworkPoliciesConfigDump");
 
   std::vector<uint64_t> policyEndpointIds;

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -82,8 +82,7 @@ public:
   std::map<std::string, std::shared_ptr<const PolicyInstanceImpl>> policies_;
 
   void Update(std::vector<std::shared_ptr<PolicyInstanceImpl>>& added,
-              std::vector<std::string>& deleted,
-              const std::string& version_info);
+              std::vector<std::string>& deleted, const std::string& version_info);
 };
 
 class NetworkPolicyDecoder : public Envoy::Config::OpaqueResourceDecoder {
@@ -189,7 +188,7 @@ private:
   std::unique_ptr<Envoy::Config::Subscription> subscription_;
   Envoy::Config::ScopedResume resume_;
 
-  ProtobufTypes::MessagePtr dumpNetworkPolicyConfigs(const Matchers::StringMatcher &name_matcher);
+  ProtobufTypes::MessagePtr dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_matcher);
   Server::ConfigTracker::EntryOwnerPtr config_tracker_entry_;
 
 public:

--- a/cilium/privileged_service_client.h
+++ b/cilium/privileged_service_client.h
@@ -4,12 +4,12 @@
 #error "Linux platform file is part of non-Linux build."
 #endif
 
+#include "envoy/api/os_sys_calls_common.h"
+
 #include "source/common/common/assert.h"
 #include "source/common/singleton/threadsafe_singleton.h"
 
 #include "starter/privileged_service_protocol.h"
-
-#include "envoy/api/os_sys_calls_common.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -30,19 +30,20 @@ public:
 
 protected:
   // Read-only bpf syscalls
-  Envoy::Api::SysCallIntResult bpf_open(const char *path);
-  Envoy::Api::SysCallIntResult bpf_lookup(int fd, const void *key, uint32_t key_size, void* value,
-					  uint32_t value_size);
+  Envoy::Api::SysCallIntResult bpf_open(const char* path);
+  Envoy::Api::SysCallIntResult bpf_lookup(int fd, const void* key, uint32_t key_size, void* value,
+                                          uint32_t value_size);
 
   // Set a socket option
-  Envoy::Api::SysCallIntResult setsockopt(int sockfd, int level, int optname, const void *optval,
-					  socklen_t optlen);
+  Envoy::Api::SysCallIntResult setsockopt(int sockfd, int level, int optname, const void* optval,
+                                          socklen_t optlen);
 
 private:
   bool check_privileged_service();
   bool have_cilium_privileged_service() const { return is_open(); }
 
-  ssize_t transact(MessageHeader& req, size_t req_len, const void *data, size_t datalen, int *fd, Response& resp, void *buf = nullptr, size_t bufsize = 0, bool assert = true);
+  ssize_t transact(MessageHeader& req, size_t req_len, const void* data, size_t datalen, int* fd,
+                   Response& resp, void* buf = nullptr, size_t bufsize = 0, bool assert = true);
 
   pthread_mutex_t call_mutex_;
   uint32_t seq_;

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -54,7 +54,8 @@ public:
       return true;
     }
     auto& cilium_calls = PrivilegedService::Singleton::get();
-    auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_SOCKET, SO_MARK, &mark_, sizeof(mark_));
+    auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_SOCKET, SO_MARK,
+                                          &mark_, sizeof(mark_));
     if (status.return_value_ < 0) {
       if (status.errno_ == EPERM) {
         // Do not assert out in this case so that we can run tests without
@@ -72,8 +73,7 @@ public:
 
     auto ipVersion = socket.ipVersion();
     if (!ipVersion.has_value()) {
-      ENVOY_LOG(critical,
-                "Socket address family is not available, can not choose source address");
+      ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
       return false;
     }
     Network::Address::InstanceConstSharedPtr source_address = original_source_address_;
@@ -94,37 +94,39 @@ public:
 
       // Set ip transparent option based on the socket address family
       if (*ipVersion == Network::Address::IpVersion::v4) {
-	auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_IP, IP_TRANSPARENT, &one, sizeof(one));
-	if (status.return_value_ < 0) {
-	  if (status.errno_ == EPERM) {
-	    // Do not assert out in this case so that we can run tests without
-	    // CAP_NET_ADMIN.
-	    ENVOY_LOG(critical,
-		      "Failed to set socket option IP_TRANSPARENT, capability "
-		      "CAP_NET_ADMIN needed: {}",
-		      Envoy::errorDetails(status.errno_));
-	  } else {
-	    ENVOY_LOG(critical, "Socket option failure. Failed to set IP_TRANSPARENT: {}",
-		      Envoy::errorDetails(status.errno_));
-	    return false;
-	  }
-	}
+        auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_IP,
+                                              IP_TRANSPARENT, &one, sizeof(one));
+        if (status.return_value_ < 0) {
+          if (status.errno_ == EPERM) {
+            // Do not assert out in this case so that we can run tests without
+            // CAP_NET_ADMIN.
+            ENVOY_LOG(critical,
+                      "Failed to set socket option IP_TRANSPARENT, capability "
+                      "CAP_NET_ADMIN needed: {}",
+                      Envoy::errorDetails(status.errno_));
+          } else {
+            ENVOY_LOG(critical, "Socket option failure. Failed to set IP_TRANSPARENT: {}",
+                      Envoy::errorDetails(status.errno_));
+            return false;
+          }
+        }
       } else if (*ipVersion == Network::Address::IpVersion::v6) {
-	auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_IPV6, IPV6_TRANSPARENT, &one, sizeof(one));
-	if (status.return_value_ < 0) {
-	  if (status.errno_ == EPERM) {
-	    // Do not assert out in this case so that we can run tests without
-	    // CAP_NET_ADMIN.
-	    ENVOY_LOG(critical,
-		      "Failed to set socket option IPV6_TRANSPARENT, capability "
-		      "CAP_NET_ADMIN needed: {}",
-		      Envoy::errorDetails(status.errno_));
-	  } else {
-	    ENVOY_LOG(critical, "Socket option failure. Failed to set IPV6_TRANSPARENT: {}",
-		      Envoy::errorDetails(status.errno_));
-	    return false;
-	  }
-	}	
+        auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_IPV6,
+                                              IPV6_TRANSPARENT, &one, sizeof(one));
+        if (status.return_value_ < 0) {
+          if (status.errno_ == EPERM) {
+            // Do not assert out in this case so that we can run tests without
+            // CAP_NET_ADMIN.
+            ENVOY_LOG(critical,
+                      "Failed to set socket option IPV6_TRANSPARENT, capability "
+                      "CAP_NET_ADMIN needed: {}",
+                      Envoy::errorDetails(status.errno_));
+          } else {
+            ENVOY_LOG(critical, "Socket option failure. Failed to set IPV6_TRANSPARENT: {}",
+                      Envoy::errorDetails(status.errno_));
+            return false;
+          }
+        }
       }
 
       auto status = socket.setSocketOption(SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
@@ -202,18 +204,18 @@ public:
 
 class SocketOption : public SocketMarkOption {
 public:
-  SocketOption(PolicyInstanceConstSharedPtr policy, uint32_t mark,
-               uint32_t ingress_source_identity, uint32_t source_identity,
-               bool ingress, bool l7lb, uint16_t port, std::string&& pod_ip,
+  SocketOption(PolicyInstanceConstSharedPtr policy, uint32_t mark, uint32_t ingress_source_identity,
+               uint32_t source_identity, bool ingress, bool l7lb, uint16_t port,
+               std::string&& pod_ip,
                Network::Address::InstanceConstSharedPtr original_source_address,
                Network::Address::InstanceConstSharedPtr ipv4_source_address,
                Network::Address::InstanceConstSharedPtr ipv6_source_address,
                const std::shared_ptr<PolicyResolver>& policy_id_resolver)
-      : SocketMarkOption(mark, source_identity, original_source_address,
-                         ipv4_source_address, ipv6_source_address),
-        ingress_source_identity_(ingress_source_identity),
-        initial_policy_(policy), ingress_(ingress), is_l7lb_(l7lb), port_(port),
-        pod_ip_(std::move(pod_ip)), policy_id_resolver_(policy_id_resolver) {
+      : SocketMarkOption(mark, source_identity, original_source_address, ipv4_source_address,
+                         ipv6_source_address),
+        ingress_source_identity_(ingress_source_identity), initial_policy_(policy),
+        ingress_(ingress), is_l7lb_(l7lb), port_(port), pod_ip_(std::move(pod_ip)),
+        policy_id_resolver_(policy_id_resolver) {
     ENVOY_LOG(debug,
               "Cilium SocketOption(): source_identity: {}, "
               "ingress: {}, port: {}, pod_ip: {}, source_addresses: {}/{}/{}, mark: {:x} (magic "

--- a/cilium/uds_client.cc
+++ b/cilium/uds_client.cc
@@ -1,3 +1,5 @@
+#include "cilium/uds_client.h"
+
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/socket.h>
@@ -5,10 +7,9 @@
 #include <unistd.h>
 
 #include "envoy/common/exception.h"
+
 #include "source/common/common/lock_guard.h"
 #include "source/common/common/utility.h"
-
-#include "cilium/uds_client.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/uds_client.h
+++ b/cilium/uds_client.h
@@ -29,6 +29,5 @@ private:
   int errno_ ABSL_GUARDED_BY(fd_mutex_);
 };
 
-  
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/websocket_codec.cc
+++ b/cilium/websocket_codec.cc
@@ -306,8 +306,7 @@ void Codec::closeOnError(const char* msg) {
     ENVOY_LOG(debug, "websocket: Closing connection: {}", msg);
   }
   // Close downstream, this should result also in the upstream getting closed (if any).
-  connection_.close(Network::ConnectionCloseType::NoFlush,
-		    fmt::format("websocket error: {}", msg));
+  connection_.close(Network::ConnectionCloseType::NoFlush, fmt::format("websocket error: {}", msg));
 }
 
 void Codec::closeOnError(Buffer::Instance& data, const char* msg) {

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -3,28 +3,27 @@ EXTENSIONS = {
     #
     # Access loggers
     #
-
-    "envoy.access_loggers.file":                        "//source/extensions/access_loggers/file:config",
-    "envoy.access_loggers.extension_filters.cel":       "//source/extensions/access_loggers/filters/cel:config",
-    "envoy.access_loggers.http_grpc":                   "//source/extensions/access_loggers/grpc:http_config",
-    "envoy.access_loggers.tcp_grpc":                    "//source/extensions/access_loggers/grpc:tcp_config",
-    "envoy.access_loggers.open_telemetry":              "//source/extensions/access_loggers/open_telemetry:config",
-    "envoy.access_loggers.stdout":                      "//source/extensions/access_loggers/stream:config",
-    "envoy.access_loggers.stderr":                      "//source/extensions/access_loggers/stream:config",
-    "envoy.access_loggers.wasm":                        "//source/extensions/access_loggers/wasm:config",
+    "envoy.access_loggers.file": "//source/extensions/access_loggers/file:config",
+    "envoy.access_loggers.extension_filters.cel": "//source/extensions/access_loggers/filters/cel:config",
+    "envoy.access_loggers.http_grpc": "//source/extensions/access_loggers/grpc:http_config",
+    "envoy.access_loggers.tcp_grpc": "//source/extensions/access_loggers/grpc:tcp_config",
+    "envoy.access_loggers.open_telemetry": "//source/extensions/access_loggers/open_telemetry:config",
+    "envoy.access_loggers.stdout": "//source/extensions/access_loggers/stream:config",
+    "envoy.access_loggers.stderr": "//source/extensions/access_loggers/stream:config",
+    "envoy.access_loggers.wasm": "//source/extensions/access_loggers/wasm:config",
 
     #
     # Clusters
     #
 
     # "envoy.clusters.aggregate":                         "//source/extensions/clusters/aggregate:cluster",
-    "envoy.clusters.dynamic_forward_proxy":             "//source/extensions/clusters/dynamic_forward_proxy:cluster",
-    "envoy.clusters.eds":                               "//source/extensions/clusters/eds:eds_lib",
+    "envoy.clusters.dynamic_forward_proxy": "//source/extensions/clusters/dynamic_forward_proxy:cluster",
+    "envoy.clusters.eds": "//source/extensions/clusters/eds:eds_lib",
     # "envoy.clusters.redis":                             "//source/extensions/clusters/redis:redis_cluster",
-    "envoy.clusters.static":                            "//source/extensions/clusters/static:static_cluster_lib",
-    "envoy.clusters.strict_dns":                        "//source/extensions/clusters/strict_dns:strict_dns_cluster_lib",
-    "envoy.clusters.original_dst":                      "//source/extensions/clusters/original_dst:original_dst_cluster_lib",
-    "envoy.clusters.logical_dns":                       "//source/extensions/clusters/logical_dns:logical_dns_cluster_lib",
+    "envoy.clusters.static": "//source/extensions/clusters/static:static_cluster_lib",
+    "envoy.clusters.strict_dns": "//source/extensions/clusters/strict_dns:strict_dns_cluster_lib",
+    "envoy.clusters.original_dst": "//source/extensions/clusters/original_dst:original_dst_cluster_lib",
+    "envoy.clusters.logical_dns": "//source/extensions/clusters/logical_dns:logical_dns_cluster_lib",
 
     #
     # Compression
@@ -53,8 +52,7 @@ EXTENSIONS = {
     #
     # WASM
     #
-
-    "envoy.bootstrap.wasm":                             "//source/extensions/bootstrap/wasm:config",
+    "envoy.bootstrap.wasm": "//source/extensions/bootstrap/wasm:config",
 
     #
     # Health checkers
@@ -69,8 +67,7 @@ EXTENSIONS = {
     #
     # Health check event sinks
     #
-
-    "envoy.health_check.event_sinks.file":              "//source/extensions/health_check/event_sinks/file:file_sink_lib",
+    "envoy.health_check.event_sinks.file": "//source/extensions/health_check/event_sinks/file:file_sink_lib",
 
     #
     # Input Matchers
@@ -134,8 +131,8 @@ EXTENSIONS = {
     # "envoy.filters.http.csrf":                          "//source/extensions/filters/http/csrf:config",
     # "envoy.filters.http.custom_response":               "//source/extensions/filters/http/custom_response:factory",
     # "envoy.filters.http.decompressor":                  "//source/extensions/filters/http/decompressor:config",
-    "envoy.filters.http.dynamic_forward_proxy":         "//source/extensions/filters/http/dynamic_forward_proxy:config",
-    "envoy.filters.http.ext_authz":                     "//source/extensions/filters/http/ext_authz:config",
+    "envoy.filters.http.dynamic_forward_proxy": "//source/extensions/filters/http/dynamic_forward_proxy:config",
+    "envoy.filters.http.ext_authz": "//source/extensions/filters/http/ext_authz:config",
     # "envoy.filters.http.ext_proc":                      "//source/extensions/filters/http/ext_proc:config",
     # "envoy.filters.http.fault":                         "//source/extensions/filters/http/fault:config",
     # "envoy.filters.http.file_system_buffer":            "//source/extensions/filters/http/file_system_buffer:config",
@@ -145,26 +142,26 @@ EXTENSIONS = {
     # "envoy.filters.http.grpc_http1_bridge":             "//source/extensions/filters/http/grpc_http1_bridge:config",
     # "envoy.filters.http.grpc_http1_reverse_bridge":     "//source/extensions/filters/http/grpc_http1_reverse_bridge:config",
     # "envoy.filters.http.grpc_json_transcoder":          "//source/extensions/filters/http/grpc_json_transcoder:config",
-    "envoy.filters.http.grpc_stats":                    "//source/extensions/filters/http/grpc_stats:config",
-    "envoy.filters.http.grpc_web":                      "//source/extensions/filters/http/grpc_web:config",
+    "envoy.filters.http.grpc_stats": "//source/extensions/filters/http/grpc_stats:config",
+    "envoy.filters.http.grpc_web": "//source/extensions/filters/http/grpc_web:config",
     # "envoy.filters.http.header_to_metadata":            "//source/extensions/filters/http/header_to_metadata:config",
     # "envoy.filters.http.health_check":                  "//source/extensions/filters/http/health_check:config",
     # "envoy.filters.http.ip_tagging":                    "//source/extensions/filters/http/ip_tagging:config",
-    "envoy.filters.http.jwt_authn":                     "//source/extensions/filters/http/jwt_authn:config",
-    "envoy.filters.http.rate_limit_quota":              "//source/extensions/filters/http/rate_limit_quota:config",
+    "envoy.filters.http.jwt_authn": "//source/extensions/filters/http/jwt_authn:config",
+    "envoy.filters.http.rate_limit_quota": "//source/extensions/filters/http/rate_limit_quota:config",
     # Disabled by default
     # "envoy.filters.http.kill_request":                  "//source/extensions/filters/http/kill_request:kill_request_config",
-    "envoy.filters.http.local_ratelimit":               "//source/extensions/filters/http/local_ratelimit:config",
+    "envoy.filters.http.local_ratelimit": "//source/extensions/filters/http/local_ratelimit:config",
     # "envoy.filters.http.lua":                           "//source/extensions/filters/http/lua:config",
-    "envoy.filters.http.oauth2":                        "//source/extensions/filters/http/oauth2:config",
+    "envoy.filters.http.oauth2": "//source/extensions/filters/http/oauth2:config",
     # "envoy.filters.http.on_demand":                     "//source/extensions/filters/http/on_demand:config",
     # "envoy.filters.http.original_src":                  "//source/extensions/filters/http/original_src:config",
-    "envoy.filters.http.ratelimit":                     "//source/extensions/filters/http/ratelimit:config",
+    "envoy.filters.http.ratelimit": "//source/extensions/filters/http/ratelimit:config",
     # "envoy.filters.http.rbac":                          "//source/extensions/filters/http/rbac:config",
-    "envoy.filters.http.router":                        "//source/extensions/filters/http/router:config",
-    "envoy.filters.http.set_metadata":                  "//source/extensions/filters/http/set_metadata:config",
+    "envoy.filters.http.router": "//source/extensions/filters/http/router:config",
+    "envoy.filters.http.set_metadata": "//source/extensions/filters/http/set_metadata:config",
     # "envoy.filters.http.tap":                           "//source/extensions/filters/http/tap:config",
-    "envoy.filters.http.wasm":                          "//source/extensions/filters/http/wasm:config",
+    "envoy.filters.http.wasm": "//source/extensions/filters/http/wasm:config",
     # "envoy.filters.http.stateful_session":              "//source/extensions/filters/http/stateful_session:config",
     # "envoy.filters.http.header_mutation":               "//source/extensions/filters/http/header_mutation:config",
 
@@ -181,30 +178,30 @@ EXTENSIONS = {
     # NOTE: The proxy_protocol filter is implicitly loaded if proxy_protocol functionality is
     #       configured on the listener. Do not remove it in that case or configs will fail to load.
     # "envoy.filters.listener.proxy_protocol":            "//source/extensions/filters/listener/proxy_protocol:config",
-    "envoy.filters.listener.tls_inspector":             "//source/extensions/filters/listener/tls_inspector:config",
+    "envoy.filters.listener.tls_inspector": "//source/extensions/filters/listener/tls_inspector:config",
 
     #
     # Network filters
     #
 
     # "envoy.filters.network.client_ssl_auth":                      "//contrib/client_ssl_auth/filters/network/source:config",
-    "envoy.filters.network.connection_limit":                     "//source/extensions/filters/network/connection_limit:config",
+    "envoy.filters.network.connection_limit": "//source/extensions/filters/network/connection_limit:config",
     # "envoy.filters.network.direct_response":                      "//source/extensions/filters/network/direct_response:config",
     # "envoy.filters.network.dubbo_proxy":                          "//source/extensions/filters/network/dubbo_proxy:config",
     # "envoy.filters.network.echo":                                 "//source/extensions/filters/network/echo:config",
-    "envoy.filters.network.ext_authz":                            "//source/extensions/filters/network/ext_authz:config",
-    "envoy.filters.network.http_connection_manager":              "//source/extensions/filters/network/http_connection_manager:config",
-    "envoy.filters.network.local_ratelimit":                      "//source/extensions/filters/network/local_ratelimit:config",
-    "envoy.filters.network.mongo_proxy":                          "//source/extensions/filters/network/mongo_proxy:config",
-    "envoy.filters.network.mysql_proxy":                          "//contrib/mysql_proxy/filters/network/source:config",
-    "envoy.filters.network.ratelimit":                            "//source/extensions/filters/network/ratelimit:config",
+    "envoy.filters.network.ext_authz": "//source/extensions/filters/network/ext_authz:config",
+    "envoy.filters.network.http_connection_manager": "//source/extensions/filters/network/http_connection_manager:config",
+    "envoy.filters.network.local_ratelimit": "//source/extensions/filters/network/local_ratelimit:config",
+    "envoy.filters.network.mongo_proxy": "//source/extensions/filters/network/mongo_proxy:config",
+    "envoy.filters.network.mysql_proxy": "//contrib/mysql_proxy/filters/network/source:config",
+    "envoy.filters.network.ratelimit": "//source/extensions/filters/network/ratelimit:config",
     # "envoy.filters.network.rbac":                                 "//source/extensions/filters/network/rbac:config",
     # "envoy.filters.network.redis_proxy":                          "//source/extensions/filters/network/redis_proxy:config",
-    "envoy.filters.network.tcp_proxy":                            "//source/extensions/filters/network/tcp_proxy:config",
+    "envoy.filters.network.tcp_proxy": "//source/extensions/filters/network/tcp_proxy:config",
     # "envoy.filters.network.thrift_proxy":                         "//source/extensions/filters/network/thrift_proxy:config",
-    "envoy.filters.network.sni_cluster":                          "//source/extensions/filters/network/sni_cluster:config",
-    "envoy.filters.network.sni_dynamic_forward_proxy":            "//source/extensions/filters/network/sni_dynamic_forward_proxy:config",
-    "envoy.filters.network.wasm":                                 "//source/extensions/filters/network/wasm:config",
+    "envoy.filters.network.sni_cluster": "//source/extensions/filters/network/sni_cluster:config",
+    "envoy.filters.network.sni_dynamic_forward_proxy": "//source/extensions/filters/network/sni_dynamic_forward_proxy:config",
+    "envoy.filters.network.wasm": "//source/extensions/filters/network/wasm:config",
     # "envoy.filters.network.zookeeper_proxy":                      "//source/extensions/filters/network/zookeeper_proxy:config",
 
     #
@@ -229,10 +226,10 @@ EXTENSIONS = {
     # "envoy.stat_sinks.dog_statsd":                      "//source/extensions/stat_sinks/dog_statsd:config",
     # "envoy.stat_sinks.graphite_statsd":                 "//source/extensions/stat_sinks/graphite_statsd:config",
     # "envoy.stat_sinks.hystrix":                         "//source/extensions/stat_sinks/hystrix:config",
-    "envoy.stat_sinks.metrics_service":                 "//source/extensions/stat_sinks/metrics_service:config",
-    "envoy.stat_sinks.open_telemetry":                  "//source/extensions/stat_sinks/open_telemetry:config",
+    "envoy.stat_sinks.metrics_service": "//source/extensions/stat_sinks/metrics_service:config",
+    "envoy.stat_sinks.open_telemetry": "//source/extensions/stat_sinks/open_telemetry:config",
     # "envoy.stat_sinks.statsd":                          "//source/extensions/stat_sinks/statsd:config",
-    "envoy.stat_sinks.wasm":                            "//source/extensions/stat_sinks/wasm:config",
+    "envoy.stat_sinks.wasm": "//source/extensions/stat_sinks/wasm:config",
 
     #
     # Thrift filters
@@ -262,11 +259,11 @@ EXTENSIONS = {
     # "envoy.transport_sockets.alts":                     "//source/extensions/transport_sockets/alts:config",
     # "envoy.transport_sockets.http_11_proxy":            "//source/extensions/transport_sockets/http_11_proxy:upstream_config",
     # "envoy.transport_sockets.upstream_proxy_protocol":  "//source/extensions/transport_sockets/proxy_protocol:upstream_config",
-    "envoy.transport_sockets.raw_buffer":               "//source/extensions/transport_sockets/raw_buffer:config",
+    "envoy.transport_sockets.raw_buffer": "//source/extensions/transport_sockets/raw_buffer:config",
     # "envoy.transport_sockets.tap":                      "//source/extensions/transport_sockets/tap:config",
     # "envoy.transport_sockets.starttls":                 "//source/extensions/transport_sockets/starttls:config",
     # "envoy.transport_sockets.tcp_stats":                "//source/extensions/transport_sockets/tcp_stats:config",
-    "envoy.transport_sockets.internal_upstream":        "//source/extensions/transport_sockets/internal_upstream:config",
+    "envoy.transport_sockets.internal_upstream": "//source/extensions/transport_sockets/internal_upstream:config",
 
     #
     # Retry host predicates
@@ -299,10 +296,9 @@ EXTENSIONS = {
     #
     # Http Upstreams (excepting envoy.upstreams.http.generic which is hard-coded into the build so not registered here)
     #
-
-    "envoy.upstreams.http.http":                        "//source/extensions/upstreams/http/http:config",
-    "envoy.upstreams.http.tcp":                         "//source/extensions/upstreams/http/tcp:config",
-    "envoy.upstreams.http.udp":                         "//source/extensions/upstreams/http/udp:config",
+    "envoy.upstreams.http.http": "//source/extensions/upstreams/http/http:config",
+    "envoy.upstreams.http.tcp": "//source/extensions/upstreams/http/tcp:config",
+    "envoy.upstreams.http.udp": "//source/extensions/upstreams/http/udp:config",
 
     #
     # Watchdog actions
@@ -313,25 +309,23 @@ EXTENSIONS = {
     #
     # WebAssembly runtimes
     #
-
-    "envoy.wasm.runtime.null":                          "//source/extensions/wasm_runtime/null:config",
-    "envoy.wasm.runtime.v8":                            "//source/extensions/wasm_runtime/v8:config",
-    "envoy.wasm.runtime.wamr":                          "//source/extensions/wasm_runtime/wamr:config",
-    "envoy.wasm.runtime.wavm":                          "//source/extensions/wasm_runtime/wavm:config",
-    "envoy.wasm.runtime.wasmtime":                      "//source/extensions/wasm_runtime/wasmtime:config",
+    "envoy.wasm.runtime.null": "//source/extensions/wasm_runtime/null:config",
+    "envoy.wasm.runtime.v8": "//source/extensions/wasm_runtime/v8:config",
+    "envoy.wasm.runtime.wamr": "//source/extensions/wasm_runtime/wamr:config",
+    "envoy.wasm.runtime.wavm": "//source/extensions/wasm_runtime/wavm:config",
+    "envoy.wasm.runtime.wasmtime": "//source/extensions/wasm_runtime/wasmtime:config",
 
     #
     # Rate limit descriptors
     #
-
-    "envoy.rate_limit_descriptors.expr":                "//source/extensions/rate_limit_descriptors/expr:config",
+    "envoy.rate_limit_descriptors.expr": "//source/extensions/rate_limit_descriptors/expr:config",
 
     #
     # IO socket
     #
 
     # "envoy.io_socket.user_space":                       "//source/extensions/io_socket/user_space:config",
-    "envoy.bootstrap.internal_listener":                "//source/extensions/bootstrap/internal_listener:config",
+    "envoy.bootstrap.internal_listener": "//source/extensions/bootstrap/internal_listener:config",
 
     #
     # TLS peer certification validators
@@ -406,7 +400,7 @@ EXTENSIONS = {
     #
 
     # c-ares DNS resolver extension is recommended to be enabled to maintain the legacy DNS resolving behavior.
-    "envoy.network.dns_resolver.cares":                "//source/extensions/network/dns_resolver/cares:config",
+    "envoy.network.dns_resolver.cares": "//source/extensions/network/dns_resolver/cares:config",
     # apple DNS resolver extension is only needed in MacOS build plus one want to use apple library for DNS resolving.
     # "envoy.network.dns_resolver.apple":                "//source/extensions/network/dns_resolver/apple:config",
     # getaddrinfo DNS resolver extension can be used when the system resolver is desired (e.g., Android)
@@ -432,19 +426,18 @@ EXTENSIONS = {
     #
     # Early Data option
     #
-
-    "envoy.route.early_data_policy.default":           "//source/extensions/early_data:default_early_data_policy_lib",
+    "envoy.route.early_data_policy.default": "//source/extensions/early_data:default_early_data_policy_lib",
 
     #
     # Load balancing policies for upstream
     #
-    "envoy.load_balancing_policies.least_request":     "//source/extensions/load_balancing_policies/least_request:config",
-    "envoy.load_balancing_policies.random":            "//source/extensions/load_balancing_policies/random:config",
-    "envoy.load_balancing_policies.round_robin":       "//source/extensions/load_balancing_policies/round_robin:config",
-    "envoy.load_balancing_policies.maglev":            "//source/extensions/load_balancing_policies/maglev:config",
-    "envoy.load_balancing_policies.ring_hash":         "//source/extensions/load_balancing_policies/ring_hash:config",
-    "envoy.load_balancing_policies.subset":            "//source/extensions/load_balancing_policies/subset:config",
-    "envoy.load_balancing_policies.cluster_provided":  "//source/extensions/load_balancing_policies/cluster_provided:config",
+    "envoy.load_balancing_policies.least_request": "//source/extensions/load_balancing_policies/least_request:config",
+    "envoy.load_balancing_policies.random": "//source/extensions/load_balancing_policies/random:config",
+    "envoy.load_balancing_policies.round_robin": "//source/extensions/load_balancing_policies/round_robin:config",
+    "envoy.load_balancing_policies.maglev": "//source/extensions/load_balancing_policies/maglev:config",
+    "envoy.load_balancing_policies.ring_hash": "//source/extensions/load_balancing_policies/ring_hash:config",
+    "envoy.load_balancing_policies.subset": "//source/extensions/load_balancing_policies/subset:config",
+    "envoy.load_balancing_policies.cluster_provided": "//source/extensions/load_balancing_policies/cluster_provided:config",
 
     #
     # HTTP Early Header Mutation

--- a/starter/BUILD
+++ b/starter/BUILD
@@ -3,10 +3,10 @@ licenses(["notice"])  # Apache 2
 cc_library(
     name = "main_entry_lib",
     srcs = ["main.cc"],
+    visibility = ["//visibility:public"],
     deps = [
         "privileged_service_server_lib",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -18,8 +18,8 @@ cc_library(
 
 cc_library(
     name = "privileged_service_server_lib",
-    hdrs = ["privileged_service_server.h"],
     srcs = ["privileged_service_server.cc"],
+    hdrs = ["privileged_service_server.h"],
     deps = [
         "privileged_service_protocol",
     ],

--- a/starter/main.cc
+++ b/starter/main.cc
@@ -3,12 +3,11 @@
 #endif
 
 #include <errno.h>
-#include <syscall.h>
-#include <unistd.h>
-
 #include <sys/prctl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <syscall.h>
+#include <unistd.h>
 
 #include "starter/privileged_service_server.h"
 
@@ -22,12 +21,13 @@ int main(int /* argc */, char** argv) {
   uint64_t caps = Envoy::Cilium::PrivilegedService::get_capabilities(CAP_EFFECTIVE);
   if ((caps & (1UL << CAP_NET_ADMIN)) == 0 ||
       (caps & (1UL << CAP_SYS_ADMIN | 1UL << CAP_BPF)) == 0) {
-    fprintf(stderr, "CAP_NET_ADMIN and either CAP_SYS_ADMIN or CAP_BPF capabilities are needed for Cilium datapath integration.\n");
+    fprintf(stderr, "CAP_NET_ADMIN and either CAP_SYS_ADMIN or CAP_BPF capabilities are needed for "
+                    "Cilium datapath integration.\n");
     exit(1);
   }
 
   // Get the path we're running from
-  char *path = new char[PATH_MAX];
+  char* path = new char[PATH_MAX];
   constexpr size_t path_size = PATH_MAX;
   int path_len = readlink("/proc/self/exe", path, path_size);
   if (path_len < 0 || path_len >= int(path_size)) {
@@ -41,11 +41,14 @@ int main(int /* argc */, char** argv) {
   if (size_t(path_len) > STARTER_SUFFIX_LEN && // more than suffix in path
       strncmp(path + path_len - STARTER_SUFFIX_LEN, STARTER_SUFFIX, STARTER_SUFFIX_LEN) == 0 &&
       path[path_len - STARTER_SUFFIX_LEN - 1] != '/' // slash not the last before suffix
-      ) {
+  ) {
     path_len -= STARTER_SUFFIX_LEN;
     path[path_len] = '\0';
   } else {
-    fprintf(stderr, "Executable name must end in \"" STARTER_SUFFIX "\" and not be empty without it: \"%s\"\n", path);
+    fprintf(stderr,
+            "Executable name must end in \"" STARTER_SUFFIX
+            "\" and not be empty without it: \"%s\"\n",
+            path);
     exit(1);
   }
 
@@ -61,7 +64,9 @@ int main(int /* argc */, char** argv) {
     close(fds[0]);
 
     // Unconditionally drop all capabilities
-    struct __user_cap_header_struct hdr{_LINUX_CAPABILITY_VERSION_3, 0};
+    struct __user_cap_header_struct hdr {
+      _LINUX_CAPABILITY_VERSION_3, 0
+    };
     struct __user_cap_data_struct data[2];
     memset(&data, 0, sizeof(data));
     if (::syscall(SYS_capset, &hdr, &data, sizeof(data)) != 0) {
@@ -76,19 +81,19 @@ int main(int /* argc */, char** argv) {
     }
 
     RELEASE_ASSERT(Envoy::Cilium::PrivilegedService::get_capabilities(CAP_EFFECTIVE) == 0 &&
-		   Envoy::Cilium::PrivilegedService::get_capabilities(CAP_PERMITTED) == 0 &&
-		   Envoy::Cilium::PrivilegedService::get_capabilities(CAP_INHERITABLE) == 0,
-		   "Failed dropping privileges");
+                       Envoy::Cilium::PrivilegedService::get_capabilities(CAP_PERMITTED) == 0 &&
+                       Envoy::Cilium::PrivilegedService::get_capabilities(CAP_INHERITABLE) == 0,
+                   "Failed dropping privileges");
 
     // Dup the client end to CILIUM_PRIVILEGED_SERVICE_FD
     if (fds[1] != CILIUM_PRIVILEGED_SERVICE_FD) {
       if (dup2(fds[1], CILIUM_PRIVILEGED_SERVICE_FD) < 0) {
-	perror("dup2");
-	exit(1);
+        perror("dup2");
+        exit(1);
       }
       close(fds[1]);
     }
-    
+
     // Exec cilium-envoy process
     execv(path, argv);
     perror("execv");

--- a/starter/privileged_service_protocol.cc
+++ b/starter/privileged_service_protocol.cc
@@ -2,12 +2,11 @@
 #error "Linux platform file is part of non-Linux build."
 #endif
 
-#include <errno.h>
-
-#include <sys/unistd.h>
-#include <sys/syscall.h>
-
 #include "starter/privileged_service_protocol.h"
+
+#include <errno.h>
+#include <sys/syscall.h>
+#include <sys/unistd.h>
 
 namespace Envoy {
 namespace Cilium {
@@ -15,75 +14,77 @@ namespace PrivilegedService {
 
 // Capabiilty names used in DumpCapabilites responses.
 static const char* cap_names[64] = {
-  "CAP_CHOWN",              //  0
-  "CAP_DAC_OVERRIDE",       //  1
-  "CAP_DAC_READ_SEARCH",    //  2
-  "CAP_FOWNER",             //  3
-  "CAP_FSETID",             //  4 
-  "CAP_KILL",               //  5
-  "CAP_SETGID",             //  6
-  "CAP_SETUID",             //  7 
-  "CAP_SETPCAP",            //  8 
-  "CAP_LINUX_IMMUTABLE",    //  9
-  "CAP_NET_BIND_SERVICE",   // 10
-  "CAP_NET_BROADCAST",      // 11
-  "CAP_NET_ADMIN",          // 12
-  "CAP_NET_RAW",            // 13
-  "CAP_IPC_LOCK",           // 14
-  "CAP_IPC_OWNER",          // 15
-  "CAP_SYS_MODULE",         // 16
-  "CAP_SYS_RAWIO",          // 17
-  "CAP_SYS_CHROOT",         // 18
-  "CAP_SYS_PTRACE",         // 19
-  "CAP_SYS_PACCT",          // 20
-  "CAP_SYS_ADMIN",          // 21
-  "CAP_SYS_BOOT",           // 22
-  "CAP_SYS_NICE",           // 23
-  "CAP_SYS_RESOURCE",       // 24
-  "CAP_SYS_TIME",           // 25
-  "CAP_SYS_TTY_CONFIG",     // 26
-  "CAP_MKNOD",              // 27
-  "CAP_LEASE",              // 28
-  "CAP_AUDIT_WRITE",        // 29
-  "CAP_AUDIT_CONTROL",      // 30
-  "CAP_SETFCAP",            // 31
-  "CAP_MAC_OVERRIDE",       // 32
-  "CAP_MAC_ADMIN",          // 33
-  "CAP_SYSLOG",             // 34
-  "CAP_WAKE_ALARM",         // 35
-  "CAP_BLOCK_SUSPEND",      // 36
-  "CAP_AUDIT_READ",         // 37
-  "CAP_PERFMON",            // 38 
-  "CAP_BPF",                // 39
-  "CAP_CHECKPOINT_RESTORE", // 40
-  "CAP_41",
-  "CAP_42",
-  "CAP_43",
-  "CAP_44",
-  "CAP_45",
-  "CAP_46",
-  "CAP_47",
-  "CAP_48",
-  "CAP_49",
-  "CAP_50",
-  "CAP_51",
-  "CAP_52",
-  "CAP_53",
-  "CAP_54",
-  "CAP_55",
-  "CAP_56",
-  "CAP_57",
-  "CAP_58",
-  "CAP_59",
-  "CAP_60",
-  "CAP_61",
-  "CAP_62",
-  "CAP_63",
+    "CAP_CHOWN",              //  0
+    "CAP_DAC_OVERRIDE",       //  1
+    "CAP_DAC_READ_SEARCH",    //  2
+    "CAP_FOWNER",             //  3
+    "CAP_FSETID",             //  4
+    "CAP_KILL",               //  5
+    "CAP_SETGID",             //  6
+    "CAP_SETUID",             //  7
+    "CAP_SETPCAP",            //  8
+    "CAP_LINUX_IMMUTABLE",    //  9
+    "CAP_NET_BIND_SERVICE",   // 10
+    "CAP_NET_BROADCAST",      // 11
+    "CAP_NET_ADMIN",          // 12
+    "CAP_NET_RAW",            // 13
+    "CAP_IPC_LOCK",           // 14
+    "CAP_IPC_OWNER",          // 15
+    "CAP_SYS_MODULE",         // 16
+    "CAP_SYS_RAWIO",          // 17
+    "CAP_SYS_CHROOT",         // 18
+    "CAP_SYS_PTRACE",         // 19
+    "CAP_SYS_PACCT",          // 20
+    "CAP_SYS_ADMIN",          // 21
+    "CAP_SYS_BOOT",           // 22
+    "CAP_SYS_NICE",           // 23
+    "CAP_SYS_RESOURCE",       // 24
+    "CAP_SYS_TIME",           // 25
+    "CAP_SYS_TTY_CONFIG",     // 26
+    "CAP_MKNOD",              // 27
+    "CAP_LEASE",              // 28
+    "CAP_AUDIT_WRITE",        // 29
+    "CAP_AUDIT_CONTROL",      // 30
+    "CAP_SETFCAP",            // 31
+    "CAP_MAC_OVERRIDE",       // 32
+    "CAP_MAC_ADMIN",          // 33
+    "CAP_SYSLOG",             // 34
+    "CAP_WAKE_ALARM",         // 35
+    "CAP_BLOCK_SUSPEND",      // 36
+    "CAP_AUDIT_READ",         // 37
+    "CAP_PERFMON",            // 38
+    "CAP_BPF",                // 39
+    "CAP_CHECKPOINT_RESTORE", // 40
+    "CAP_41",
+    "CAP_42",
+    "CAP_43",
+    "CAP_44",
+    "CAP_45",
+    "CAP_46",
+    "CAP_47",
+    "CAP_48",
+    "CAP_49",
+    "CAP_50",
+    "CAP_51",
+    "CAP_52",
+    "CAP_53",
+    "CAP_54",
+    "CAP_55",
+    "CAP_56",
+    "CAP_57",
+    "CAP_58",
+    "CAP_59",
+    "CAP_60",
+    "CAP_61",
+    "CAP_62",
+    "CAP_63",
 };
 
 // Get a 64-bit set of capabilities of the given kind
 uint64_t get_capabilities(cap_flag_t kind) {
-  struct __user_cap_header_struct hdr{_LINUX_CAPABILITY_VERSION_3, 0};
+  struct __user_cap_header_struct hdr {
+    _LINUX_CAPABILITY_VERSION_3, 0
+  };
   struct __user_cap_data_struct data[2];
   memset(&data, 0, sizeof(data));
   int rc = ::syscall(SYS_capget, &hdr, &data, sizeof(data));
@@ -107,11 +108,11 @@ uint64_t get_capabilities(cap_flag_t kind) {
 }
 
 // dumpCaps returns the capabilities of the given kind in string form.
-size_t dump_capabilities(cap_flag_t kind, char *buf, size_t buf_size) {
+size_t dump_capabilities(cap_flag_t kind, char* buf, size_t buf_size) {
   size_t remaining = buf_size;
   uint64_t caps = get_capabilities(kind);
 
-  auto append = [&](const char *str) {
+  auto append = [&](const char* str) {
     auto len = strlen(str);
     if (len < remaining) {
       memcpy(buf, str, len);
@@ -119,8 +120,8 @@ size_t dump_capabilities(cap_flag_t kind, char *buf, size_t buf_size) {
       buf += len;
     }
   };
-  
-  for (int i=0, n=0; i < 64; i++) {
+
+  for (int i = 0, n = 0; i < 64; i++) {
     if (caps & (1UL << i)) {
       if (n > 0)
         append(", ");
@@ -132,9 +133,7 @@ size_t dump_capabilities(cap_flag_t kind, char *buf, size_t buf_size) {
   return buf_size - remaining;
 }
 
-Protocol::~Protocol() {
-  close();
-}
+Protocol::~Protocol() { close(); }
 
 Protocol::Protocol(int fd) : fd_(fd) {}
 
@@ -147,16 +146,16 @@ void Protocol::close() {
 
 namespace {
 
-static inline struct msghdr
-init_iov(struct iovec iov[2], const void *header, ssize_t headerlen, const void *data, ssize_t datalen) {
-  struct msghdr msg{};
+static inline struct msghdr init_iov(struct iovec iov[2], const void* header, ssize_t headerlen,
+                                     const void* data, ssize_t datalen) {
+  struct msghdr msg {};
   msg.msg_iov = iov;
   msg.msg_iovlen = 1;
-  iov[0].iov_base = const_cast<void *>(header);
+  iov[0].iov_base = const_cast<void*>(header);
   iov[0].iov_len = headerlen;
   if (data && datalen > 0) {
     msg.msg_iovlen = 2;
-    iov[1].iov_base = const_cast<void *>(data);
+    iov[1].iov_base = const_cast<void*>(data);
     iov[1].iov_len = datalen;
   }
   return msg;
@@ -164,44 +163,46 @@ init_iov(struct iovec iov[2], const void *header, ssize_t headerlen, const void 
 
 } // namespace
 
-ssize_t Protocol::send_fd_msg(const void *header, ssize_t headerlen, const void *data, ssize_t datalen, int fd) {
-  struct iovec  iov[2];
+ssize_t Protocol::send_fd_msg(const void* header, ssize_t headerlen, const void* data,
+                              ssize_t datalen, int fd) {
+  struct iovec iov[2];
   struct msghdr msg = init_iov(iov, header, headerlen, data, datalen);
   union {
-    struct cmsghdr  cmsghdr;
-    char            control[CMSG_SPACE(sizeof (int))];
+    struct cmsghdr cmsghdr;
+    char control[CMSG_SPACE(sizeof(int))];
   } cmsgu;
-  struct cmsghdr *cmsg;
+  struct cmsghdr* cmsg;
 
   // set up msg control for an fd?
   if (fd != -1) {
     msg.msg_control = cmsgu.control;
     msg.msg_controllen = sizeof(cmsgu.control);
     cmsg = CMSG_FIRSTHDR(&msg);
-    cmsg->cmsg_len = CMSG_LEN(sizeof (int));
+    cmsg->cmsg_len = CMSG_LEN(sizeof(int));
     cmsg->cmsg_level = SOL_SOCKET;
     cmsg->cmsg_type = SCM_RIGHTS;
-    *reinterpret_cast<int *>(CMSG_DATA(cmsg)) = fd;
+    *reinterpret_cast<int*>(CMSG_DATA(cmsg)) = fd;
   }
-  
+
   // send the request
   ssize_t size;
   do {
     size = sendmsg(fd_, &msg, 0);
   } while (size < 0 && errno == EINTR);
 
-  if (size >= 0 && size != headerlen+datalen) {
-    fprintf(stderr, "sendmsg truncated (%zd < %zd)\n", size, headerlen+datalen);
+  if (size >= 0 && size != headerlen + datalen) {
+    fprintf(stderr, "sendmsg truncated (%zd < %zd)\n", size, headerlen + datalen);
   }
   return size;
 }
 
-ssize_t Protocol::recv_fd_msg(const void *header, ssize_t headersize, const void *data, ssize_t datasize, int *fd) {
-  struct iovec  iov[2];
+ssize_t Protocol::recv_fd_msg(const void* header, ssize_t headersize, const void* data,
+                              ssize_t datasize, int* fd) {
+  struct iovec iov[2];
   struct msghdr msg = init_iov(iov, header, headersize, data, datasize);
   union {
     struct cmsghdr cmsghdr;
-    char           control[CMSG_SPACE(sizeof (int))];
+    char control[CMSG_SPACE(sizeof(int))];
   } cmsgu;
   msg.msg_control = cmsgu.control;
   msg.msg_controllen = sizeof(cmsgu.control);
@@ -212,10 +213,10 @@ ssize_t Protocol::recv_fd_msg(const void *header, ssize_t headersize, const void
   } while (size < 0 && errno == EINTR);
 
   if (size >= 0 && fd) {
-    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
-    if (cmsg && cmsg->cmsg_len == CMSG_LEN(sizeof(int)) &&
-        cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
-      *fd = *reinterpret_cast<int *>(CMSG_DATA(cmsg));
+    struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+    if (cmsg && cmsg->cmsg_len == CMSG_LEN(sizeof(int)) && cmsg->cmsg_level == SOL_SOCKET &&
+        cmsg->cmsg_type == SCM_RIGHTS) {
+      *fd = *reinterpret_cast<int*>(CMSG_DATA(cmsg));
     } else {
       *fd = -1;
     }

--- a/starter/privileged_service_protocol.h
+++ b/starter/privileged_service_protocol.h
@@ -4,40 +4,39 @@
 #error "Linux platform file is part of non-Linux build."
 #endif
 
+#include <linux/capability.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <linux/capability.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 
 // Use Envoy version of this if defined, otherwise roll a simple stderr one without further
 // dependencies
 #ifndef RELEASE_ASSERT
-#define _ASSERT_IMPL(CONDITION, CONDITION_STR, DETAILS)			\
-  do {									\
-    if (!(CONDITION)) {							\
-      fprintf(stderr, "assert failure: %s. Details: %s", CONDITION_STR, (DETAILS)); \
-      ::abort();							\
-    }									\
+#define _ASSERT_IMPL(CONDITION, CONDITION_STR, DETAILS)                                            \
+  do {                                                                                             \
+    if (!(CONDITION)) {                                                                            \
+      fprintf(stderr, "assert failure: %s. Details: %s", CONDITION_STR, (DETAILS));                \
+      ::abort();                                                                                   \
+    }                                                                                              \
   } while (false)
 #define RELEASE_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, DETAILS)
 #endif
 
 // Kernel headers may miss CAP_BPF added in Linux 5.8
 #ifndef CAP_BPF
-#define CAP_BPF                 39
+#define CAP_BPF 39
 #endif
 
 #ifndef _SYS_CAPABILITY_H
-// These are normally defined in <sys/capability.h> added in libcap-dev package.  Define these here
+// These are normally defined in <sys/capability.h> added in libcap-dev package. Define these here
 // to avoid that dependency due to complications in cross-compilation for Intel/Arm.
 typedef enum {
-    CAP_EFFECTIVE = 0,                 /* Specifies the effective flag */
-    CAP_PERMITTED = 1,                 /* Specifies the permitted flag */
-    CAP_INHERITABLE = 2                /* Specifies the inheritable flag */
+  CAP_EFFECTIVE = 0,  /* Specifies the effective flag */
+  CAP_PERMITTED = 1,  /* Specifies the permitted flag */
+  CAP_INHERITABLE = 2 /* Specifies the inheritable flag */
 } cap_flag_t;
 #endif
 
@@ -46,7 +45,7 @@ namespace Cilium {
 namespace PrivilegedService {
 
 uint64_t get_capabilities(cap_flag_t kind);
-size_t dump_capabilities(cap_flag_t kind, char *buf, size_t buf_size);
+size_t dump_capabilities(cap_flag_t kind, char* buf, size_t buf_size);
 
 #define CILIUM_PRIVILEGED_SERVICE_FD 3
 
@@ -89,7 +88,6 @@ struct Response {
   uint8_t data_[];
 };
 
-
 // Dump requests consists only of the message header, but with the TYPE_DUMP_REQUEST.
 // Response contains the effective capabilitites in a string form.
 struct DumpRequest {
@@ -123,8 +121,8 @@ struct BpfLookupRequest {
 // SetSockOptRequest only supports setting 4-byte options.
 // Response is SyscallResponse.
 struct SetSockOptRequest {
-  SetSockOptRequest(int level, int optname, const void *optval, socklen_t optlen)
-    : hdr_(TYPE_SETSOCKOPT32_REQUEST), level_(level), optname_(optname) {
+  SetSockOptRequest(int level, int optname, const void* optval, socklen_t optlen)
+      : hdr_(TYPE_SETSOCKOPT32_REQUEST), level_(level), optname_(optname) {
     RELEASE_ASSERT(optlen == sizeof(uint32_t), "optlen must be 4 bytes");
     memcpy(&optval_, optval, optlen);
   }
@@ -144,10 +142,10 @@ public:
   void close();
   bool is_open() const { return fd_ != -1; }
 
-  ssize_t send_fd_msg(const void *header, ssize_t headerlen,
-		      const void *data = nullptr, ssize_t datalen = 0, int fd = -1);
-  ssize_t recv_fd_msg(const void *header, ssize_t headersize,
-		      const void *data = nullptr, ssize_t datasize = 0, int *fd = nullptr);
+  ssize_t send_fd_msg(const void* header, ssize_t headerlen, const void* data = nullptr,
+                      ssize_t datalen = 0, int fd = -1);
+  ssize_t recv_fd_msg(const void* header, ssize_t headersize, const void* data = nullptr,
+                      ssize_t datasize = 0, int* fd = nullptr);
 
 protected:
   int fd_;

--- a/starter/privileged_service_server.h
+++ b/starter/privileged_service_server.h
@@ -28,7 +28,7 @@ private:
     BpfOpenRequest bpf_open_req;
     BpfLookupRequest bpf_lookup_req;
     SetSockOptRequest setsockopt_req;
-      
+
     // resposes use the same buffer, so they inherit the message sequence number from the request
     Response response;
 
@@ -36,7 +36,7 @@ private:
     char buf[sizeof(BpfOpenRequest) + PATH_MAX + 1];
   };
 
-  int pid_;  // child pid
+  int pid_; // child pid
 };
 
 } // namespace PrivilegedService

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -287,9 +287,9 @@ envoy_cc_test(
 envoy_cc_test(
     name = "health_check_sink_test",
     srcs = [
-        "health_check_sink_test.cc",
-        "health_check_sink_server.h",
         "health_check_sink_server.cc",
+        "health_check_sink_server.h",
+        "health_check_sink_test.cc",
     ],
     repository = "@envoy",
     deps = [

--- a/tests/accesslog_server.cc
+++ b/tests/accesslog_server.cc
@@ -15,8 +15,8 @@
 
 namespace Envoy {
 
-AccessLogServer::AccessLogServer(const std::string path) :
-    UDSServer(path, std::bind(&AccessLogServer::msgCallback, this, std::placeholders::_1)) {}
+AccessLogServer::AccessLogServer(const std::string path)
+    : UDSServer(path, std::bind(&AccessLogServer::msgCallback, this, std::placeholders::_1)) {}
 
 AccessLogServer::~AccessLogServer() {}
 

--- a/tests/accesslog_server.h
+++ b/tests/accesslog_server.h
@@ -13,7 +13,6 @@
 #include "absl/synchronization/mutex.h"
 #include "absl/types/optional.h"
 #include "cilium/api/accesslog.pb.h"
-
 #include "tests/uds_server.h"
 
 namespace Envoy {

--- a/tests/accesslog_test.cc
+++ b/tests/accesslog_test.cc
@@ -1,4 +1,5 @@
 #include <cstdint>
+
 #include "envoy/http/protocol.h"
 
 #include "source/common/network/address_impl.h"

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -1,8 +1,8 @@
 #include "tests/bpf_metadata.h"
 
 #include "source/common/common/logger.h"
-#include "source/extensions/config_subscription/filesystem/filesystem_subscription_impl.h"
 #include "source/common/config/utility.h"
+#include "source/extensions/config_subscription/filesystem/filesystem_subscription_impl.h"
 
 #include "test/test_common/environment.h"
 
@@ -172,10 +172,9 @@ bool TestConfig::getMetadata(Network::ConnectionSocket& socket) {
     ENVOY_LOG_MISC(info, "setRequestedApplicationProtocols({})", l7proto);
   }
 
-  socket.addOption(std::make_shared<Cilium::SocketOption>(policy, 0, 0, source_identity,
-                                                          is_ingress_, false, port,
-                                                          std::move(pod_ip), nullptr,
-                                                          nullptr, nullptr, shared_from_this()));
+  socket.addOption(std::make_shared<Cilium::SocketOption>(
+      policy, 0, 0, source_identity, is_ingress_, false, port, std::move(pod_ip), nullptr, nullptr,
+      nullptr, shared_from_this()));
 
   return true;
 }

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -23,19 +23,21 @@ protected:
   ~CiliumNetworkPolicyTest() override {}
 
   void SetUp() override {
-    // Mock SDS secrets with a real implementation, which will not return anything if there is no SDS server.
-    // This is only useful for testing functionality with a missing secret.
-    auto& secret_manager = factory_context_.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+    // Mock SDS secrets with a real implementation, which will not return anything if there is no
+    // SDS server. This is only useful for testing functionality with a missing secret.
+    auto& secret_manager = factory_context_.server_factory_context_.cluster_manager_
+                               .cluster_manager_factory_.secretManager();
     ON_CALL(secret_manager, findOrCreateGenericSecretProvider(_, _, _, _))
-      .WillByDefault(Invoke([](const envoy::config::core::v3::ConfigSource& sds_config_source,
-			       const std::string& config_name,
-			       Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
-			       Init::Manager& init_manager) {
-	auto secret_provider = Secret::GenericSecretSdsApi::create(secret_provider_context, sds_config_source,
-								   config_name, [](){});
-	init_manager.add(*secret_provider->initTarget());
-	return secret_provider;
-      }));
+        .WillByDefault(
+            Invoke([](const envoy::config::core::v3::ConfigSource& sds_config_source,
+                      const std::string& config_name,
+                      Server::Configuration::TransportSocketFactoryContext& secret_provider_context,
+                      Init::Manager& init_manager) {
+              auto secret_provider = Secret::GenericSecretSdsApi::create(
+                  secret_provider_context, sds_config_source, config_name, []() {});
+              init_manager.add(*secret_provider->initTarget());
+              return secret_provider;
+            }));
 
     policy_map_ = std::make_shared<NetworkPolicyMap>(factory_context_);
   }

--- a/tests/cilium_tls_http_integration_test.cc
+++ b/tests/cilium_tls_http_integration_test.cc
@@ -254,7 +254,8 @@ public:
 
     static auto* upstream_stats_store = new Stats::IsolatedStoreImpl();
     return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
-        std::move(cfg), context_manager_, *upstream_stats_store->rootScope(), std::vector<std::string>{});
+        std::move(cfg), context_manager_, *upstream_stats_store->rootScope(),
+        std::vector<std::string>{});
   }
 
   std::string testPolicyFmt() override {

--- a/tests/cilium_tls_integration.cc
+++ b/tests/cilium_tls_integration.cc
@@ -34,8 +34,8 @@ createClientSslTransportSocketFactory(Ssl::ContextManager& context_manager, Api:
       tls_context, mock_factory_ctx);
   static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
   return Network::UpstreamTransportSocketFactoryPtr{
-      new Extensions::TransportSockets::Tls::ClientSslSocketFactory(std::move(cfg), context_manager,
-                                                                    *client_stats_store->rootScope())};
+      new Extensions::TransportSockets::Tls::ClientSslSocketFactory(
+          std::move(cfg), context_manager, *client_stats_store->rootScope())};
 }
 
 } // namespace Cilium

--- a/tests/cilium_tls_tcp_integration_test.cc
+++ b/tests/cilium_tls_tcp_integration_test.cc
@@ -115,7 +115,8 @@ public:
 
     static auto* upstream_stats_store = new Stats::IsolatedStoreImpl();
     return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
-        std::move(cfg), context_manager_, *upstream_stats_store->rootScope(), std::vector<std::string>{});
+        std::move(cfg), context_manager_, *upstream_stats_store->rootScope(),
+        std::vector<std::string>{});
   }
 
   void setupConnections() {

--- a/tests/health_check_sink_server.cc
+++ b/tests/health_check_sink_server.cc
@@ -15,8 +15,9 @@
 
 namespace Envoy {
 
-HealthCheckSinkServer::HealthCheckSinkServer(const std::string path) :
-    UDSServer(path, std::bind(&HealthCheckSinkServer::msgCallback, this, std::placeholders::_1)) {}
+HealthCheckSinkServer::HealthCheckSinkServer(const std::string path)
+    : UDSServer(path, std::bind(&HealthCheckSinkServer::msgCallback, this, std::placeholders::_1)) {
+}
 
 HealthCheckSinkServer::~HealthCheckSinkServer() {}
 

--- a/tests/health_check_sink_server.h
+++ b/tests/health_check_sink_server.h
@@ -15,7 +15,6 @@
 
 #include "absl/synchronization/mutex.h"
 #include "absl/types/optional.h"
-
 #include "tests/uds_server.h"
 
 namespace Envoy {

--- a/tests/health_check_sink_test.cc
+++ b/tests/health_check_sink_test.cc
@@ -1,10 +1,7 @@
-#include "cilium/api/health_check_sink.pb.h"
-#include "cilium/api/health_check_sink.pb.validate.h"
 #include "envoy/registry/registry.h"
 
 #include "source/common/common/logger.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "cilium/health_check_sink.h"
 
 #include "test/mocks/access_log/mocks.h"
 #include "test/mocks/event/mocks.h"
@@ -12,9 +9,11 @@
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/utility.h"
 
+#include "cilium/api/health_check_sink.pb.h"
+#include "cilium/api/health_check_sink.pb.validate.h"
+#include "cilium/health_check_sink.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
 #include "tests/health_check_sink_server.h"
 
 using testing::SaveArg;
@@ -23,8 +22,9 @@ namespace Envoy {
 namespace Cilium {
 
 TEST(HealthCheckEventPipeSinkFactory, createHealthCheckEventSink) {
-  auto factory = Envoy::Registry::FactoryRegistry<Upstream::HealthCheckEventSinkFactory>::getFactory(
-      "cilium.health_check.event_sink.pipe");
+  auto factory =
+      Envoy::Registry::FactoryRegistry<Upstream::HealthCheckEventSinkFactory>::getFactory(
+          "cilium.health_check.event_sink.pipe");
   EXPECT_NE(factory, nullptr);
 
   cilium::HealthCheckEventPipeSink config;
@@ -37,8 +37,9 @@ TEST(HealthCheckEventPipeSinkFactory, createHealthCheckEventSink) {
 }
 
 TEST(HealthCheckEventPipeSinkFactory, createEmptyHealthCheckEventSink) {
-  auto factory = Envoy::Registry::FactoryRegistry<Upstream::HealthCheckEventSinkFactory>::getFactory(
-      "cilium.health_check.event_sink.pipe");
+  auto factory =
+      Envoy::Registry::FactoryRegistry<Upstream::HealthCheckEventSinkFactory>::getFactory(
+          "cilium.health_check.event_sink.pipe");
   EXPECT_NE(factory, nullptr);
   auto empty_proto = factory->createEmptyConfigProto();
   auto config = *dynamic_cast<cilium::HealthCheckEventPipeSink*>(empty_proto.get());
@@ -77,9 +78,10 @@ TEST(HealthCheckEventPipeSink, logTest) {
                             eject_event);
 
   pipe_sink.log(eject_event);
-  EXPECT_TRUE(eventSink.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
-    return Protobuf::util::MessageDifferencer::Equals(observed_event, eject_event);
-  }));
+  EXPECT_TRUE(
+      eventSink.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
+        return Protobuf::util::MessageDifferencer::Equals(observed_event, eject_event);
+      }));
 
   // Set up 2nd client on the same socket
   HealthCheckEventPipeSink pipe_sink2(config);
@@ -102,14 +104,15 @@ TEST(HealthCheckEventPipeSink, logTest) {
                             add_event);
 
   pipe_sink2.log(add_event);
-  EXPECT_TRUE(eventSink.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
-    return Protobuf::util::MessageDifferencer::Equals(observed_event, add_event);
-  }));
+  EXPECT_TRUE(
+      eventSink.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
+        return Protobuf::util::MessageDifferencer::Equals(observed_event, add_event);
+      }));
 
   // Set up another server on a different socket in an abstract namespace
   // Set up server
 #define ABSTRACT_PATH "@another\0test_path"
-  std::string abstract_name(ABSTRACT_PATH, sizeof(ABSTRACT_PATH)-1);
+  std::string abstract_name(ABSTRACT_PATH, sizeof(ABSTRACT_PATH) - 1);
   HealthCheckSinkServer eventSink3(abstract_name);
 
   // Set up 3rd client on a different socket
@@ -118,10 +121,11 @@ TEST(HealthCheckEventPipeSink, logTest) {
   HealthCheckEventPipeSink pipe_sink3(config3);
 
   pipe_sink3.log(eject_event);
-  EXPECT_TRUE(eventSink3.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
-    return Protobuf::util::MessageDifferencer::Equals(observed_event, eject_event);
-  }));
+  EXPECT_TRUE(
+      eventSink3.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
+        return Protobuf::util::MessageDifferencer::Equals(observed_event, eject_event);
+      }));
 }
 
-} // namespace Upstream
+} // namespace Cilium
 } // namespace Envoy

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -406,7 +406,6 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadataNoOriginalSource) {
   EXPECT_TRUE((option->mark_ & 0xffff) == 0x0B00 && (option->mark_ >> 16) == 8);
 }
 
-
 } // namespace
 } // namespace Cilium
 } // namespace Envoy


### PR DESCRIPTION
Add `starter` and `vendor` to the list of excluded directories and apply `make fix`.

This helps make future PRs cleaner, and allows to add a CI step for format check.