### PR TITLE
bpfmetadata: change loglevel of unsuccessful ct lookup from info to debug

### DIFF
--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -225,7 +225,7 @@ uint32_t CtMap::lookupSrcIdentity(const std::string& map_name, const Network::Ad
     auto ct = it->second.get();
     if (!ct->ctmap4_tcp_.lookup(&key4, &value)) {
       ct_maps4_.erase(it); // flush the map to force reload after each failure.
-      ENVOY_LOG(info, "cilium.bpf_metadata: IPv4 conntrack map {} lookup failed: {}", map_name,
+      ENVOY_LOG(debug, "cilium.bpf_metadata: IPv4 conntrack map {} lookup failed: {}", map_name,
                 Envoy::errorDetails(errno));
       return 0;
     }
@@ -243,7 +243,7 @@ uint32_t CtMap::lookupSrcIdentity(const std::string& map_name, const Network::Ad
     auto ct = it->second.get();
     if (!ct->ctmap6_tcp_.lookup(&key6, &value)) {
       ct_maps6_.erase(it); // flush the map to force reload after each failure.
-      ENVOY_LOG(info, "cilium.bpf_metadata: IPv6 conntrack map {} lookup failed: {}", map_name,
+      ENVOY_LOG(debug, "cilium.bpf_metadata: IPv6 conntrack map {} lookup failed: {}", map_name,
                 Envoy::errorDetails(errno));
       return 0;
     }


### PR DESCRIPTION
Currently, during BPF metadata extraction, the source security id gets resolved by looking up the ID in the conntrack and ipcache BPF map. (preferring conntrack, with a fallback to ipcache).

If the loglevel of the Cilium Proxy (Envoy) is set to `info` (default), this leads to the following logoutput.

```
[2024-03-27 08:06:10.227][27][info][filter] [cilium/conntrack.cc:229] cilium.bpf_metadata: IPv4 conntrack map global lookup failed: Success
```

This might confuses users - especially because there's no indication that this was only the first attempt in the conntrack map, without a signal that there's the fallback to the ipcache map. This gets visible once loglevel is set to `debug`.

```
[2024-03-27 08:06:10.227][27][info][filter] [cilium/conntrack.cc:229] cilium.bpf_metadata: IPv4 conntrack map global lookup failed: Success
[2024-03-27 08:06:10.227][27][debug][filter] [cilium/ipcache.cc:90] cilium.ipcache: 127.0.0.1 has ID 2
```

Therefore, this commit sets the loglevel of the unsuccessful ct map lookup to the same loglevel `debug`.