### PR TITLE
build: Enable envoy.transport_sockets.upstream_proxy_protocol

### DIFF
--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -291,7 +291,7 @@ EXTENSIONS = {
 
     # "envoy.transport_sockets.alts":                     "//source/extensions/transport_sockets/alts:config",
     # "envoy.transport_sockets.http_11_proxy":            "//source/extensions/transport_sockets/http_11_proxy:upstream_config",
-    # "envoy.transport_sockets.upstream_proxy_protocol":  "//source/extensions/transport_sockets/proxy_protocol:upstream_config",
+    "envoy.transport_sockets.upstream_proxy_protocol":  "//source/extensions/transport_sockets/proxy_protocol:upstream_config",
     "envoy.transport_sockets.raw_buffer": "//source/extensions/transport_sockets/raw_buffer:config",
     # "envoy.transport_sockets.tap":                      "//source/extensions/transport_sockets/tap:config",
     # "envoy.transport_sockets.starttls":                 "//source/extensions/transport_sockets/starttls:config",


### PR DESCRIPTION
This could be useful on supporting passing through proxy protocol info to downstream.