### PR TITLE
ci: github action naming cleanup

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           path: /tmp/buildx-cache
           key: docker-cache-${{ github.head_ref }}
-          restore-keys: docker-cache-master
+          restore-keys: docker-cache-main
 
       - name: Login to quay.io
         uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -179,14 +179,14 @@ jobs:
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: /tmp/buildx-cache
-          key: docker-cache-master
+          key: docker-cache-main
 
       - name: Clear cache
         run: |
           rm -rf /tmp/buildx-cache/*
           docker buildx prune -f
 
-      - name: Multi-arch build & push master latest
+      - name: Multi-arch build & push main latest
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         id: docker_build_cd
         with:

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -32,7 +32,7 @@ jobs:
           username: ${{ secrets.QUAY_ENVOY_USERNAME }}
           password: ${{ secrets.QUAY_ENVOY_PASSWORD }}
 
-      - name: Checkout PR
+      - name: Checkout source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
@@ -55,7 +55,7 @@ jobs:
             echo exists="false" >> $GITHUB_OUTPUT
           fi
 
-      - name: PR Multi-arch build & push of Builder image (test)
+      - name: Multi-arch build & push of Builder image (test)
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         if: steps.cilium-builder-test-tag-in-repositories.outputs.exists == 'false'
         id: docker_build_builder_test
@@ -127,7 +127,7 @@ jobs:
           username: ${{ secrets.QUAY_ENVOY_USERNAME }}
           password: ${{ secrets.QUAY_ENVOY_PASSWORD }}
 
-      - name: Checkout PR
+      - name: Checkout source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Prep for build
         run: |
@@ -147,7 +147,7 @@ jobs:
             echo exists="false" >> $GITHUB_OUTPUT
           fi
 
-      - name: PR Multi-arch build & push of Builder image
+      - name: Multi-arch build & push of Builder image
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         if: steps.cilium-builder-tag-in-repositories.outputs.exists == 'false'
         id: docker_build_builder

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           path: /tmp/buildx-cache
           key: docker-cache-tests
-          restore-keys: docker-cache-master
+          restore-keys: docker-cache-main
 
       - name: Checkout PR Source Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -42,7 +42,7 @@ jobs:
       github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - name: Prepare variables for pushes to master
+      - name: Prepare variables for pushes to main
         if: github.event_name == 'push'
         run: |
           echo "PROXY_IMAGE=quay.io/cilium/cilium-envoy" >> $GITHUB_ENV


### PR DESCRIPTION
This PR cleans up some wordings in the github action workflows

- `master` -> `main`
- remove word `PR` in release pipeline