### PR TITLE
build: Enable local_ratelimit and http_inspector listener filters

### DIFF
--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -174,8 +174,8 @@ EXTENSIONS = {
     # Listener filters
     #
 
-    # "envoy.filters.listener.http_inspector":            "//source/extensions/filters/listener/http_inspector:config",
-    # "envoy.filters.listener.local_ratelimit":           "//source/extensions/filters/listener/local_ratelimit:config",
+    "envoy.filters.listener.http_inspector":            "//source/extensions/filters/listener/http_inspector:config",
+    "envoy.filters.listener.local_ratelimit":           "//source/extensions/filters/listener/local_ratelimit:config",
     # NOTE: The original_dst filter is implicitly loaded if original_dst functionality is
     #       configured on the listener. Do not remove it in that case or configs will fail to load.
     # "envoy.filters.listener.original_dst":              "//source/extensions/filters/listener/original_dst:config",


### PR DESCRIPTION
Enable local_ratelimit and http_inspector listeners filters as they may come in handy in some situations and do not interfere with Cilium integration (like original_dst and original_src listener filters could).