### PR TITLE
policy: Do not store policy reference in Cilium socket option

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -146,6 +146,7 @@ jobs:
             --helm-set operator.image.tag=${{ env.CILIUM_IMAGE_TAG }} \
             --helm-set operator.image.useDigest=false \
             --helm-set operator.image.pullPolicy=Never \
+            --helm-set envoy.enabled=false \
             --helm-set debug.enabled=true \
             --helm-set debug.verbose=envoy
 
@@ -155,7 +156,7 @@ jobs:
 
       - name: Execute Cilium L7 Connectivity Tests
         shell: bash
-        run: cilium connectivity test --test=l7
+        run: cilium connectivity test --test="l7|sni|check-log-errors"
 
       - name: Gather Cilium system dump
         if: failure()

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -443,7 +443,7 @@ Cilium::SocketOptionSharedPtr Config::getMetadata(Network::ConnectionSocket& soc
     mark = ((is_ingress_) ? 0x0A00 : 0x0B00) | cluster_id | identity_id;
   }
   return std::make_shared<Cilium::SocketOption>(
-      policy, mark, ingress_source_identity, source_identity, is_ingress_, is_l7lb_, dip->port(),
+      mark, ingress_source_identity, source_identity, is_ingress_, is_l7lb_, dip->port(),
       std::move(pod_ip), std::move(src_address), std::move(source_addresses.ipv4_),
       std::move(source_addresses.ipv6_), shared_from_this(), proxy_id_, sni);
 }

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -606,6 +606,17 @@ public:
     }
   }
 
+  ~PortNetworkPolicyRules() {
+    if (!Thread::MainThread::isMainOrTestThread()) {
+      ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::envoy_bug), error,
+                          "envoy bug failure: !Thread::MainThread::isMainOrTestThread()");
+      Envoy::Assert::EnvoyBugStackTrace st;
+      st.capture();
+      st.logStackTrace();
+      ::abort();
+    }
+  }
+
   bool allowed(uint32_t remote_id, Envoy::Http::RequestHeaderMap& headers,
                Cilium::AccessLog::Entry& log_entry, bool& denied) const {
     // Empty set matches any payload from anyone

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -109,7 +109,7 @@ public:
 
 class PolicyInstance {
 public:
-  virtual ~PolicyInstance() = default;
+  virtual ~PolicyInstance() { ASSERT_IS_MAIN_OR_TEST_THREAD(); };
 
   virtual bool allowed(bool ingress, uint32_t remote_id, uint16_t port,
                        Envoy::Http::RequestHeaderMap& headers,

--- a/cilium/secret_watcher.cc
+++ b/cilium/secret_watcher.cc
@@ -34,7 +34,10 @@ SecretWatcher::SecretWatcher(const NetworkPolicyMap& parent, const std::string& 
       secret_provider_(secretProvider(parent.transportFactoryContext(), sds_name)),
       update_secret_(readAndWatchSecret()) {}
 
-SecretWatcher::~SecretWatcher() { delete load(); }
+SecretWatcher::~SecretWatcher() {
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  delete load();
+}
 
 Envoy::Common::CallbackHandlePtr SecretWatcher::readAndWatchSecret() {
   THROW_IF_NOT_OK(store());

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -222,19 +222,18 @@ public:
 
 class SocketOption : public SocketMarkOption {
 public:
-  SocketOption(PolicyInstanceConstSharedPtr policy, uint32_t mark, uint32_t ingress_source_identity,
-               uint32_t source_identity, bool ingress, bool l7lb, uint16_t port,
-               std::string&& pod_ip,
+  SocketOption(uint32_t mark, uint32_t ingress_source_identity, uint32_t source_identity,
+               bool ingress, bool l7lb, uint16_t port, std::string&& pod_ip,
                Network::Address::InstanceConstSharedPtr original_source_address,
                Network::Address::InstanceConstSharedPtr ipv4_source_address,
                Network::Address::InstanceConstSharedPtr ipv6_source_address,
-               const std::shared_ptr<PolicyResolver>& policy_id_resolver, uint32_t proxy_id,
+               const std::shared_ptr<PolicyResolver>& policy_resolver, uint32_t proxy_id,
                absl::string_view sni)
       : SocketMarkOption(mark, source_identity, original_source_address, ipv4_source_address,
                          ipv6_source_address),
-        ingress_source_identity_(ingress_source_identity), initial_policy_(policy),
-        ingress_(ingress), is_l7lb_(l7lb), port_(port), pod_ip_(std::move(pod_ip)),
-        proxy_id_(proxy_id), sni_(sni), policy_id_resolver_(policy_id_resolver) {
+        ingress_source_identity_(ingress_source_identity), ingress_(ingress), is_l7lb_(l7lb),
+        port_(port), pod_ip_(std::move(pod_ip)), proxy_id_(proxy_id), sni_(sni),
+        policy_resolver_(policy_resolver) {
     ENVOY_LOG(debug,
               "Cilium SocketOption(): source_identity: {}, "
               "ingress: {}, port: {}, pod_ip: {}, source_addresses: {}/{}/{}, mark: {:x} (magic "
@@ -244,15 +243,14 @@ public:
               ipv4_source_address_ ? ipv4_source_address_->asString() : "",
               ipv6_source_address_ ? ipv6_source_address_->asString() : "", mark_, mark & 0xff00,
               mark & 0xff, mark >> 16, proxy_id_, sni_);
-    ASSERT(initial_policy_ != nullptr);
   }
 
   uint32_t resolvePolicyId(const Network::Address::Ip* ip) const {
-    return policy_id_resolver_->resolvePolicyId(ip);
+    return policy_resolver_->resolvePolicyId(ip);
   }
 
   const PolicyInstanceConstSharedPtr getPolicy() const {
-    return policy_id_resolver_->getPolicy(pod_ip_);
+    return policy_resolver_->getPolicy(pod_ip_);
   }
 
   // policyUseUpstreamDestinationAddress returns 'true' if policy enforcement should be done on the
@@ -261,7 +259,6 @@ public:
 
   // Additional ingress policy enforcement is performed if ingress_source_identity is non-zero
   uint32_t ingress_source_identity_;
-  const PolicyInstanceConstSharedPtr initial_policy_; // Never NULL
   bool ingress_;
   bool is_l7lb_;
   uint16_t port_;
@@ -270,7 +267,7 @@ public:
   std::string sni_;
 
 private:
-  const std::shared_ptr<PolicyResolver> policy_id_resolver_;
+  const std::shared_ptr<PolicyResolver> policy_resolver_;
 };
 
 using SocketOptionSharedPtr = std::shared_ptr<SocketOption>;

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -183,9 +183,9 @@ Cilium::SocketOptionSharedPtr TestConfig::getMetadata(Network::ConnectionSocket&
     ENVOY_LOG_MISC(info, "setRequestedApplicationProtocols({})", l7proto);
   }
 
-  return std::make_shared<Cilium::SocketOption>(policy, 0, 0, source_identity, is_ingress_,
-                                                is_l7lb_, port, std::move(pod_ip), nullptr, nullptr,
-                                                nullptr, shared_from_this(), 0, "");
+  return std::make_shared<Cilium::SocketOption>(0, 0, source_identity, is_ingress_, is_l7lb_, port,
+                                                std::move(pod_ip), nullptr, nullptr, nullptr,
+                                                shared_from_this(), 0, "");
 }
 
 } // namespace BpfMetadata

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -263,7 +263,6 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbMetadata) {
   EXPECT_EQ("[face::42]:0", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
-  EXPECT_NE(nullptr, option->initial_policy_);
   EXPECT_EQ(0, option->ingress_source_identity_);
 
   // Check that Ingress security ID is used in the socket mark
@@ -296,14 +295,13 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedMetadata) {
   EXPECT_EQ("[face::42]:0", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
-  EXPECT_NE(nullptr, option->initial_policy_);
   EXPECT_EQ(12345678, option->ingress_source_identity_);
 
   // Check that Ingress security ID is used in the socket mark
   EXPECT_TRUE((option->mark_ & 0xffff) == 0x0B00 && (option->mark_ >> 16) == 8);
 
   // Expect policy accepts security ID 12345678 on ingress on port 80
-  auto port_policy = option->initial_policy_->findPortPolicy(true, 80);
+  auto port_policy = option->getPolicy()->findPortPolicy(true, 80);
   EXPECT_TRUE(port_policy.allowed(12345678, ""));
 }
 
@@ -333,14 +331,13 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedCIDRMetadata) {
   EXPECT_EQ("[face::42]:0", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
-  EXPECT_NE(nullptr, option->initial_policy_);
   EXPECT_EQ(2, option->ingress_source_identity_);
 
   // Check that Ingress security ID is used in the socket mark
   EXPECT_TRUE((option->mark_ & 0xffff) == 0x0B00 && (option->mark_ >> 16) == 8);
 
   // Expect policy does not accept security ID 2 on ingress on port 80
-  auto port_policy = option->initial_policy_->findPortPolicy(true, 80);
+  auto port_policy = option->getPolicy()->findPortPolicy(true, 80);
   EXPECT_FALSE(port_policy.allowed(2, ""));
 }
 
@@ -387,7 +384,6 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadata) {
   EXPECT_EQ("[face::1:1:1]:41234", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.1", option->pod_ip_);
-  EXPECT_NE(nullptr, option->initial_policy_);
 
   // Check that Endpoint's ID is used in the socket mark
   EXPECT_TRUE((option->mark_ & 0xffff) == 0x0900 && (option->mark_ >> 16) == 2048);
@@ -417,7 +413,6 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadataNoOriginalSource) {
   EXPECT_EQ("[face::42]:0", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
-  EXPECT_NE(nullptr, option->initial_policy_);
   EXPECT_EQ(0, option->ingress_source_identity_);
 
   // Check that Ingress ID is used in the socket mark


### PR DESCRIPTION
Remove the member `initial_policy_` from the Cilium `SocketOption` class, as that reference was possibly kept after the policy had already been deleted. This made it possible for the policy to be destructed from the worker thread, which can lead to Envoy crash.

`initial_policy_` was stored as we already did the policy lookup and the same policy is needed in other Cilium filters. Have the `cilium.network` and `cilium.tls_wrapper` filters do their own policy lookups instead, so that we do not need to keep the reference in `SocketOption`.

Worker threads do the policy lookup from their own thread local maps, which hold a reference to the policy. These thread local references are relinquished from post function during policy update, which will release worker thread's last reference to the policy at the time. The main thread is the last one to update or delete policy, so the policy instance destruction happens from the main thread. For this to work it is imperative to only hold policy references in these thread local maps.

Note that even keeping a weak reference accessible to the worker threads outside of the policy maps is risky, as then the worker thread could convert that weak reference to a shared pointer while the reference has already been relinquished from the thread's local policy map. In this situation the other threads could also relinquish their references concurrently to the worker thread holding the shared pointer, which would then become the last reference and destruction would happen from the worker thread again.
