### PR TITLE
renovate: Remove config for v1.29

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,8 +23,7 @@
   separateMinorPatch: false,
   pruneStaleBranches: true,
   baseBranches: [
-    'main',
-    'v1.29',
+    'main'
   ],
   labels: [
     'kind/enhancement',
@@ -60,24 +59,6 @@
       ],
     },
     {
-      groupName: 'all go dependencies stable',
-      groupSlug: 'all-go-deps-stable',
-      matchFileNames: [
-        'go.mod',
-        'go.sum',
-      ],
-      matchUpdateTypes: [
-        'minor',
-        'digest',
-        'patch',
-        'pin',
-        'pinDigest',
-      ],
-      matchBaseBranches: [
-        'v1.29',
-      ],
-    },
-    {
       groupName: 'all github action dependencies',
       groupSlug: 'all-github-action',
       matchFileNames: [
@@ -102,7 +83,6 @@
       allowedVersions: '22.04',
       matchBaseBranches: [
         'main',
-        'v1.29',
       ],
     },
     {
@@ -124,7 +104,6 @@
       allowedVersions: '22.04',
       matchBaseBranches: [
         'main',
-        'v1.29',
       ],
     },
     {
@@ -134,20 +113,9 @@
       matchPackageNames: [
         'go',
       ],
-      allowedVersions: '<=1.22',
+      allowedVersions: '<=1.23',
       matchBaseBranches: [
         'main',
-        'v1.29',
-      ],
-    },
-    {
-      groupName: 'envoy 1.29.x',
-      matchDepNames: [
-        'envoyproxy/envoy',
-      ],
-      allowedVersions: '<=1.29',
-      matchBaseBranches: [
-        'v1.29',
       ],
     },
     {
@@ -161,17 +129,16 @@
       ],
     },
     {
-      groupName: 'go 1.22.x',
+      groupName: 'go 1.23.x',
       matchFileNames: [
         '.github/workflows/**',
       ],
       matchPackageNames: [
         'go',
       ],
-      allowedVersions: '<=1.22',
+      allowedVersions: '<=1.23',
       matchBaseBranches: [
-        'main',
-        'v1.29',
+        'main'
       ],
     },
   ],

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -1,0 +1,22 @@
+name: Validate Renovate configuration
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json5'
+
+jobs:
+  validate:
+    name: Validate Renovate configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout configuration
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # this step uses latest renovate slim release
+      - name: Validate configuration
+        run: >
+          docker run --rm --entrypoint "renovate-config-validator"
+          -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5"
+          renovate/renovate:slim "/renovate.json5"
+


### PR DESCRIPTION
This stable branch is now read-only, as all stable releases are now with envoy 1.30.x.