### PR TITLE
bpf_metadata: Allow use without bpf

### DIFF
--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -122,7 +122,10 @@ namespace {
 
 TestConfig::TestConfig(const ::cilium::TestBpfMetadata& config,
                        Server::Configuration::ListenerFactoryContext& context)
-    : Config(getTestConfig(config), context) {}
+    : Config(getTestConfig(config), context) {
+  hosts_ = hostmap;
+  npmap_ = npmap;
+}
 
 TestConfig::~TestConfig() {
   hostmap.reset();

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -17,6 +17,9 @@ namespace Envoy {
 namespace Cilium {
 namespace {
 
+// Test Cilium::BpfMetadata::Config filter config
+// (NOT Cilium::BpfMetadata::TestConfig)
+
 class MetadataConfigTest : public testing::Test {
 protected:
   MetadataConfigTest() : api_(Api::createApiForTest()) {
@@ -161,6 +164,8 @@ resources:
     context_.initManager().initialize(watcher);
 
     config_ = std::make_shared<Cilium::BpfMetadata::Config>(config, context_);
+    config_->hosts_ = hostmap;
+    config_->npmap_ = npmap;
   }
 
   void TearDown() override {}


### PR DESCRIPTION
Do not try create host or policy maps if bpf_root is not configured. In this mode only egress traffic is allowed, if Cilium policy enforcement filters are also configured and destinations are assumed to not be local to the node so that it is safe to use the original source address if so configured.

Tests can't configure bpf path, but assume full functionality. Adjust test code to mitigate for the change.