### PR TITLE
Build: Push image to local docker registry by default

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -45,11 +45,9 @@ ifdef DOCKER_PLATFORMS
   endif
 endif
 ifneq ($(DOCKER_BUILDER),default)
-  # Only insert '--push' if user did not pass a conflicting '--output' option
-  ifeq ($(findstring --output,$(DOCKER_BUILD_OPTS)),)
-    ifeq ($(findstring --load,$(DOCKER_BUILD_OPTS)),)
-      DOCKER_BUILD_OPTS += --push
-    endif
+  # Only insert '--push' if user did not pass a conflicting '--output' or '--load' option
+  ifeq ($(filter --output --load,$(DOCKER_BUILD_OPTS)),)
+		DOCKER_BUILD_OPTS += --push
   endif
   DOCKER_BUILD_OPTS += $(DOCKER_PLATFORMS)
   ifdef CACHE_PUSH

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -48,7 +48,11 @@ ifneq ($(DOCKER_BUILDER),default)
   # Only insert '--push' or '--output' if the user did not pass a conflicting '--output' or '--load' option
   ifeq ($(filter --output --load,$(DOCKER_BUILD_OPTS)),)
     ifdef IMAGE_PUSH
-      # Push to registry if IMAGE_PUSH=1 is set (needs auth)
+      # Push to registry if explicit push is enforce via IMAGE_PUSH=1 (needs auth)
+      DOCKER_BUILD_OPTS += --push
+    else ifeq ($(ARCH),multi)
+      # Push to registry if multi-arch is enforced via ARCH=multi (needs auth)
+      # (It's not supported to write multi-arch builds to the local Docker registry)
       DOCKER_BUILD_OPTS += --push
     else
       # Push to local docker registry by default

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -62,13 +62,13 @@ ifneq ($(DOCKER_BUILDER),default)
 endif
 $(info Using Docker Buildx builder "$(DOCKER_BUILDER)" with build flags "$(DOCKER_BUILD_OPTS)".)
 
-SLASH = -
+HYPHEN = -
 ARCH ?= $(subst aarch64,arm64,$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))))
 # Add -<arch> suffix if ARCH is not "multi"
 ifeq ($(ARCH),multi)
   ARCH :=
 else
-  IMAGE_ARCH := $(SLASH)$(ARCH)
+  IMAGE_ARCH := $(HYPHEN)$(ARCH)
 endif
 
 SOURCE_VERSION :=

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -45,9 +45,15 @@ ifdef DOCKER_PLATFORMS
   endif
 endif
 ifneq ($(DOCKER_BUILDER),default)
-  # Only insert '--push' if user did not pass a conflicting '--output' or '--load' option
+  # Only insert '--push' or '--output' if the user did not pass a conflicting '--output' or '--load' option
   ifeq ($(filter --output --load,$(DOCKER_BUILD_OPTS)),)
-		DOCKER_BUILD_OPTS += --push
+    ifdef IMAGE_PUSH
+      # Push to registry if IMAGE_PUSH=1 is set (needs auth)
+      DOCKER_BUILD_OPTS += --push
+    else
+      # Push to local docker registry by default
+      DOCKER_BUILD_OPTS += --output type=docker
+    endif
   endif
   DOCKER_BUILD_OPTS += $(DOCKER_PLATFORMS)
   ifdef CACHE_PUSH

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ architecture only:
 make docker-image-envoy
 ```
 
+This will write the image to the local Docker registry.
+
 Depending on hour host CPU and memory resources a fresh build can take
 an hour or more. Docker caching will speed up subsequent builds.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ amd64 and arm64:
 ARCH=multi make docker-image-envoy
 ```
 
+This will try to push the images to the container registry. Appropriate
+authentication is required. (Pushing to the local Docker registry isn't
+supported for multi-arch builds. See [Docker documentation](https://docs.docker.com/reference/cli/docker/buildx/build/#docker))
+
 Builds will be performed concurrently when building for multiple
 architectures on a single machine. You most likely need to limit the
 number of jobs allowed for each builder, see the note above for


### PR DESCRIPTION
Currently, building the Cilium Proxy via `make docker-image-envoy` fails with the following error if the user isn't authenticated to the remote container registry (Quay).

```
❯ make docker-image-envoy
...
 => => pushing layers                                                                                                                                                                                                                                                                                                                                  2.9s
------
 > exporting to image:
------
ERROR: failed to solve: failed to push quay.io/cilium/cilium-envoy:a24135cdcd9c42eb2b4c9ab708a2c5b9bc47ea4c-amd64: unexpected status from POST request to https://quay.io/v2/cilium/cilium-envoy/blobs/uploads/: 401 UNAUTHORIZED
make: *** [Makefile.docker:213: docker-image-envoy] Error 1
```

This isn't the best user experience.

Therefore, this PR tries to load the images into the local docker registry whenever possible.

Exceptions (pushed to (remote) registry):

- Multi Arch build (not supported by Docker)
- Enforced via `IMAGE_PUSH=1`