### PR TITLE
renovate: pin ubuntu to version 22.04 in dockerfile on v1.26

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,7 +56,8 @@
       ],
       "allowedVersions": "22.04",
       "matchBaseBranches": [
-        "main"
+        "main",
+        "v1.26",
       ]
     },
     {


### PR DESCRIPTION
This comit pins the ubuntu version to 22.04 on v1.26.