### PR TITLE
Tests build all targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,7 +25,7 @@ build:release --fission=dbg
 
 # Manual link stamping, forces link to include current git SHA even if binary is otherwise
 # upto-date
-build --define manual_stamp=manual_stamp
+build:release --define manual_stamp=manual_stamp
 
 # Always have LD_LIBRARY_PATH=/usr/cross-compat/lib defined in the test environment.
 # The path does not need to exist, but can be created when needed for running tests.

--- a/Makefile
+++ b/Makefile
@@ -164,14 +164,14 @@ proxylib/libcilium.so:
 .PHONY: envoy-test-deps
 envoy-test-deps: $(COMPILER_DEP) SOURCE_VERSION proxylib/libcilium.so
 	@$(ECHO_BAZEL)
-	$(BAZEL) $(BAZEL_OPTS) build --build_tests_only -c fastbuild $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
+	$(BAZEL) $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... @envoy//test/integration:tcp_proxy_integration_test $(BAZEL_FILTER)
 
 .PHONY: envoy-tests
 envoy-tests: $(COMPILER_DEP) SOURCE_VERSION proxylib/libcilium.so
 	@$(ECHO_BAZEL)
-	$(BAZEL) $(BAZEL_OPTS) test -c fastbuild $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... $(BAZEL_FILTER)
-	# To validate the upstream integration tests to make sure that our custom patches didn't break anything
-	$(BAZEL) $(BAZEL_OPTS) test -c fastbuild $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) @envoy//test/integration:tcp_proxy_integration_test
+	# Upstream tcp_proxy_integration_test included to validate that our custom patches
+	# didn't break anything
+	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... @envoy//test/integration:tcp_proxy_integration_test $(BAZEL_FILTER)
 
 .PHONY: \
 	install \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Other combinations may work but are not tested.
 
 | Cilium Version | Envoy version |
 |----------------|---------------|
-| (main)         | v1.30.x       |
+| (main)         | v1.31.x       |
 | v1.16.4        | v1.30.6       |
 | v1.16.3        | v1.29.9       |
 | v1.16.2        | v1.29.9       |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,6 +47,7 @@ git_repository(
         "@//patches:0004-Patch-cel-cpp-to-not-break-build.patch",
         "@//patches:0005-original_dst_cluster-Avoid-multiple-hosts-for-the-sa.patch",
         "@//patches:0006-liburing.patch",
+        "@//patches:0007-tcp_proxy-Check-for-nullptr-in-watermark-ASSERTs.patch",
     ],
     # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
     remote = "https://github.com/envoyproxy/envoy.git",

--- a/patches/0007-tcp_proxy-Check-for-nullptr-in-watermark-ASSERTs.patch
+++ b/patches/0007-tcp_proxy-Check-for-nullptr-in-watermark-ASSERTs.patch
@@ -1,0 +1,32 @@
+From 1e054ee1e266386fc53026c327ff915232f76ece Mon Sep 17 00:00:00 2001
+From: Jarno Rajahalme <jarno@isovalent.com>
+Date: Mon, 2 Dec 2024 08:58:54 +0100
+Subject: [PATCH] tcp_proxy: Check for nullptr in watermark ASSERTs
+
+Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
+
+diff --git a/source/common/tcp_proxy/tcp_proxy.cc b/source/common/tcp_proxy/tcp_proxy.cc
+index f28bf3f2ec..e8a37bdbda 100644
+--- a/source/common/tcp_proxy/tcp_proxy.cc
++++ b/source/common/tcp_proxy/tcp_proxy.cc
+@@ -389,7 +389,7 @@ void Filter::UpstreamCallbacks::onEvent(Network::ConnectionEvent event) {
+ 
+ void Filter::UpstreamCallbacks::onAboveWriteBufferHighWatermark() {
+   // TCP Tunneling may call on high/low watermark multiple times.
+-  ASSERT(parent_->config_->tunnelingConfigHelper() || !on_high_watermark_called_);
++  ASSERT(parent_ == nullptr || parent_->config_->tunnelingConfigHelper() || !on_high_watermark_called_);
+   on_high_watermark_called_ = true;
+ 
+   if (parent_ != nullptr) {
+@@ -400,7 +400,7 @@ void Filter::UpstreamCallbacks::onAboveWriteBufferHighWatermark() {
+ 
+ void Filter::UpstreamCallbacks::onBelowWriteBufferLowWatermark() {
+   // TCP Tunneling may call on high/low watermark multiple times.
+-  ASSERT(parent_->config_->tunnelingConfigHelper() || on_high_watermark_called_);
++  ASSERT(parent_ == nullptr || parent_->config_->tunnelingConfigHelper() || on_high_watermark_called_);
+   on_high_watermark_called_ = false;
+ 
+   if (parent_ != nullptr) {
+-- 
+2.47.0
+

--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -10,6 +10,11 @@
 #
 # In each case this script will add file and line information to any backtrace log
 # lines found and echo back all non-Backtrace lines untouched.
+#
+# This has been found to work best if the envoy binary was built with gcc, and with
+# bazel option -c dbg
+# This can be used to decode a stack trace produced by a non-debug gcc build, if
+# the debug build passed to stack_decode.py is otherwise identical.
 
 import re
 import subprocess
@@ -21,15 +26,17 @@ import sys
 # and line information. Output appended to end of original backtrace line. Output
 # any nonmatching lines unmodified. End when EOF received.
 def decode_stacktrace_log(object_file, input_source, address_offset=0):
-    traces = {}
     # Match something like:
     #     [backtrace] [bazel-out/local-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:84]
     backtrace_marker = "\[backtrace\] [^\s]+"
     # Match something like:
+    #     ${backtrace_marker} Address mapping: 010c0000-02a77000
+    offset_re = re.compile("%s Address mapping: ([0-9A-Fa-f]+)-([0-9A-Fa-f]+)" % backtrace_marker)
+    # Match something like:
     #     ${backtrace_marker} #10: SYMBOL [0xADDR]
     # or:
     #     ${backtrace_marker} #10: [0xADDR]
-    stackaddr_re = re.compile("\[#\d+:(?: .*)? \[(0x[0-9a-fA-F]+)\]$")
+    stackaddr_re = re.compile("%s #\d+:(?: .*)? \[(0x[0-9a-fA-F]+)\]$" % backtrace_marker)
     # Match something like:
     #     #10 0xLOCATION (BINARY+0xADDR)
     asan_re = re.compile(" *#\d+ *0x[0-9a-fA-F]+ *\([^+]*\+(0x[0-9a-fA-F]+)\)")
@@ -39,6 +46,11 @@ def decode_stacktrace_log(object_file, input_source, address_offset=0):
             line = input_source.readline()
             if line == "":
                 return  # EOF
+            offset_match = offset_re.search(line)
+            if offset_match:
+                address_offset = int(offset_match.groups()[0], 16)
+                sys.stdout.write("%s (used as address offset)\n" % line.strip())
+                continue
             stackaddr_match = stackaddr_re.search(line)
             if not stackaddr_match:
                 stackaddr_match = asan_re.search(line)
@@ -123,8 +135,13 @@ if __name__ == "__main__":
             sys.argv[1:], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
         offset = find_address_offset(rununder.pid)
         decode_stacktrace_log(sys.argv[1], ignore_decoding_errors(rununder.stdout), offset)
-        rununder.wait()
-        sys.exit(rununder.returncode)  # Pass back test pass/fail result
+        returncode = rununder.wait()
+        # negative return code means process terminated by signal
+        # if so, add 128 to signal value to follow convention.
+        # sys.exit casts to unsigned int so a negative value leads
+        # to unexpected exit code.
+        exitcode = returncode if returncode >= 0 else 128 + abs(returncode)
+        sys.exit(exitcode)  # Pass back test pass/fail result
     else:
         print("Usage (execute subprocess): stack_decode.py executable_file [additional args]")
         print("Usage (read from stdin): stack_decode.py -s executable_file")


### PR DESCRIPTION
Include also non-test targets in the `envoy-test-deps` target in hopes to make running tests with the tests-archive faster.

Other miscellaneous fixes:
- Add a new patch to fix segfault in integration tests when compiled for debug by testing for nullptr in ASSERT (ASSERT is a no-op in release builds)
- Update tools/stack_decode.py (even though it seems to require a GCC debug build to work)
- Update main branch Envoy version in README.md