### PR TITLE
patches: Call upstream callbacks via UpstreamFilterManager

### DIFF
--- a/patches/0001-network-Add-callback-for-upstream-authorization.patch
+++ b/patches/0001-network-Add-callback-for-upstream-authorization.patch
@@ -1,4 +1,4 @@
-From 372e6203c5f1a999e9c410995ad57495cfe70d2d Mon Sep 17 00:00:00 2001
+From 0aa6c5d69295fb5d78cc0a1bda8746a3740c0687 Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
 Date: Mon, 24 Jan 2022 15:40:28 +0200
 Subject: [PATCH 1/4] network: Add callback for upstream authorization
@@ -23,6 +23,23 @@ adding the callback, as the calls to the callbacks are only ever be
 done from the tcp_proxy or router filter in the same filter chain.
 
 Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
+---
+ envoy/http/filter.h                         |  8 ++++++
+ envoy/network/filter.h                      | 28 +++++++++++++++++++++
+ envoy/tcp/upstream.h                        |  5 ++++
+ source/common/http/async_client_impl.h      |  4 +++
+ source/common/http/conn_manager_impl.h      |  6 +++++
+ source/common/http/filter_manager.cc        |  6 +++++
+ source/common/http/filter_manager.h         |  8 ++++++
+ source/common/network/filter_manager_impl.h | 21 ++++++++++++++++
+ source/common/router/router.cc              |  8 ++++++
+ source/common/router/upstream_request.h     |  5 ++++
+ source/common/tcp_proxy/tcp_proxy.cc        |  7 ++++++
+ source/common/tcp_proxy/tcp_proxy.h         |  1 +
+ source/common/tcp_proxy/upstream.cc         |  8 ++++++
+ source/common/tcp_proxy/upstream.h          |  2 ++
+ source/server/api_listener_impl.h           |  3 +++
+ 15 files changed, 120 insertions(+)
 
 diff --git a/envoy/http/filter.h b/envoy/http/filter.h
 index 361eacc244..88123f71b2 100644
@@ -41,16 +58,16 @@ index 361eacc244..88123f71b2 100644
 +  virtual bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
 +                                        StreamInfo::StreamInfo&) PURE;
  };
- 
+
  /**
 diff --git a/envoy/network/filter.h b/envoy/network/filter.h
 index c1fa3a3b9e..4d1809fdc5 100644
 --- a/envoy/network/filter.h
 +++ b/envoy/network/filter.h
 @@ -112,6 +112,22 @@ public:
- 
+
  using WriteFilterSharedPtr = std::shared_ptr<WriteFilter>;
- 
+
 +/**
 + * UpstreamCallback can be used to reject upstream host selection made by the TCP proxy filter.
 + * This callback is passed the Upstream::HostDescriptionConstSharedPtr, and StreamInfo.
@@ -87,7 +104,7 @@ index c1fa3a3b9e..4d1809fdc5 100644
 +  virtual bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
 +                                        StreamInfo::StreamInfo&) PURE;
  };
- 
+
  /**
 diff --git a/envoy/tcp/upstream.h b/envoy/tcp/upstream.h
 index 200ec7fc9e..a1bf9b0542 100644
@@ -103,7 +120,7 @@ index 200ec7fc9e..a1bf9b0542 100644
 +   */
 +  virtual Upstream::HostDescriptionConstSharedPtr host() const PURE;
  };
- 
+
  // An API for the UpstreamRequest to get callbacks from either an HTTP or TCP
 diff --git a/source/common/http/async_client_impl.h b/source/common/http/async_client_impl.h
 index 83cee970b4..b55a169101 100644
@@ -117,16 +134,16 @@ index 83cee970b4..b55a169101 100644
 +                                StreamInfo::StreamInfo&) override {
 +    return true;
 +  }
- 
+
    // ScopeTrackedObject
    void dumpState(std::ostream& os, int indent_level) const override {
 diff --git a/source/common/http/conn_manager_impl.h b/source/common/http/conn_manager_impl.h
-index b82b1967a5..e55a1f803c 100644
+index e79a6a81c0..18db44fbf3 100644
 --- a/source/common/http/conn_manager_impl.h
 +++ b/source/common/http/conn_manager_impl.h
-@@ -317,6 +317,12 @@ private:
+@@ -326,6 +326,12 @@ private:
      }
- 
+
      absl::optional<Router::ConfigConstSharedPtr> routeConfig();
 +
 +    bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
@@ -135,7 +152,7 @@ index b82b1967a5..e55a1f803c 100644
 +    }
 +
      void traceRequest();
- 
+
      // Updates the snapped_route_config_ (by reselecting scoped route configuration), if a scope is
 diff --git a/source/common/http/filter_manager.cc b/source/common/http/filter_manager.cc
 index 5f71e1cfb5..2190b0b2fe 100644
@@ -144,7 +161,7 @@ index 5f71e1cfb5..2190b0b2fe 100644
 @@ -1720,5 +1720,11 @@ absl::optional<absl::string_view> ActiveStreamDecoderFilter::upstreamOverrideHos
    return parent_.upstream_override_host_;
  }
- 
+
 +bool ActiveStreamDecoderFilter::iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
 +                                                         StreamInfo::StreamInfo& stream_info) {
 +  return parent_.filter_manager_callbacks_.iterateUpstreamCallbacks(host, stream_info);
@@ -163,7 +180,7 @@ index 610ca49fd9..3fc168de60 100644
    absl::optional<absl::string_view> upstreamOverrideHost() const override;
 +  bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
 +                                StreamInfo::StreamInfo& stream_info) override;
- 
+
    // Each decoder filter instance checks if the request passed to the filter is gRPC
    // so that we can issue gRPC local responses to gRPC requests. Filter's decodeHeaders()
 @@ -518,6 +520,12 @@ public:
@@ -177,7 +194,7 @@ index 610ca49fd9..3fc168de60 100644
 +  virtual bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
 +                                        StreamInfo::StreamInfo&) const PURE;
  };
- 
+
  /**
 diff --git a/source/common/network/filter_manager_impl.h b/source/common/network/filter_manager_impl.h
 index 27bc856921..9bc7adb691 100644
@@ -194,17 +211,17 @@ index 27bc856921..9bc7adb691 100644
 +                                  StreamInfo::StreamInfo& stream_info) override {
 +      return parent_.iterateUpstreamCallbacks(host, stream_info);
 +    }
- 
+
      FilterManagerImpl& parent_;
      ReadFilterSharedPtr filter_;
 @@ -162,6 +169,20 @@ private:
    FilterStatus onWrite(ActiveWriteFilter* filter, WriteBufferSource& buffer_source);
    void onResumeWriting(ActiveWriteFilter* filter, WriteBufferSource& buffer_source);
- 
+
 +  void addUpstreamCallback(const UpstreamCallback& cb) {
 +    decoder_filter_upstream_cbs_.emplace_back(cb);
 +  }
-+    
++
 +  bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
 +				StreamInfo::StreamInfo& stream_info) {
 +    bool accept = true;
@@ -219,13 +236,13 @@ index 27bc856921..9bc7adb691 100644
    const Socket& socket_;
    Upstream::HostDescriptionConstSharedPtr host_description_;
 diff --git a/source/common/router/router.cc b/source/common/router/router.cc
-index 82dea84326..754a43c9cd 100644
+index ab28804d09..f0c4a76da5 100644
 --- a/source/common/router/router.cc
 +++ b/source/common/router/router.cc
 @@ -622,6 +622,14 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
      return Http::FilterHeadersStatus::StopIteration;
    }
- 
+
 +  bool accepted = callbacks_->iterateUpstreamCallbacks(host, callbacks_->streamInfo());
 +  if (!accepted) {
 +    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
@@ -233,9 +250,9 @@ index 82dea84326..754a43c9cd 100644
 +                               nullptr, absl::nullopt, absl::string_view());
 +    return Http::FilterHeadersStatus::StopIteration;
 +  }
-+  
++
    hedging_params_ = FilterUtility::finalHedgingParams(*route_entry_, headers);
- 
+
    timeout_ = FilterUtility::finalTimeout(*route_entry_, headers, !config_.suppress_envoy_headers_,
 diff --git a/source/common/router/upstream_request.h b/source/common/router/upstream_request.h
 index a91b75c833..33b57fa641 100644
@@ -244,7 +261,7 @@ index a91b75c833..33b57fa641 100644
 @@ -349,6 +349,11 @@ public:
    }
    OptRef<UpstreamStreamFilterCallbacks> upstreamCallbacks() override { return {*this}; }
- 
+
 +  bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
 +				StreamInfo::StreamInfo&) const override {
 +    return true;
@@ -281,7 +298,7 @@ index 4ce8a350ab..6abaea2f6c 100644
      NoRoute,
 +    UnauthorizedExternalService,
    };
- 
+
    // Callbacks for different error and success states during connection establishment
 diff --git a/source/common/tcp_proxy/upstream.cc b/source/common/tcp_proxy/upstream.cc
 index ea9e2ba73e..1997b84166 100644
@@ -290,7 +307,7 @@ index ea9e2ba73e..1997b84166 100644
 @@ -191,6 +191,10 @@ void TcpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
    }
  }
- 
+
 +Upstream::HostDescriptionConstSharedPtr TcpConnPool::host() const {
 +  return conn_pool_data_.value().host();
 +}
@@ -301,7 +318,7 @@ index ea9e2ba73e..1997b84166 100644
 @@ -258,6 +262,10 @@ void HttpConnPool::newStream(GenericConnectionPoolCallbacks& callbacks) {
    }
  }
- 
+
 +Upstream::HostDescriptionConstSharedPtr HttpConnPool::host() const {
 +  return conn_pool_data_.value().host();
 +}
@@ -314,19 +331,19 @@ index feeea15a56..ef56d69d29 100644
 --- a/source/common/tcp_proxy/upstream.h
 +++ b/source/common/tcp_proxy/upstream.h
 @@ -29,6 +29,7 @@ public:
- 
+
    // GenericConnPool
    void newStream(GenericConnectionPoolCallbacks& callbacks) override;
 +  Upstream::HostDescriptionConstSharedPtr host() const override;
- 
+
    // Tcp::ConnectionPool::Callbacks
    void onPoolFailure(ConnectionPool::PoolFailureReason reason,
 @@ -59,6 +60,7 @@ public:
- 
+
    // GenericConnPool
    void newStream(GenericConnectionPoolCallbacks& callbacks) override;
 +  Upstream::HostDescriptionConstSharedPtr host() const override;
- 
+
    // Http::ConnectionPool::Callbacks,
    void onPoolFailure(ConnectionPool::PoolFailureReason reason,
 diff --git a/source/server/api_listener_impl.h b/source/server/api_listener_impl.h
@@ -340,9 +357,9 @@ index fb787f8172..b37cdc9e85 100644
 +    void addUpstreamCallback(const Network::UpstreamCallback&) override {}
 +    bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr,
 +				  StreamInfo::StreamInfo&) override { return true; }
- 
+
      // Synthetic class that acts as a stub for the connection backing the
      // Network::ReadFilterCallbacks.
--- 
-2.41.0
+--
+2.43.2
 

--- a/patches/0002-upstream-Add-callback-for-upstream-authorization.patch
+++ b/patches/0002-upstream-Add-callback-for-upstream-authorization.patch
@@ -1,4 +1,4 @@
-From 2aaec87a26464142252888f9f04e3f50bc2542be Mon Sep 17 00:00:00 2001
+From ec6415a16ced684a55c8ee2ee8b8535679355a4f Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
 Date: Fri, 21 Jan 2022 15:42:00 +0200
 Subject: [PATCH 2/4] upstream: Add callback for upstream authorization
@@ -21,12 +21,13 @@ done from the router filter in the same filter chain.
 
 Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
 ---
- envoy/http/filter.h                      | 30 ++++++++++++++++++++++++
- source/common/http/async_client_impl.h   |  5 ++++
- source/common/http/filter_manager.cc     | 22 +++++++++++++++++
- source/common/http/filter_manager.h      |  8 +++++++
- source/common/router/upstream_request.cc |  9 +++++++
- 5 files changed, 74 insertions(+)
+ envoy/http/filter.h                           | 30 +++++++++++++++++++
+ source/common/http/async_client_impl.h        |  5 ++++
+ source/common/http/filter_manager.cc          | 20 +++++++++++++
+ source/common/http/filter_manager.h           | 11 +++++++
+ source/common/router/upstream_codec_filter.cc |  9 ++++++
+ source/common/router/upstream_request.cc      |  9 ++++++
+ 6 files changed, 84 insertions(+)
 
 diff --git a/envoy/http/filter.h b/envoy/http/filter.h
 index 88123f71b2..7b529bec55 100644
@@ -63,7 +64,7 @@ index 88123f71b2..7b529bec55 100644
                                          StreamInfo::StreamInfo&) PURE;
 +
 +  /*
-+   * Adds the given callback to be executed later via 
++   * Adds the given callback to be executed later via
 +   */
 +  virtual void addUpstreamCallback(const UpstreamCallback& cb) PURE;
 +
@@ -74,13 +75,13 @@ index 88123f71b2..7b529bec55 100644
 +  virtual bool iterateUpstreamCallbacks(Http::RequestHeaderMap&,
 +                                        StreamInfo::StreamInfo&) PURE;
  };
- 
+
  /**
 diff --git a/source/common/http/async_client_impl.h b/source/common/http/async_client_impl.h
-index c3849b092f..f66d5cd9ef 100644
+index b55a169101..0dfb0f5bcb 100644
 --- a/source/common/http/async_client_impl.h
 +++ b/source/common/http/async_client_impl.h
-@@ -258,6 +258,11 @@ private:
+@@ -486,6 +486,11 @@ private:
                                  StreamInfo::StreamInfo&) override {
      return true;
    }
@@ -89,37 +90,35 @@ index c3849b092f..f66d5cd9ef 100644
 +                                StreamInfo::StreamInfo&) override {
 +    return true;
 +  }
- 
+
    // ScopeTrackedObject
    void dumpState(std::ostream& os, int indent_level) const override {
 diff --git a/source/common/http/filter_manager.cc b/source/common/http/filter_manager.cc
-index 5c46a28091..2d5a2d9983 100644
+index 2190b0b2fe..869d886697 100644
 --- a/source/common/http/filter_manager.cc
 +++ b/source/common/http/filter_manager.cc
-@@ -1539,6 +1539,19 @@ bool FilterManager::createFilterChain() {
-   return !upgrade_rejected;
+@@ -1072,6 +1072,17 @@ void DownstreamFilterManager::sendDirectLocalReply(
+       Utility::LocalReplyData{state_.is_grpc_request_, code, body, grpc_status, is_head_request});
  }
- 
-+void FilterManager::addUpstreamCallback(const UpstreamCallback& cb) {
-+  decoder_filter_upstream_cbs_.emplace_back(cb);
-+}
-+  
-+bool FilterManager::iterateUpstreamCallbacks(Http::RequestHeaderMap& headers,
-+                                             StreamInfo::StreamInfo& upstream_info) {
+
++bool DownstreamFilterManager::iterateUpstreamCallbacks(Http::RequestHeaderMap& headers,
++                                                       StreamInfo::StreamInfo& upstream_info) {
 +  bool accept = true;
 +  for (const auto& cb : decoder_filter_upstream_cbs_) {
-+    accept = accept && cb(headers, upstream_info);
++    if (!cb(headers, upstream_info)) {
++      accept = false;
++    }
 +  }
 +  return accept;
 +}
 +
- void ActiveStreamDecoderFilter::requestDataDrained() {
-   // If this is called it means the call to requestDataTooLarge() was a
-   // streaming call, or a 413 would have been sent.
-@@ -1765,5 +1778,14 @@ bool ActiveStreamDecoderFilter::iterateUpstreamCallbacks(Upstream::HostDescripti
+ void FilterManager::encode1xxHeaders(ActiveStreamEncoderFilter* filter,
+                                      ResponseHeaderMap& headers) {
+   filter_manager_callbacks_.resetIdleTimer();
+@@ -1726,5 +1737,14 @@ bool ActiveStreamDecoderFilter::iterateUpstreamCallbacks(Upstream::HostDescripti
 
  }
- 
+
 +void ActiveStreamDecoderFilter::addUpstreamCallback(const UpstreamCallback& cb) {
 +  parent_.addUpstreamCallback(cb);
 +}
@@ -132,58 +131,81 @@ index 5c46a28091..2d5a2d9983 100644
  } // namespace Http
  } // namespace Envoy
 diff --git a/source/common/http/filter_manager.h b/source/common/http/filter_manager.h
-index 3329051489..207de4faab 100644
+index 3fc168de60..beeff6506e 100644
 --- a/source/common/http/filter_manager.h
 +++ b/source/common/http/filter_manager.h
-@@ -243,6 +243,9 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
+@@ -242,6 +242,9 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
    absl::optional<absl::string_view> upstreamOverrideHost() const override;
    bool iterateUpstreamCallbacks(Upstream::HostDescriptionConstSharedPtr host,
                                  StreamInfo::StreamInfo& stream_info) override;
 +  void addUpstreamCallback(const UpstreamCallback& cb) override;
 +  bool iterateUpstreamCallbacks(Http::RequestHeaderMap& headers,
 +                                StreamInfo::StreamInfo& stream_info) override;
- 
+
    // Each decoder filter instance checks if the request passed to the filter is gRPC
    // so that we can issue gRPC local responses to gRPC requests. Filter's decodeHeaders()
-@@ -993,6 +996,9 @@ private:
-     return request_metadata_map_vector_.get();
-   }
- 
-+  void addUpstreamCallback(const UpstreamCallback&);
-+  bool iterateUpstreamCallbacks(Http::RequestHeaderMap&, StreamInfo::StreamInfo&);
+@@ -830,6 +833,12 @@ public:
+   void onDownstreamReset() { state_.saw_downstream_reset_ = true; }
+   bool sawDownstreamReset() { return state_.saw_downstream_reset_; }
+
++  void addUpstreamCallback(const UpstreamCallback& cb) {
++    decoder_filter_upstream_cbs_.emplace_back(cb);
++  }
 +
-   FilterManagerCallbacks& filter_manager_callbacks_;
-   Event::Dispatcher& dispatcher_;
-   // This is unset if there is no downstream connection, e.g. for health check or
-@@ -1002,6 +1008,8 @@ private:
++  virtual bool iterateUpstreamCallbacks(Http::RequestHeaderMap&, StreamInfo::StreamInfo&) PURE;
++
+ protected:
+   struct State {
+     State()
+@@ -996,6 +1005,8 @@ private:
    Buffer::BufferMemoryAccountSharedPtr account_;
    const bool proxy_100_continue_;
- 
+
 +  std::vector<UpstreamCallback> decoder_filter_upstream_cbs_{};
 +
    std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
    std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;
    std::list<StreamFilterBase*> filters_;
-diff --git a/source/common/router/upstream_request.cc b/source/common/router/upstream_request.cc
-index 5ba6402235..dc1be68e2d 100644
---- a/source/common/router/upstream_request.cc
-+++ b/source/common/router/upstream_request.cc
-@@ -673,6 +673,15 @@ void UpstreamRequest::onPoolReady(std::unique_ptr<GenericUpstream>&& upstream,
-     upstreamLog(AccessLog::AccessLogType::UpstreamPoolReady);
+diff --git a/source/common/router/upstream_codec_filter.cc b/source/common/router/upstream_codec_filter.cc
+index 158d2b7297..8aee672826 100644
+--- a/source/common/router/upstream_codec_filter.cc
++++ b/source/common/router/upstream_codec_filter.cc
+@@ -58,6 +58,15 @@ Http::FilterHeadersStatus UpstreamCodecFilter::decodeHeaders(Http::RequestHeader
+     return Http::FilterHeadersStatus::StopAllIterationAndWatermark;
    }
- 
-+  bool accepted = parent_.callbacks()->iterateUpstreamCallbacks(*parent_.downstreamHeaders(),
-+                                                                stream_info_);
+
++  // This block has to be right before the encodeHeaders() (and any related logging) call below!
++  bool accepted = callbacks_->iterateUpstreamCallbacks(headers, callbacks_->streamInfo());
 +  if (!accepted) {
-+    stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
-+    parent_.callbacks()->sendLocalReply(Http::Code::Forbidden, "Access denied\r\n",
-+                                        nullptr, absl::nullopt, absl::string_view());
-+    return;
++    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
++    callbacks_->sendLocalReply(Http::Code::Forbidden, "Access denied\r\n", nullptr,
++                               absl::nullopt, absl::string_view());
++    return Http::FilterHeadersStatus::StopIteration;
 +  }
 +
-   if (address_provider.connectionID() && stream_info_.downstreamAddressProvider().connectionID()) {
-     ENVOY_LOG(debug, "Attached upstream connection [C{}] to downstream connection [C{}]",
-               address_provider.connectionID().value(),
+   ENVOY_STREAM_LOG(trace, "proxying headers", *callbacks_);
+   calling_encode_headers_ = true;
+   const Http::Status status =
+diff --git a/source/common/router/upstream_request.cc b/source/common/router/upstream_request.cc
+index 653c87d39d..14c6e53b8a 100644
+--- a/source/common/router/upstream_request.cc
++++ b/source/common/router/upstream_request.cc
+@@ -75,6 +75,15 @@ public:
+                                                           details);
+   }
+   void executeLocalReplyIfPrepared() override {}
++
++  // Iterate upstream callbacks set on the downstream filter manager.
++  // Any upstream callbacks set by upstream filters will be ignored.
++  bool iterateUpstreamCallbacks(Http::RequestHeaderMap& headers,
++                                StreamInfo::StreamInfo& stream_info) override {
++    return upstream_request_.parent_.callbacks()->iterateUpstreamCallbacks(headers,
++									   stream_info);
++  }
++
+   UpstreamRequest& upstream_request_;
+ };
+
 --
 2.43.2
 

--- a/patches/0003-tcp_proxy-Add-filter-state-proxy_read_before_connect.patch
+++ b/patches/0003-tcp_proxy-Add-filter-state-proxy_read_before_connect.patch
@@ -1,4 +1,4 @@
-From c22e7ed504dcf2e70d4a8d151fb988e8bb2cca76 Mon Sep 17 00:00:00 2001
+From c1b5948eef6e601284102f307f4b184a2b00daac Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
 Date: Tue, 27 Sep 2022 15:51:46 +0300
 Subject: [PATCH 3/4] tcp_proxy: Add filter state proxy_read_before_connect
@@ -29,6 +29,13 @@ reliant on the tcp_proxy internal detail, such as balancing and timing of
 the readDisable() calls on the downstream connection.
 
 Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
+---
+ source/common/tcp_proxy/BUILD                 |  1 +
+ source/common/tcp_proxy/tcp_proxy.cc          | 34 ++++++++--
+ source/common/tcp_proxy/tcp_proxy.h           |  6 ++
+ test/integration/BUILD                        |  1 +
+ .../integration/tcp_proxy_integration_test.cc | 67 +++++++++++++------
+ 5 files changed, 83 insertions(+), 26 deletions(-)
 
 diff --git a/source/common/tcp_proxy/BUILD b/source/common/tcp_proxy/BUILD
 index db2c5b1895..94a36240ad 100644
@@ -53,7 +60,7 @@ index f40b5bdb2d..b74695f45a 100644
 +#include "envoy/stream_info/bool_accessor.h"
  #include "envoy/upstream/cluster_manager.h"
  #include "envoy/upstream/upstream.h"
- 
+
 @@ -244,7 +245,17 @@ void Filter::initialize(Network::ReadFilterCallbacks& callbacks, bool set_connec
    // Need to disable reads so that we don't write to an upstream that might fail
    // in onData(). This will get re-enabled when the upstream connection is
@@ -72,7 +79,7 @@ index f40b5bdb2d..b74695f45a 100644
 +
    getStreamInfo().setDownstreamBytesMeter(std::make_shared<StreamInfo::BytesMeter>());
    getStreamInfo().setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());
- 
+
 @@ -467,8 +478,11 @@ Network::FilterStatus Filter::establishUpstreamConnection() {
      // cluster->trafficStats()->upstream_cx_none_healthy in the latter case.
      getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoHealthyUpstream);
@@ -84,7 +91,7 @@ index f40b5bdb2d..b74695f45a 100644
 +  return receive_before_connect_ ? Network::FilterStatus::Continue
 +                                 : Network::FilterStatus::StopIteration;
  }
- 
+
  void Filter::onClusterDiscoveryCompletion(Upstream::ClusterDiscoveryStatus cluster_status) {
 @@ -683,12 +697,18 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
    if (upstream_) {
@@ -105,7 +112,7 @@ index f40b5bdb2d..b74695f45a 100644
 -  resetIdleTimer(); // TODO(ggreenway) PERF: do we need to reset timer on both send and receive?
    return Network::FilterStatus::StopIteration;
  }
- 
+
 @@ -803,7 +823,13 @@ void Filter::onUpstreamConnection() {
    connecting_ = false;
    // Re-enable downstream reads now that the upstream connection is established
@@ -118,7 +125,7 @@ index f40b5bdb2d..b74695f45a 100644
 +    upstream_->encodeData(early_data_buffer_, early_data_end_stream_);
 +    ASSERT(0 == early_data_buffer_.length());
 +  }
- 
+
    read_callbacks_->upstreamHost()->outlierDetector().putResult(
        Upstream::Outlier::Result::LocalOriginConnectSuccessFinal);
 diff --git a/source/common/tcp_proxy/tcp_proxy.h b/source/common/tcp_proxy/tcp_proxy.h
@@ -128,7 +135,7 @@ index 6abaea2f6c..72c28f2bfe 100644
 @@ -22,6 +22,7 @@
  #include "envoy/upstream/cluster_manager.h"
  #include "envoy/upstream/upstream.h"
- 
+
 +#include "source/common/buffer/buffer_impl.h"
  #include "source/common/common/logger.h"
  #include "source/common/formatter/substitution_format_string.h"
@@ -136,7 +143,7 @@ index 6abaea2f6c..72c28f2bfe 100644
 @@ -38,6 +39,8 @@
  namespace Envoy {
  namespace TcpProxy {
- 
+
 +constexpr absl::string_view ReceiveBeforeConnectKey = "envoy.tcp_proxy.receive_before_connect";
 +
  /**
@@ -150,13 +157,13 @@ index 6abaea2f6c..72c28f2bfe 100644
 +  bool early_data_end_stream_{false};
 +  Buffer::OwnedImpl early_data_buffer_{};
  };
- 
+
  // This class deals with an upstream connection that needs to finish flushing, when the downstream
 diff --git a/test/integration/BUILD b/test/integration/BUILD
-index 257fde93a7..08cdf45535 100644
+index f2b7b874f6..fcee6e8cd4 100644
 --- a/test/integration/BUILD
 +++ b/test/integration/BUILD
-@@ -1665,6 +1665,7 @@ envoy_cc_test(
+@@ -1659,6 +1659,7 @@ envoy_cc_test(
          "//source/common/event:dispatcher_includes",
          "//source/common/event:dispatcher_lib",
          "//source/common/network:utility_lib",
@@ -169,14 +176,14 @@ index f88cf9a62f..d13f9d2aef 100644
 --- a/test/integration/tcp_proxy_integration_test.cc
 +++ b/test/integration/tcp_proxy_integration_test.cc
 @@ -12,6 +12,8 @@
- 
+
  #include "source/common/config/api_version.h"
  #include "source/common/network/utility.h"
 +#include "source/common/stream_info/bool_accessor_impl.h"
 +#include "source/common/tcp_proxy/tcp_proxy.h"
  #include "source/extensions/filters/network/common/factory_base.h"
  #include "source/extensions/transport_sockets/tls/context_manager_impl.h"
- 
+
 @@ -1259,18 +1261,27 @@ public:
    Network::FilterStatus onData(Buffer::Instance& data, bool) override {
      if (!metadata_set_) {
@@ -198,7 +205,7 @@ index f88cf9a62f..d13f9d2aef 100644
 +        // so that we can get to it later when enough data has been received.
          return Network::FilterStatus::StopIteration;
        }
- 
+
 +      void* p = data.linearize(index);
 +      std::string first_word(static_cast<char*>(p), index);
 +
@@ -210,13 +217,13 @@ index f88cf9a62f..d13f9d2aef 100644
        ProtobufWkt::Value val;
 -      val.set_string_value(data.toString());
 +      val.set_string_value(first_word);
- 
+
        ProtobufWkt::Struct& map =
            (*read_callbacks_->connection()
 @@ -1279,24 +1290,25 @@ public:
                  .mutable_filter_metadata())[Envoy::Config::MetadataFilters::get().ENVOY_LB];
        (*map.mutable_fields())[key_] = val;
- 
+
 -      // Put this back in the state that TcpProxy expects.
 -      read_callbacks_->connection().readDisable(true);
 -
@@ -224,7 +231,7 @@ index f88cf9a62f..d13f9d2aef 100644
      }
      return Network::FilterStatus::Continue;
    }
- 
+
    Network::FilterStatus onNewConnection() override {
 -    // TcpProxy disables read; must re-enable so we can read headers.
 -    read_callbacks_->connection().readDisable(false);
@@ -233,7 +240,7 @@ index f88cf9a62f..d13f9d2aef 100644
 +    // TcpProxy proceeds with upstream connection once onData() returns FilterStatus::Continue.
      return Network::FilterStatus::StopIteration;
    }
- 
+
    void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
      read_callbacks_ = &callbacks;
 +
@@ -243,11 +250,11 @@ index f88cf9a62f..d13f9d2aef 100644
 +        StreamInfo::FilterState::StateType::ReadOnly,
 +        StreamInfo::FilterState::LifeSpan::Connection);
    }
- 
+
    const std::string key_;
 @@ -1354,14 +1366,25 @@ TEST_P(TcpProxyDynamicMetadataMatchIntegrationTest, DynamicMetadataMatch) {
    initialize();
- 
+
    expectEndpointToMatchRoute([](IntegrationTcpClient& tcp_client) -> std::string {
 -    // Break the write into two; validate that the first is received before sending the second. This
 -    // validates that a downstream filter can use this functionality, even if it can't make a
@@ -277,16 +284,16 @@ index f88cf9a62f..d13f9d2aef 100644
 +    return "primary is selected before upstream connection exists";
    });
  }
- 
+
 @@ -1378,7 +1401,7 @@ TEST_P(TcpProxyDynamicMetadataMatchIntegrationTest, DynamicMetadataNonMatch) {
- 
+
    initialize();
- 
+
 -  expectEndpointNotToMatchRoute("does_not_match_role_primary");
 +  expectEndpointNotToMatchRoute("does not match role primary");
  }
- 
+
  INSTANTIATE_TEST_SUITE_P(TcpProxyIntegrationTestParams, TcpProxySslIntegrationTest,
--- 
-2.41.0
+--
+2.43.2
 

--- a/patches/0004-listener-add-socket-options.patch
+++ b/patches/0004-listener-add-socket-options.patch
@@ -1,10 +1,17 @@
-From 6a019393de48e83654a850dfb2de4f68f12a2fc8 Mon Sep 17 00:00:00 2001
+From 44b6fc6a60fcfab0502394fa17d4658092adcc7e Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
 Date: Mon, 14 Aug 2023 10:01:21 +0300
 Subject: [PATCH 4/4] Revert "listener: keep ListenerFactoryContext small
  (#7528)"
 
 This reverts commit 170c89eb0b2afb7a39d44d0f8dfb77444ffc038f.
+---
+ envoy/server/factory_context.h                            | 5 +++++
+ .../listener_managers/listener_manager/listener_impl.cc   | 3 +++
+ .../listener_managers/listener_manager/listener_impl.h    | 8 ++++++++
+ test/mocks/server/factory_context.h                       | 1 +
+ test/mocks/server/listener_factory_context.h              | 1 +
+ 5 files changed, 18 insertions(+)
 
 diff --git a/envoy/server/factory_context.h b/envoy/server/factory_context.h
 index 6384230c57..ec9c6aec4f 100644
@@ -42,16 +49,16 @@ index e19db92d4c..b26af02403 100644
 +++ b/source/extensions/listener_managers/listener_manager/listener_impl.h
 @@ -241,6 +241,7 @@ public:
    bool isQuicListener() const override;
- 
+
    // ListenerFactoryContext
 +  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& options) override;
    const Network::ListenerConfig& listenerConfig() const override;
- 
+
    ListenerFactoryContextBaseImpl& parentFactoryContext() { return *listener_factory_context_base_; }
 @@ -386,6 +387,13 @@ public:
      return config().traffic_direction();
    }
- 
+
 +  void addListenSocketOptions(const Network::Socket::OptionsSharedPtr& append_options) {
 +    for (std::vector<Network::Address::InstanceConstSharedPtr>::size_type i = 0;
 +         i < addresses_.size(); i++) {
@@ -69,10 +76,10 @@ index e1327228eb..db110d263e 100644
 @@ -46,6 +46,7 @@ public:
    MOCK_METHOD(envoy::config::core::v3::TrafficDirection, direction, (), (const));
    MOCK_METHOD(TimeSource&, timeSource, ());
- 
+
 +  MOCK_METHOD(void, addListenSocketOptions, (const Network::Socket::OptionsSharedPtr&));
    MOCK_METHOD(const Network::ListenerConfig&, listenerConfig, (), (const));
- 
+
    Event::TestTimeSystem& timeSystem() { return time_system_; }
 diff --git a/test/mocks/server/listener_factory_context.h b/test/mocks/server/listener_factory_context.h
 index 5341b517d1..924b8cb0b1 100644
@@ -81,11 +88,11 @@ index 5341b517d1..924b8cb0b1 100644
 @@ -20,6 +20,7 @@ public:
    MockListenerFactoryContext();
    ~MockListenerFactoryContext() override;
- 
+
 +  MOCK_METHOD(void, addListenSocketOptions, (const Network::Socket::OptionsSharedPtr&));
    const Network::ListenerConfig& listenerConfig() const override { return listener_config_; }
    MOCK_METHOD(const Network::ListenerConfig&, listenerConfig_, (), (const));
    MOCK_METHOD(ServerFactoryContext&, getServerFactoryContext, (), (const));
--- 
-2.41.0
+--
+2.43.2
 


### PR DESCRIPTION
Envoy has moved the encodeHeaders() call to a new call path in upstream decoder filter. Move the upstream callbacks iteration call there to be just before the encodeHeaders() call, and call the iteration via UpstreamFilterManager so that the callbacks registered in the downstream filter manager are used.

Call sendLocalReply also via the UpstreamFilterManager to have its local state updated properly for upstream processing.

Relates: https://github.com/envoyproxy/envoy/pull/26916/files#r1176556258