### PR TITLE
Ipcache reopen on cilium restart

### DIFF
--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -41,6 +41,7 @@ envoy_cc_library(
         "//cilium:accesslog_lib",
         "//cilium:conntrack_lib",
         "//cilium:grpc_subscription_lib",
+        "//cilium:ipcache_lib",
         "//cilium/api:npds_cc_proto",
         "@envoy//envoy/config:subscription_interface",
         "@envoy//envoy/singleton:manager_interface",

--- a/cilium/bpf.h
+++ b/cilium/bpf.h
@@ -56,6 +56,7 @@ public:
   bool lookup(const void* key, void* value);
 
 protected:
+  std::string path_;
   int fd_;
 
 public:

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -97,7 +97,7 @@ createPolicyMap(Server::Configuration::FactoryContext& context, Cilium::CtMapSha
   return context.serverFactoryContext().singletonManager().getTyped<const Cilium::NetworkPolicyMap>(
       SINGLETON_MANAGER_REGISTERED_NAME(cilium_network_policy), [&context, &ct] {
         auto map = std::make_shared<Cilium::NetworkPolicyMap>(context, ct);
-        map->startSubscription(context);
+        map->startSubscription();
         return map;
       });
 }

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -78,7 +78,6 @@ namespace BpfMetadata {
 // Singleton registration via macro defined in envoy/singleton/manager.h
 SINGLETON_MANAGER_REGISTRATION(cilium_bpf_conntrack);
 SINGLETON_MANAGER_REGISTRATION(cilium_host_map);
-SINGLETON_MANAGER_REGISTRATION(cilium_ipcache);
 SINGLETON_MANAGER_REGISTRATION(cilium_network_policy);
 
 namespace {
@@ -143,14 +142,7 @@ Config::Config(const ::cilium::BpfMetadata& config,
           // later.
           return std::make_shared<Cilium::CtMap>(bpf_root);
         });
-    ipcache_ = context.serverFactoryContext().singletonManager().getTyped<Cilium::IPCache>(
-        SINGLETON_MANAGER_REGISTERED_NAME(cilium_ipcache), [&bpf_root] {
-          auto ipcache = std::make_shared<Cilium::IPCache>(bpf_root);
-          if (!ipcache->Open()) {
-            ipcache.reset();
-          }
-          return ipcache;
-        });
+    ipcache_ = IPCache::NewIPCache(context.serverFactoryContext(), bpf_root);
     if (bpf_root != ct_maps_->bpfRoot()) {
       // bpf root may not change during runtime
       throw EnvoyException(fmt::format("cilium.bpf_metadata: Invalid bpf_root: {}", bpf_root));

--- a/cilium/grpc_subscription.cc
+++ b/cilium/grpc_subscription.cc
@@ -156,8 +156,8 @@ subscribe(const std::string& type_url, const LocalInfo::LocalInfo& local_info,
   };
 
   return std::make_unique<Config::GrpcSubscriptionImpl>(
-      std::make_shared<Config::GrpcMuxImpl>(grpc_mux_context,
-                                            api_config_source.set_node_on_first_message_only()),
+      std::make_shared<GrpcMuxImpl>(grpc_mux_context,
+                                    api_config_source.set_node_on_first_message_only()),
       callbacks, resource_decoder, stats, type_url, dispatcher, init_fetch_timeout,
       /*is_aggregated*/ false, options);
 }

--- a/cilium/grpc_subscription.h
+++ b/cilium/grpc_subscription.h
@@ -8,6 +8,7 @@
 #include "envoy/local_info/local_info.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "source/extensions/config_subscription/grpc/grpc_mux_impl.h"
 #include "source/extensions/config_subscription/grpc/grpc_subscription_impl.h"
 
 namespace Envoy {
@@ -15,6 +16,30 @@ namespace Cilium {
 
 // Cilium XDS API config source. Used for all Cilium XDS.
 extern envoy::config::core::v3::ConfigSource cilium_xds_api_config;
+
+// GrpcMux wrapper to get access to control plane identifier
+class GrpcMuxImpl : public Config::GrpcMuxImpl {
+public:
+  GrpcMuxImpl(Config::GrpcMuxContext& grpc_mux_context, bool skip_subsequent_node)
+      : Config::GrpcMuxImpl(grpc_mux_context, skip_subsequent_node) {}
+
+  ~GrpcMuxImpl() override {}
+
+  void onStreamEstablished() override {
+    new_stream_ = true;
+    Config::GrpcMuxImpl::onStreamEstablished();
+  }
+
+  // isNewStream returns true for the first call after a new stream has been established
+  bool isNewStream() {
+    bool new_stream = new_stream_;
+    new_stream_ = false;
+    return new_stream;
+  }
+
+private:
+  bool new_stream_ = true;
+};
 
 std::unique_ptr<Config::GrpcSubscriptionImpl>
 subscribe(const std::string& type_url, const LocalInfo::LocalInfo& local_info,

--- a/cilium/ipcache.h
+++ b/cilium/ipcache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/network/address.h"
+#include "envoy/server/factory_context.h"
 #include "envoy/singleton/instance.h"
 
 #include "source/common/common/logger.h"
@@ -12,6 +13,10 @@ namespace Cilium {
 
 class IPCache : public Singleton::Instance, public Bpf {
 public:
+  static std::shared_ptr<IPCache> NewIPCache(Server::Configuration::ServerFactoryContext& context,
+                                             const std::string& bpf_root);
+  static std::shared_ptr<IPCache> GetIPCache(Server::Configuration::ServerFactoryContext& context);
+
   IPCache(const std::string& bpf_root);
   bool Open();
 

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -1063,20 +1063,17 @@ private:
 // Common base constructor
 // This is used directly for testing with a file-based subscription
 NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& context)
-    : tls_map_(context.serverFactoryContext().threadLocal()),
-      local_ip_str_(context.serverFactoryContext().localInfo().address()->ip()->addressAsString()),
+    : context_(context.serverFactoryContext()), tls_map_(context_.threadLocal()),
+      local_ip_str_(context_.localInfo().address()->ip()->addressAsString()),
       name_(fmt::format("cilium.policymap.{}.{}.", local_ip_str_, ++instance_id_)),
-      scope_(context.serverFactoryContext().serverScope().createScope(name_)),
+      scope_(context_.serverScope().createScope(name_)),
       init_target_(fmt::format("Cilium Network Policy subscription start"),
                    [this]() { subscription_->start({}); }),
       transport_factory_context_(
           std::make_shared<Server::Configuration::TransportSocketFactoryContextImpl>(
-              context.serverFactoryContext(),
-              context.getTransportSocketFactoryContext().sslContextManager(), *scope_,
-              context.serverFactoryContext().clusterManager(),
-              context.serverFactoryContext()
-                  .messageValidationContext()
-                  .dynamicValidationVisitor())) {
+              context_, context.getTransportSocketFactoryContext().sslContextManager(), *scope_,
+              context_.clusterManager(),
+              context_.messageValidationContext().dynamicValidationVisitor())) {
   // Use listener init manager for the first initialization
   transport_factory_context_->setInitManager(context.initManager());
   context.initManager().add(init_target_);
@@ -1084,9 +1081,9 @@ NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& contex
   ENVOY_LOG(trace, "NetworkPolicyMap({}) created.", name_);
   tls_map_.set([&](Event::Dispatcher&) { return std::make_shared<ThreadLocalPolicyMap>(); });
 
-  if (context.serverFactoryContext().admin().has_value()) {
+  if (context_.admin().has_value()) {
     ENVOY_LOG(debug, "Registering NetworkPolicies to config tracker");
-    config_tracker_entry_ = context.serverFactoryContext().admin()->getConfigTracker().add(
+    config_tracker_entry_ = context_.admin()->getConfigTracker().add(
         "networkpolicies", [this](const Matchers::StringMatcher& name_matcher) {
           return dumpNetworkPolicyConfigs(name_matcher);
         });
@@ -1105,12 +1102,10 @@ NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& contex
 // shared_from_this(), which cannot be called before a shared
 // pointer is formed by the caller of the constructor, hence this
 // can't be called from the constructor!
-void NetworkPolicyMap::startSubscription(Server::Configuration::FactoryContext& context) {
-  subscription_ = subscribe("type.googleapis.com/cilium.NetworkPolicy",
-                            context.serverFactoryContext().localInfo(),
-                            context.serverFactoryContext().clusterManager(),
-                            context.serverFactoryContext().mainThreadDispatcher(),
-                            context.serverFactoryContext().api().randomGenerator(), *scope_, *this,
+void NetworkPolicyMap::startSubscription() {
+  subscription_ = subscribe("type.googleapis.com/cilium.NetworkPolicy", context_.localInfo(),
+                            context_.clusterManager(), context_.mainThreadDispatcher(),
+                            context_.api().randomGenerator(), *scope_, *this,
                             std::make_shared<NetworkPolicyDecoder>());
 }
 
@@ -1274,7 +1269,7 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
         ENVOY_LOG(trace, "Resuming NPDS subscription");
         shared_this->resume();
       } else {
-        ENVOY_LOG_MISC(debug, "NetworkPolicyMap expired on watcher completion!");
+        ENVOY_LOG(debug, "NetworkPolicyMap expired on watcher completion!");
       }
     });
 

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -178,7 +178,7 @@ public:
   // shared_from_this(), which cannot be called before a shared
   // pointer is formed by the caller of the constructor, hence this
   // can't be called from the constructor!
-  void startSubscription(Server::Configuration::FactoryContext& context);
+  void startSubscription();
 
   // This is used for testing with a file-based subscription
   void startSubscription(std::unique_ptr<Envoy::Config::Subscription>&& subscription) {
@@ -225,6 +225,7 @@ private:
 
   static uint64_t instance_id_;
 
+  Server::Configuration::ServerFactoryContext& context_;
   ThreadLocal::TypedSlot<ThreadLocalPolicyMap> tls_map_;
   const std::string local_ip_str_;
   std::string name_;

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -223,6 +223,8 @@ private:
   void pause();
   void resume();
 
+  bool isNewStream();
+
   static uint64_t instance_id_;
 
   Server::Configuration::ServerFactoryContext& context_;


### PR DESCRIPTION
Reopen ipcache whenever a new NetworkPolicy stream is opened. This way we get access to the new ipcache after cilium agent restart.