### PR TITLE
renovate: Pin ubuntu version for v1.30 branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,6 +87,18 @@
       ],
     },
     {
+      matchFileNames: [
+        'Dockerfile',
+      ],
+      matchPackageNames: [
+        'docker.io/library/ubuntu',
+      ],
+      allowedVersions: '22.04',
+      matchBaseBranches: [
+        'v1.30',
+      ],
+    },
+    {
       enabled: false,
       matchFileNames: [
         'Dockerfile',


### PR DESCRIPTION
This is related to the below comment. Ideally, we will be able to bump ubuntu version to 24.04 onlt when all Cilium stable releases are with 24.04.

https://github.com/cilium/proxy/pull/1033#issuecomment-2526677354