### PR TITLE
patches: Call sendLocalReply via UpstreamFilterManager

### DIFF
--- a/patches/0001-network-Add-callback-for-upstream-authorization.patch
+++ b/patches/0001-network-Add-callback-for-upstream-authorization.patch
@@ -1,4 +1,4 @@
-From 372e6203c5f1a999e9c410995ad57495cfe70d2d Mon Sep 17 00:00:00 2001
+From 61fe43076c93a95f9628f1a5f1f14c51e78fc741 Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
 Date: Mon, 24 Jan 2022 15:40:28 +0200
 Subject: [PATCH 1/4] network: Add callback for upstream authorization
@@ -44,10 +44,10 @@ index 361eacc244..88123f71b2 100644
  
  /**
 diff --git a/envoy/network/filter.h b/envoy/network/filter.h
-index c1fa3a3b9e..4d1809fdc5 100644
+index 221578898f..0d892ea81d 100644
 --- a/envoy/network/filter.h
 +++ b/envoy/network/filter.h
-@@ -112,6 +112,22 @@ public:
+@@ -116,6 +116,22 @@ public:
  
  using WriteFilterSharedPtr = std::shared_ptr<WriteFilter>;
  
@@ -70,7 +70,7 @@ index c1fa3a3b9e..4d1809fdc5 100644
  /**
   * Callbacks used by individual read filter instances to communicate with the filter manager.
   */
-@@ -170,6 +186,18 @@ public:
+@@ -174,6 +190,18 @@ public:
     * mode to secure mode.
     */
    virtual bool startUpstreamSecureTransport() PURE;
@@ -106,10 +106,10 @@ index 200ec7fc9e..a1bf9b0542 100644
  
  // An API for the UpstreamRequest to get callbacks from either an HTTP or TCP
 diff --git a/source/common/http/async_client_impl.h b/source/common/http/async_client_impl.h
-index 83cee970b4..b55a169101 100644
+index 4d5c80527a..c3849b092f 100644
 --- a/source/common/http/async_client_impl.h
 +++ b/source/common/http/async_client_impl.h
-@@ -482,6 +482,10 @@ private:
+@@ -254,6 +254,10 @@ private:
    void setUpstreamOverrideHost(absl::string_view) override {}
    absl::optional<absl::string_view> upstreamOverrideHost() const override { return {}; }
    absl::string_view filterConfigName() const override { return ""; }
@@ -121,10 +121,10 @@ index 83cee970b4..b55a169101 100644
    // ScopeTrackedObject
    void dumpState(std::ostream& os, int indent_level) const override {
 diff --git a/source/common/http/conn_manager_impl.h b/source/common/http/conn_manager_impl.h
-index b82b1967a5..e55a1f803c 100644
+index 143f425000..896e7051c8 100644
 --- a/source/common/http/conn_manager_impl.h
 +++ b/source/common/http/conn_manager_impl.h
-@@ -317,6 +317,12 @@ private:
+@@ -329,6 +329,12 @@ private:
      }
  
      absl::optional<Router::ConfigConstSharedPtr> routeConfig();
@@ -138,10 +138,10 @@ index b82b1967a5..e55a1f803c 100644
  
      // Updates the snapped_route_config_ (by reselecting scoped route configuration), if a scope is
 diff --git a/source/common/http/filter_manager.cc b/source/common/http/filter_manager.cc
-index 5f71e1cfb5..2190b0b2fe 100644
+index fbe7277b9a..5c46a28091 100644
 --- a/source/common/http/filter_manager.cc
 +++ b/source/common/http/filter_manager.cc
-@@ -1720,5 +1720,11 @@ absl::optional<absl::string_view> ActiveStreamDecoderFilter::upstreamOverrideHos
+@@ -1759,5 +1759,11 @@ absl::optional<absl::string_view> ActiveStreamDecoderFilter::upstreamOverrideHos
    return parent_.upstream_override_host_;
  }
  
@@ -154,10 +154,10 @@ index 5f71e1cfb5..2190b0b2fe 100644
  } // namespace Http
  } // namespace Envoy
 diff --git a/source/common/http/filter_manager.h b/source/common/http/filter_manager.h
-index 610ca49fd9..3fc168de60 100644
+index b276327444..3329051489 100644
 --- a/source/common/http/filter_manager.h
 +++ b/source/common/http/filter_manager.h
-@@ -240,6 +240,8 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
+@@ -241,6 +241,8 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
    Buffer::BufferMemoryAccountSharedPtr account() const override;
    void setUpstreamOverrideHost(absl::string_view host) override;
    absl::optional<absl::string_view> upstreamOverrideHost() const override;
@@ -166,7 +166,7 @@ index 610ca49fd9..3fc168de60 100644
  
    // Each decoder filter instance checks if the request passed to the filter is gRPC
    // so that we can issue gRPC local responses to gRPC requests. Filter's decodeHeaders()
-@@ -518,6 +520,12 @@ public:
+@@ -519,6 +521,12 @@ public:
     * Returns a handle to the downstream callbacks, if available.
     */
    virtual OptRef<DownstreamStreamFilterCallbacks> downstreamCallbacks() { return {}; }
@@ -219,10 +219,10 @@ index 27bc856921..9bc7adb691 100644
    const Socket& socket_;
    Upstream::HostDescriptionConstSharedPtr host_description_;
 diff --git a/source/common/router/router.cc b/source/common/router/router.cc
-index 82dea84326..754a43c9cd 100644
+index 13dd915e10..161e8be036 100644
 --- a/source/common/router/router.cc
 +++ b/source/common/router/router.cc
-@@ -622,6 +622,14 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
+@@ -664,6 +664,14 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
      return Http::FilterHeadersStatus::StopIteration;
    }
  
@@ -254,10 +254,10 @@ index a91b75c833..33b57fa641 100644
    StreamInfo::StreamInfo& upstreamStreamInfo() override { return upstream_request_.streamInfo(); }
    OptRef<GenericUpstream> upstream() override {
 diff --git a/source/common/tcp_proxy/tcp_proxy.cc b/source/common/tcp_proxy/tcp_proxy.cc
-index 4d611627a3..f40b5bdb2d 100644
+index 0b07d56cd6..16afd76f5b 100644
 --- a/source/common/tcp_proxy/tcp_proxy.cc
 +++ b/source/common/tcp_proxy/tcp_proxy.cc
-@@ -518,6 +518,13 @@ bool Filter::maybeTunnel(Upstream::ThreadLocalCluster& cluster) {
+@@ -530,6 +530,13 @@ bool Filter::maybeTunnel(Upstream::ThreadLocalCluster& cluster) {
    generic_conn_pool_ = factory->createGenericConnPool(cluster, config_->tunnelingConfigHelper(),
                                                        this, *upstream_callbacks_, getStreamInfo());
    if (generic_conn_pool_) {
@@ -272,10 +272,10 @@ index 4d611627a3..f40b5bdb2d 100644
      connect_attempts_++;
      getStreamInfo().setAttemptCount(connect_attempts_);
 diff --git a/source/common/tcp_proxy/tcp_proxy.h b/source/common/tcp_proxy/tcp_proxy.h
-index 4ce8a350ab..6abaea2f6c 100644
+index ae360352de..41697d2f0d 100644
 --- a/source/common/tcp_proxy/tcp_proxy.h
 +++ b/source/common/tcp_proxy/tcp_proxy.h
-@@ -481,6 +481,7 @@ protected:
+@@ -486,6 +486,7 @@ protected:
      NoHealthyUpstream,
      ResourceLimitExceeded,
      NoRoute,
@@ -284,10 +284,10 @@ index 4ce8a350ab..6abaea2f6c 100644
  
    // Callbacks for different error and success states during connection establishment
 diff --git a/source/common/tcp_proxy/upstream.cc b/source/common/tcp_proxy/upstream.cc
-index ea9e2ba73e..1997b84166 100644
+index 82c389d6fa..fd6b7043bf 100644
 --- a/source/common/tcp_proxy/upstream.cc
 +++ b/source/common/tcp_proxy/upstream.cc
-@@ -191,6 +191,10 @@ void TcpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
+@@ -192,6 +192,10 @@ void TcpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
    }
  }
  
@@ -298,7 +298,7 @@ index ea9e2ba73e..1997b84166 100644
  void TcpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason,
                                  absl::string_view failure_reason,
                                  Upstream::HostDescriptionConstSharedPtr host) {
-@@ -258,6 +262,10 @@ void HttpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
+@@ -259,6 +263,10 @@ void HttpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
    }
  }
  
@@ -310,7 +310,7 @@ index ea9e2ba73e..1997b84166 100644
                                   absl::string_view failure_reason,
                                   Upstream::HostDescriptionConstSharedPtr host) {
 diff --git a/source/common/tcp_proxy/upstream.h b/source/common/tcp_proxy/upstream.h
-index feeea15a56..ef56d69d29 100644
+index 5532f81480..621651503a 100644
 --- a/source/common/tcp_proxy/upstream.h
 +++ b/source/common/tcp_proxy/upstream.h
 @@ -29,6 +29,7 @@ public:
@@ -330,7 +330,7 @@ index feeea15a56..ef56d69d29 100644
    // Http::ConnectionPool::Callbacks,
    void onPoolFailure(ConnectionPool::PoolFailureReason reason,
 diff --git a/source/server/api_listener_impl.h b/source/server/api_listener_impl.h
-index fb787f8172..b37cdc9e85 100644
+index ee2038d454..9493b9cb7b 100644
 --- a/source/server/api_listener_impl.h
 +++ b/source/server/api_listener_impl.h
 @@ -76,6 +76,9 @@ protected:

--- a/patches/0002-upstream-Add-callback-for-upstream-authorization.patch
+++ b/patches/0002-upstream-Add-callback-for-upstream-authorization.patch
@@ -1,15 +1,16 @@
-From 2aaec87a26464142252888f9f04e3f50bc2542be Mon Sep 17 00:00:00 2001
+From 09806206d57c2cd4d124416ce57104d62e1157ed Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
-Date: Fri, 21 Jan 2022 15:42:00 +0200
+Date: Fri, 23 Feb 2024 15:14:02 +0100
 Subject: [PATCH 2/4] upstream: Add callback for upstream authorization
 
 Add new StreamDecoderFilterCallbacks addUpstreamCallback() and
 iterateUpstreamCallbacks(). Decoder filters can add callbacks using
 addUpstreamCallback(), which will then get called after an upstream
 connection has been established and all header transformations have been
-performed, and just before upstream headers are encoded by the
-router. If any of the callbacks returns 'false', the router will issue
-a 403 local response instead of encoding the request upstream.
+performed, and just before upstream headers are encoded by the router
+(encodeHeaders() call). If any of the callbacks returns 'false', the
+router will issue a 403 local response instead of encoding the request
+upstream.
 
 This allows HTTP decoder filters to perform policy enforcement on the
 upstream requests taking effect after all potential header
@@ -20,13 +21,6 @@ adding the callback, as the calls to the callbacks are only ever be
 done from the router filter in the same filter chain.
 
 Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
----
- envoy/http/filter.h                      | 30 ++++++++++++++++++++++++
- source/common/http/async_client_impl.h   |  5 ++++
- source/common/http/filter_manager.cc     | 22 +++++++++++++++++
- source/common/http/filter_manager.h      |  8 +++++++
- source/common/router/upstream_request.cc |  9 +++++++
- 5 files changed, 74 insertions(+)
 
 diff --git a/envoy/http/filter.h b/envoy/http/filter.h
 index 88123f71b2..7b529bec55 100644
@@ -117,7 +111,7 @@ index 5c46a28091..2d5a2d9983 100644
    // If this is called it means the call to requestDataTooLarge() was a
    // streaming call, or a 413 would have been sent.
 @@ -1765,5 +1778,14 @@ bool ActiveStreamDecoderFilter::iterateUpstreamCallbacks(Upstream::HostDescripti
-
+ 
  }
  
 +void ActiveStreamDecoderFilter::addUpstreamCallback(const UpstreamCallback& cb) {
@@ -132,7 +126,7 @@ index 5c46a28091..2d5a2d9983 100644
  } // namespace Http
  } // namespace Envoy
 diff --git a/source/common/http/filter_manager.h b/source/common/http/filter_manager.h
-index 3329051489..207de4faab 100644
+index 3329051489..fd3b2b74db 100644
 --- a/source/common/http/filter_manager.h
 +++ b/source/common/http/filter_manager.h
 @@ -243,6 +243,9 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
@@ -150,7 +144,7 @@ index 3329051489..207de4faab 100644
    }
  
 +  void addUpstreamCallback(const UpstreamCallback&);
-+  bool iterateUpstreamCallbacks(Http::RequestHeaderMap&, StreamInfo::StreamInfo&);
++  virtual bool iterateUpstreamCallbacks(Http::RequestHeaderMap&, StreamInfo::StreamInfo&);
 +
    FilterManagerCallbacks& filter_manager_callbacks_;
    Event::Dispatcher& dispatcher_;
@@ -164,26 +158,46 @@ index 3329051489..207de4faab 100644
    std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
    std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;
    std::list<StreamFilterBase*> filters_;
-diff --git a/source/common/router/upstream_request.cc b/source/common/router/upstream_request.cc
-index 5ba6402235..dc1be68e2d 100644
---- a/source/common/router/upstream_request.cc
-+++ b/source/common/router/upstream_request.cc
-@@ -673,6 +673,15 @@ void UpstreamRequest::onPoolReady(std::unique_ptr<GenericUpstream>&& upstream,
-     upstreamLog(AccessLog::AccessLogType::UpstreamPoolReady);
+diff --git a/source/common/router/upstream_codec_filter.cc b/source/common/router/upstream_codec_filter.cc
+index 158d2b7297..8aee672826 100644
+--- a/source/common/router/upstream_codec_filter.cc
++++ b/source/common/router/upstream_codec_filter.cc
+@@ -58,6 +58,15 @@ Http::FilterHeadersStatus UpstreamCodecFilter::decodeHeaders(Http::RequestHeader
+     return Http::FilterHeadersStatus::StopAllIterationAndWatermark;
    }
  
-+  bool accepted = parent_.callbacks()->iterateUpstreamCallbacks(*parent_.downstreamHeaders(),
-+                                                                stream_info_);
++  // This block has to be right before the encodeHeaders() (and any related logging) call below!
++  bool accepted = callbacks_->iterateUpstreamCallbacks(headers, callbacks_->streamInfo());
 +  if (!accepted) {
-+    stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
-+    parent_.callbacks()->sendLocalReply(Http::Code::Forbidden, "Access denied\r\n",
-+                                        nullptr, absl::nullopt, absl::string_view());
-+    return;
++    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
++    callbacks_->sendLocalReply(Http::Code::Forbidden, "Access denied\r\n", nullptr,
++                               absl::nullopt, absl::string_view());
++    return Http::FilterHeadersStatus::StopIteration;
 +  }
 +
-   if (address_provider.connectionID() && stream_info_.downstreamAddressProvider().connectionID()) {
-     ENVOY_LOG(debug, "Attached upstream connection [C{}] to downstream connection [C{}]",
-               address_provider.connectionID().value(),
---
-2.43.2
+   ENVOY_STREAM_LOG(trace, "proxying headers", *callbacks_);
+   calling_encode_headers_ = true;
+   const Http::Status status =
+diff --git a/source/common/router/upstream_request.cc b/source/common/router/upstream_request.cc
+index 5ba6402235..750eccec7d 100644
+--- a/source/common/router/upstream_request.cc
++++ b/source/common/router/upstream_request.cc
+@@ -75,6 +75,15 @@ public:
+                                                           details);
+   }
+   void executeLocalReplyIfPrepared() override {}
++
++  // Iterate upstream callbacks set on the downstream filter manager.
++  // Any upstream callbacks set by upstream filters will be ignored.
++  bool iterateUpstreamCallbacks(Http::RequestHeaderMap& headers,
++                                StreamInfo::StreamInfo& stream_info) override {
++    return upstream_request_.parent_.callbacks()->iterateUpstreamCallbacks(headers,
++									   stream_info);
++  }
++
+   UpstreamRequest& upstream_request_;
+ };
+ 
+-- 
+2.41.0
 

--- a/patches/0003-tcp_proxy-Add-filter-state-proxy_read_before_connect.patch
+++ b/patches/0003-tcp_proxy-Add-filter-state-proxy_read_before_connect.patch
@@ -1,4 +1,4 @@
-From c22e7ed504dcf2e70d4a8d151fb988e8bb2cca76 Mon Sep 17 00:00:00 2001
+From 1f21dbe5c06523fab39c50019fddd2c0052b0eb8 Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
 Date: Tue, 27 Sep 2022 15:51:46 +0300
 Subject: [PATCH 3/4] tcp_proxy: Add filter state proxy_read_before_connect
@@ -153,10 +153,10 @@ index 41697d2f0d..41f02eaf51 100644
  
  // This class deals with an upstream connection that needs to finish flushing, when the downstream
 diff --git a/test/integration/BUILD b/test/integration/BUILD
-index 6b33bb785b..058025c829 100644
+index d666674781..08eee106e2 100644
 --- a/test/integration/BUILD
 +++ b/test/integration/BUILD
-@@ -1755,6 +1755,7 @@ envoy_cc_test(
+@@ -1757,6 +1757,7 @@ envoy_cc_test(
          "//source/common/event:dispatcher_includes",
          "//source/common/event:dispatcher_lib",
          "//source/common/network:utility_lib",
@@ -288,5 +288,5 @@ index 8445d2f762..6ebeab02b2 100644
  
  INSTANTIATE_TEST_SUITE_P(TcpProxyIntegrationTestParams, TcpProxySslIntegrationTest,
 -- 
-2.39.2
+2.41.0
 

--- a/patches/0004-listener-add-socket-options.patch
+++ b/patches/0004-listener-add-socket-options.patch
@@ -1,13 +1,14 @@
-From 6a019393de48e83654a850dfb2de4f68f12a2fc8 Mon Sep 17 00:00:00 2001
+From 026db3df1e9a95dd7639386af684d43aea7a00f0 Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
 Date: Mon, 14 Aug 2023 10:01:21 +0300
-Subject: [PATCH 4/4] Revert "listener: keep ListenerFactoryContext small
- (#7528)"
+Subject: [PATCH 4/4] listener: add socket options
 
 This reverts commit 170c89eb0b2afb7a39d44d0f8dfb77444ffc038f.
 
+Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
+
 diff --git a/envoy/server/factory_context.h b/envoy/server/factory_context.h
-index 6384230c57..ec9c6aec4f 100644
+index e665289120..49330e3525 100644
 --- a/envoy/server/factory_context.h
 +++ b/envoy/server/factory_context.h
 @@ -309,6 +309,11 @@ public:
@@ -23,10 +24,10 @@ index 6384230c57..ec9c6aec4f 100644
     * Give access to the listener configuration
     */
 diff --git a/source/extensions/listener_managers/listener_manager/listener_impl.cc b/source/extensions/listener_managers/listener_manager/listener_impl.cc
-index 51b42225f5..420699c42a 100644
+index de199ffe5a..a7b7aa9f84 100644
 --- a/source/extensions/listener_managers/listener_manager/listener_impl.cc
 +++ b/source/extensions/listener_managers/listener_manager/listener_impl.cc
-@@ -912,6 +912,9 @@ envoy::config::core::v3::TrafficDirection PerListenerFactoryContextImpl::directi
+@@ -920,6 +920,9 @@ envoy::config::core::v3::TrafficDirection PerListenerFactoryContextImpl::directi
    return listener_factory_context_base_->direction();
  };
  TimeSource& PerListenerFactoryContextImpl::timeSource() { return api().timeSource(); }
@@ -37,10 +38,10 @@ index 51b42225f5..420699c42a 100644
    return *listener_config_;
  }
 diff --git a/source/extensions/listener_managers/listener_manager/listener_impl.h b/source/extensions/listener_managers/listener_manager/listener_impl.h
-index e19db92d4c..b26af02403 100644
+index 08808e1529..a8e88d21cd 100644
 --- a/source/extensions/listener_managers/listener_manager/listener_impl.h
 +++ b/source/extensions/listener_managers/listener_manager/listener_impl.h
-@@ -241,6 +241,7 @@ public:
+@@ -240,6 +240,7 @@ public:
    bool isQuicListener() const override;
  
    // ListenerFactoryContext
@@ -48,7 +49,7 @@ index e19db92d4c..b26af02403 100644
    const Network::ListenerConfig& listenerConfig() const override;
  
    ListenerFactoryContextBaseImpl& parentFactoryContext() { return *listener_factory_context_base_; }
-@@ -386,6 +387,13 @@ public:
+@@ -385,6 +386,13 @@ public:
      return config().traffic_direction();
    }
  
@@ -63,7 +64,7 @@ index e19db92d4c..b26af02403 100644
      if (options == nullptr) {
        options = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
 diff --git a/test/mocks/server/factory_context.h b/test/mocks/server/factory_context.h
-index e1327228eb..db110d263e 100644
+index 756160cb1c..93bd55a339 100644
 --- a/test/mocks/server/factory_context.h
 +++ b/test/mocks/server/factory_context.h
 @@ -46,6 +46,7 @@ public:


### PR DESCRIPTION
Move upstream callback iteration to happen right before encodeHeaders()