### PR TITLE
ci: Update google dep URL

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,6 +41,8 @@ git_repository(
         # https://github.com/envoyproxy/envoy/pull/31894
         "@//patches:0005-Patch-cel-cpp-to-not-break-build.patch",
         "@//patches:0006-original_dst_cluster-Avoid-multiple-hosts-for-the-sa.patch",
+        # This is for https://github.com/envoyproxy/envoy/pull/36515
+        "@//patches:0006-googleurl-dep.patch",
     ],
     # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
     remote = "https://github.com/envoyproxy/envoy.git",

--- a/patches/0006-googleurl-dep.patch
+++ b/patches/0006-googleurl-dep.patch
@@ -1,0 +1,31 @@
+From 55b0fc45cfdc2c0df002690606853540cf794fab Mon Sep 17 00:00:00 2001
+From: alyssawilk <alyssar@chromium.org>
+Date: Wed, 9 Oct 2024 16:23:02 -0400
+Subject: [PATCH] ci: change googleurl dep (#36515)
+
+backing file temporarily deleted and re-updated (with a new hash)
+
+Signed-off-by: Alyssa Wilk <alyssar@chromium.org>
+---
+ bazel/repository_locations.bzl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bazel/repository_locations.bzl b/bazel/repository_locations.bzl
+index b6e02d489b..e42a6e7e2f 100644
+--- a/bazel/repository_locations.bzl
++++ b/bazel/repository_locations.bzl
+@@ -1222,9 +1222,9 @@ REPOSITORY_LOCATIONS_SPEC = dict(
+         project_name = "Chrome URL parsing library",
+         project_desc = "Chrome URL parsing library",
+         project_url = "https://quiche.googlesource.com/googleurl",
+-        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/dd4080fec0b443296c0ed0036e1e776df8813aa7.tar.gz
+         version = "dd4080fec0b443296c0ed0036e1e776df8813aa7",
+-        sha256 = "59f14d4fb373083b9dc8d389f16bbb817b5f936d1d436aa67e16eb6936028a51",
++        sha256 = "fc694942e8a7491dcc1dde1bddf48a31370a1f46fef862bc17acf07c34dc6325",
++        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/dd4080fec0b443296c0ed0036e1e776df8813aa7.tar.gz
+         urls = ["https://storage.googleapis.com/quiche-envoy-integration/{version}.tar.gz"],
+         use_category = ["controlplane", "dataplane_core"],
+         extensions = [],
+-- 
+2.46.2
+


### PR DESCRIPTION
This is to fix the CI failure.

Relates: https://github.com/envoyproxy/envoy/pull/36515