### PR TITLE
ci: fix cilium integration test (patching dockerfile)

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -140,7 +140,7 @@ jobs:
       - name: Patch Cilium Agent Dockerfile
         shell: bash
         run: |
-          sed -i -E 's|(FROM )(quay\.io\/cilium\/cilium-envoy:)(.*)(@sha256:[0-9a-z]*)( as cilium-envoy)|\1${{ env.PROXY_IMAGE }}:${{ env.PROXY_TAG }}\5|' ./images/cilium/Dockerfile
+          sed -i -E 's|(ARG CILIUM_ENVOY_IMAGE=)(quay\.io\/cilium\/cilium-envoy:)(.*)(@sha256:[0-9a-z]*)|\1${{ env.PROXY_IMAGE }}:${{ env.PROXY_TAG }}|' ./images/cilium/Dockerfile
           cat ./images/cilium/Dockerfile
           if git diff --exit-code ./images/cilium/Dockerfile; then
             echo "Dockerfile not modified"


### PR DESCRIPTION
Currently, patching the Cilium Agent Dockerfile with the development proxy image fails due to changes in the Dockerfile (introduced with https://github.com/cilium/cilium/pull/29638).

Therefore, this commit fixes the `sed` command that patches the Dockerfile.