### PR TITLE
bpfmetadata: refactor getMetadata by extracting methods

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -375,8 +375,8 @@ bool Config::getMetadata(Network::ConnectionSocket& socket) {
 
     pod_ip = ip->addressAsString();
 
-    auto new_id = resolvePolicyId(ip);
-    if (new_id == Cilium::ID::WORLD) {
+    auto new_source_id = resolvePolicyId(ip);
+    if (new_source_id == Cilium::ID::WORLD) {
       // No security ID available for the configured source IP
       ENVOY_LOG(warn,
                 "cilium.bpf_metadata (north/south L7 LB): Unknown local IP source address "
@@ -389,7 +389,7 @@ bool Config::getMetadata(Network::ConnectionSocket& socket) {
     if (enforce_policy_on_l7lb_)
       ingress_source_identity = source_identity;
 
-    source_identity = new_id;
+    source_identity = new_source_id;
 
     // AllowAllEgressPolicy will be returned if no explicit Ingress policy exists
     policy = getPolicy(pod_ip);

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -53,6 +53,14 @@ private:
   uint32_t resolveSourceIdentity(const PolicyInstanceConstSharedPtr policy,
                                  const Network::Address::Ip* sip, const Network::Address::Ip* dip,
                                  bool ingress, bool isL7LB);
+
+  IPAddressPair getIPAddressPairFrom(const Network::Address::InstanceConstSharedPtr sourceAddress,
+                                     const IPAddressPair& addresses);
+
+  const Network::Address::Ip*
+  selectIPVersion(const Network::Address::IpVersion version,
+                  const Network::Address::InstanceConstSharedPtr ipv4SourceAddress,
+                  const Network::Address::InstanceConstSharedPtr ipv6SourceAddress);
 };
 
 typedef std::shared_ptr<Config> ConfigSharedPtr;

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -57,10 +57,8 @@ private:
   IPAddressPair getIPAddressPairFrom(const Network::Address::InstanceConstSharedPtr sourceAddress,
                                      const IPAddressPair& addresses);
 
-  const Network::Address::Ip*
-  selectIPVersion(const Network::Address::IpVersion version,
-                  const Network::Address::InstanceConstSharedPtr ipv4SourceAddress,
-                  const Network::Address::InstanceConstSharedPtr ipv6SourceAddress);
+  const Network::Address::Ip* selectIPVersion(const Network::Address::IpVersion version,
+                                              const IPAddressPair& sourceAddresses);
 };
 
 typedef std::shared_ptr<Config> ConfigSharedPtr;

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -48,6 +48,11 @@ public:
   Cilium::CtMapSharedPtr ct_maps_{};
   Cilium::IPCacheSharedPtr ipcache_{};
   std::shared_ptr<const Cilium::PolicyHostMap> hosts_{};
+
+private:
+  uint32_t resolveSourceIdentity(const PolicyInstanceConstSharedPtr policy,
+                                 const Network::Address::Ip* sip, const Network::Address::Ip* dip,
+                                 bool ingress, bool isL7LB);
 };
 
 typedef std::shared_ptr<Config> ConfigSharedPtr;

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -90,6 +90,9 @@ private:
 class IPAddressPair {
 public:
   IPAddressPair(){};
+  IPAddressPair(Network::Address::InstanceConstSharedPtr& ipv4,
+                Network::Address::InstanceConstSharedPtr& ipv6)
+      : ipv4_(ipv4), ipv6_(ipv6){};
   IPAddressPair(const cilium::NetworkPolicy& proto);
 
   Network::Address::InstanceConstSharedPtr ipv4_{};


### PR DESCRIPTION
This PR refactors the function `BPFMetadata.getMetadata` by extracting logic into separate functions

- `resolveSourceIdentity`
- `getIPAddressPairFrom`
- `selectIPVersion`

In addition some small other refactorings were added. All of this should help to ease the understanding of this function and the BPFMetadata listener filter in general.

Please review the individual commits.