### PR TITLE
rennovate: Drop the auto-update configuration for v1.24

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,6 @@
     "main",
     "v1.26",
     "v1.25",
-    "v1.24",
   ],
   "labels": [
     "kind/enhancement",
@@ -82,7 +81,6 @@
         "main",
         "v1.26",
         "v1.25",
-        "v1.24",
       ]
     },
     {
@@ -113,16 +111,6 @@
       "allowedVersions": "<=1.25",
       "matchBaseBranches": [
         "v1.25"
-      ]
-    },
-    {
-      "groupName": "envoy 1.24.x",
-      "matchDepNames": [
-        "envoyproxy/envoy"
-      ],
-      "allowedVersions": "<=1.24",
-      "matchBaseBranches": [
-        "v1.24"
       ]
     },
     {


### PR DESCRIPTION
Envoy v1.24 is EOL as per the below, so we don't need to update v1.24 anymore.

https://github.com/envoyproxy/envoy/blob/main/RELEASES.md#major-release-schedule