### PR TITLE
starter: introduce possibility to keep capability NET_BIND_SERVICE

### DIFF
--- a/cilium/privileged_service_client.cc
+++ b/cilium/privileged_service_client.cc
@@ -10,7 +10,10 @@ namespace PrivilegedService {
 
 ProtocolClient::ProtocolClient()
     : Protocol(CILIUM_PRIVILEGED_SERVICE_FD), call_mutex_(PTHREAD_MUTEX_INITIALIZER), seq_(0) {
-  RELEASE_ASSERT(get_capabilities(CAP_EFFECTIVE) == 0 && get_capabilities(CAP_PERMITTED) == 0,
+  // Check that the Envoy process isn't running with privileges.
+  // The only exception is CAP_NET_BIND_SERVICE (if explicitly excluded from being dropped).
+  RELEASE_ASSERT((get_capabilities(CAP_EFFECTIVE) & ~(1UL << CAP_NET_BIND_SERVICE)) == 0 &&
+                     (get_capabilities(CAP_PERMITTED) & ~(1UL << CAP_NET_BIND_SERVICE)) == 0,
                  "cilium-envoy running with privileges, exiting");
 
   if (!check_privileged_service()) {


### PR DESCRIPTION
Currently, the "starter" drops all capabilities before starting the Envoy process itself. This is mainly to prevent the Envoy process from having the capabilities `NET_ADMIN`, `SYS_ADMIN` etc.

But this change also comes with the drawback that it prevents Envoy from binding to privileged ports - because the capability `NET_BIND_SERVICE` gets dropped as well.

Therefore, this commit introduces a new flag `--keep-cap-net-bind-service` to the starter. If this flag is present, the capability `NET_BIND_SERVICE` is kept in the privileged and effective set for the Envoy process.