### PR TITLE
socket_option: Change policy_resolver_ to a weak pointer

### DIFF
--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -65,6 +65,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "socket_option_lib",
     hdrs = [
+        "policy_id.h",
         "socket_option.h",
     ],
     repository = "@envoy",
@@ -300,6 +301,7 @@ envoy_cc_library(
     hdrs = [
         "bpf_metadata.h",
         "host_map.h",
+        "policy_id.h",
     ],
     repository = "@envoy",
     deps = [

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -445,7 +445,7 @@ Cilium::SocketOptionSharedPtr Config::getMetadata(Network::ConnectionSocket& soc
   return std::make_shared<Cilium::SocketOption>(
       mark, ingress_source_identity, source_identity, is_ingress_, is_l7lb_, dip->port(),
       std::move(pod_ip), std::move(src_address), std::move(source_addresses.ipv4_),
-      std::move(source_addresses.ipv6_), shared_from_this(), proxy_id_, sni);
+      std::move(source_addresses.ipv6_), weak_from_this(), proxy_id_, sni);
 }
 
 Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -17,6 +17,7 @@
 #include "absl/numeric/int128.h"
 #include "cilium/api/nphds.pb.h"
 #include "cilium/api/nphds.pb.validate.h"
+#include "cilium/policy_id.h"
 
 // std::hash specialization for Abseil uint128, needed for unordered_map key.
 namespace std {
@@ -45,14 +46,6 @@ template <> inline absl::uint128 hton(absl::uint128 addr) {
 template <typename I> I masked(I addr, unsigned int plen) {
   const unsigned int PLEN_MAX = sizeof(I) * 8;
   return plen == 0 ? I(0) : addr & ~hton((I(1) << (PLEN_MAX - plen)) - 1);
-};
-
-enum ID : uint64_t {
-  UNKNOWN = 0,
-  WORLD = 2,
-  // LocalIdentityFlag is the bit in the numeric identity that identifies
-  // a numeric identity to have local scope
-  LocalIdentityFlag = 1 << 24,
 };
 
 class PolicyHostDecoder : public Envoy::Config::OpaqueResourceDecoder {

--- a/cilium/policy_id.h
+++ b/cilium/policy_id.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace Envoy {
+namespace Cilium {
+
+enum ID : uint64_t {
+  UNKNOWN = 0,
+  WORLD = 2,
+  // LocalIdentityFlag is the bit in the numeric identity that identifies
+  // a numeric identity to have local scope
+  LocalIdentityFlag = 1 << 24,
+};
+
+} // namespace Cilium
+} // namespace Envoy


### PR DESCRIPTION
A shared_ptr policy_resolver_ holds on to the passed BpfMetadata::Config, which owns the policy map reference. This could keep the the policy map alive when the listeners are destructed, leading to the destruction of the policy map from a worker thread. Change policy_resolver_ to a weak pointer to resolve this.