### PR TITLE
build: remove duplicated make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ else
   BAZEL_BUILD_OPTS += --config=release
 endif
 
-include Makefile.dev
 ifdef PKG_BUILD
   all: cilium-envoy-starter cilium-envoy
 
@@ -71,6 +70,8 @@ ifdef PKG_BUILD
 	echo "Bazel assumed to be installed in the builder image"
 
 else
+  all: precheck cilium-envoy-starter cilium-envoy
+
   include Makefile.docker
 
   # Fetch and install Bazel if needed
@@ -78,6 +79,8 @@ else
   install-bazel:
 	tools/install_bazel.sh `cat .bazelversion`
 endif
+
+include Makefile.dev
 
 BUILD_DEP_HASHES: $(BUILD_DEP_FILES)
 	sha256sum $^ >$@
@@ -105,7 +108,7 @@ clang.bazelrc: bazel/setup_clang.sh /usr/lib/llvm-15
 	echo "build --config=clang" >> $@
 
 .PHONY: bazel-bin/cilium-envoy
-bazel-bin/cilium-envoy: $(COMPILER_DEP) SOURCE_VERSION
+bazel-bin/cilium-envoy: $(COMPILER_DEP) SOURCE_VERSION install-bazel
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:cilium-envoy $(BAZEL_FILTER)
 
@@ -113,7 +116,7 @@ cilium-envoy: bazel-bin/cilium-envoy
 	mv $< $@
 
 .PHONY: bazel-bin/cilium-envoy-starter
-bazel-bin/cilium-envoy-starter: $(COMPILER_DEP) SOURCE_VERSION
+bazel-bin/cilium-envoy-starter: $(COMPILER_DEP) SOURCE_VERSION install-bazel
 	@$(ECHO_BAZEL)
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:cilium-envoy-starter $(BAZEL_FILTER)
 

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -17,8 +17,6 @@ CHECK_FORMAT ?= ./bazel-bin/check_format.py
 BAZEL_CACHE ?= ~/.cache/bazel
 BAZEL_ARCHIVE ?= ~/bazel-cache.tar.bz2
 
-all: precheck envoy-default
-
 # @envoy_api//:v3_protos must be built before invoking Makefile.api
 API_DEPS = @envoy_api//:v3_protos
 PROTOC_TARGET = @com_google_protobuf//:protoc
@@ -33,16 +31,6 @@ api-clean:
 	find go -empty -type d -delete
 	mkdir -p go/contrib/envoy
 	mkdir go/envoy
-
-envoy-default: $(COMPILER_DEP) SOURCE_VERSION install-bazel
-	@$(ECHO_BAZEL)
-	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:cilium-envoy $(BAZEL_FILTER)
-
-debug: envoy-debug
-
-envoy-debug: $(COMPILER_DEP) SOURCE_VERSION install-bazel
-	@$(ECHO_BAZEL)
-	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) -c dbg //:cilium-envoy $(BAZEL_FILTER)
 
 $(CHECK_FORMAT): force-non-root SOURCE_VERSION install-bazel clang.bazelrc
 	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) //:check_format.py


### PR DESCRIPTION
This commit removes duplicated make targets

- `envoy-default` (from `Makefile.dev`) -> duplicate of `bazel-bin/cilium-envoy` (or `cilium-envoy`) (from `Makefile`)
- `envoy-debug` (from `Makefile.dev`) -> possible by using `DEBUG=1 make cilium-envoy`

(`Makefile` also contains the new targets for the starter application - these would be missing from `Makefile.dev`)