### PR TITLE
github: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cilium/envoy


### PR DESCRIPTION
This will help with review assignment automatically. We can start with the simple rule (e.g. cilium/proxy team is the owner), and improve if required later.

cc @cilium/proxy 