### PR TITLE
policy: Change abort to an error log

### DIFF
--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -608,12 +608,8 @@ public:
 
   ~PortNetworkPolicyRules() {
     if (!Thread::MainThread::isMainOrTestThread()) {
-      ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::envoy_bug), error,
-                          "envoy bug failure: !Thread::MainThread::isMainOrTestThread()");
-      Envoy::Assert::EnvoyBugStackTrace st;
-      st.capture();
-      st.logStackTrace();
-      ::abort();
+      ENVOY_LOG(error, "PortNetworkPolicyRules: Destructor executing in a worker thread, while "
+                       "only main thread should destruct xDS resources");
     }
   }
 

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -1020,8 +1020,10 @@ egress:
   EXPECT_TRUE(IngressAllowed("10.1.2.3", 43, 90, {{":method", "PUSH"}, {":path", "/allowed"}}));
   EXPECT_TRUE(IngressAllowed("10.1.2.3", 43, 80, {{":method", "GET"}, {":path", "/also_allowed"}}));
   // wrong port for GET
-  EXPECT_FALSE(IngressAllowed("10.1.2.3", 43, 70, {{":method", "GET"}, {":path", "/also_allowed"}}));
-  EXPECT_FALSE(IngressAllowed("10.1.2.3", 43, 90, {{":method", "GET"}, {":path", "/also_allowed"}}));
+  EXPECT_FALSE(
+      IngressAllowed("10.1.2.3", 43, 70, {{":method", "GET"}, {":path", "/also_allowed"}}));
+  EXPECT_FALSE(
+      IngressAllowed("10.1.2.3", 43, 90, {{":method", "GET"}, {":path", "/also_allowed"}}));
   // Wrong remote ID:
   EXPECT_FALSE(IngressAllowed("10.1.2.3", 40, 80, {{":path", "/allowed"}}));
   // Wrong port:
@@ -1105,9 +1107,11 @@ egress:
   EXPECT_TRUE(IngressAllowed("10.1.2.3", 43, 90, {{":method", "PUSH"}, {":path", "/allowed"}}));
   EXPECT_TRUE(IngressAllowed("10.1.2.3", 43, 80, {{":method", "GET"}, {":path", "/also_allowed"}}));
   EXPECT_TRUE(IngressAllowed("10.1.2.3", 43, 90, {{":method", "GET"}, {":path", "/also_allowed"}}));
-  EXPECT_TRUE(IngressAllowed("10.1.2.3", 43, 8080, {{":method", "GET"}, {":path", "/also_allowed"}}));
+  EXPECT_TRUE(
+      IngressAllowed("10.1.2.3", 43, 8080, {{":method", "GET"}, {":path", "/also_allowed"}}));
   // wrong port for GET
-  EXPECT_FALSE(IngressAllowed("10.1.2.3", 43, 70, {{":method", "GET"}, {":path", "/also_allowed"}}));
+  EXPECT_FALSE(
+      IngressAllowed("10.1.2.3", 43, 70, {{":method", "GET"}, {":path", "/also_allowed"}}));
   // Wrong remote ID:
   EXPECT_FALSE(IngressAllowed("10.1.2.3", 40, 80, {{":path", "/allowed"}}));
   // Wrong port:


### PR DESCRIPTION
Log an error instead of crashing when Cilium NetworkPolicy resources are destructed in a worker thread. Remove stacktrace that is not useful at all with release builds.

Prior to enabling use of SDS secrets running NetworkPolicy destructors in a worker thread did not cause visible problems, even though we had taken measures to not do that a long time ago. Now that references to the policy have been removed from the connection metadata (Cilium SocketOption) this should no longer trigger. Nonetheless, crashing Envoy is too drastic as the event may be survivable (as it apparently has been for a long time when running without SDS references in the policy).

Enable trace level logging for troubleshooting if this error ever occurs.

Fixes: #1010