### PR TITLE
renovate: Remove configuration for v1.26

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,6 @@
   "pruneStaleBranches": true,
   "baseBranches": [
     "main",
-    "v1.26",
     "v1.27",
   ],
   "labels": [
@@ -74,7 +73,6 @@
         "pinDigest"
       ],
       matchBaseBranches: [
-        "v1.26",
         "v1.27"
       ]
     },
@@ -103,7 +101,6 @@
       "allowedVersions": "22.04",
       "matchBaseBranches": [
         "main",
-        "v1.26",
         "v1.27",
       ]
     },
@@ -127,7 +124,6 @@
       "allowedVersions": "20.04",
       "matchBaseBranches": [
         "main",
-        "v1.26",
         "v1.27",
       ]
     },
@@ -152,7 +148,6 @@
       ],
       "allowedVersions": "<=1.21",
       "matchBaseBranches": [
-        "v1.26",
         "v1.27",
       ]
     },
@@ -164,16 +159,6 @@
       "allowedVersions": "<=1.28",
       "matchBaseBranches": [
         "main"
-      ]
-    },
-    {
-      "groupName": "envoy 1.26.x",
-      "matchDepNames": [
-        "envoyproxy/envoy"
-      ],
-      "allowedVersions": "<=1.26",
-      "matchBaseBranches": [
-        "v1.26"
       ]
     },
     {
@@ -209,7 +194,6 @@
       ],
       "allowedVersions": "<=1.21",
       "matchBaseBranches": [
-        "v1.26",
         "v1.27",
       ]
     },
@@ -237,7 +221,6 @@
       ],
       "allowedVersions": "<=1.21",
       "matchBaseBranches": [
-        "v1.26",
         "v1.27",
       ]
     }


### PR DESCRIPTION
We can merge this PR once upstream PRs are landed

- https://github.com/cilium/cilium/pull/31498
- https://github.com/cilium/cilium/pull/31007

Post-merge Task:
- [ ] Change github setting to read-only for v1.26 branch