### PR TITLE
policy: Remove node id from stats prefix

### DIFF
--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -206,7 +206,8 @@ public:
   NetworkPolicyMap(Server::Configuration::FactoryContext& context, Cilium::CtMapSharedPtr& ct,
                    std::chrono::milliseconds policy_update_warning_limit_ms);
   ~NetworkPolicyMap() {
-    ENVOY_LOG(debug, "Cilium L7 NetworkPolicyMap({}): NetworkPolicyMap is deleted NOW!", name_);
+    ENVOY_LOG(debug, "Cilium L7 NetworkPolicyMap({}): NetworkPolicyMap is deleted NOW!",
+              instance_id_);
   }
 
   // subscription_->start() calls onConfigUpdate(), which uses
@@ -262,14 +263,13 @@ private:
 
   bool isNewStream();
 
+  friend class CiliumNetworkPolicyTest;
+
   static uint64_t instance_id_;
 
   Server::Configuration::ServerFactoryContext& context_;
   ThreadLocal::TypedSlot<ThreadLocalPolicyMap> tls_map_;
-  const std::string local_ip_str_;
-  std::string name_;
   Stats::ScopeSharedPtr scope_;
-  PolicyStats stats_;
   Stats::TimespanPtr update_latency_ms_;
   std::chrono::milliseconds policy_update_warning_limit_ms_;
 
@@ -288,6 +288,9 @@ private:
 
   ProtobufTypes::MessagePtr dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_matcher);
   Server::ConfigTracker::EntryOwnerPtr config_tracker_entry_;
+
+protected:
+  PolicyStats stats_;
 };
 
 } // namespace Cilium

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -174,10 +174,16 @@ protected:
     return TlsAllowed(false, pod_ip, remote_id, port, sni, tls_socket_required, raw_socket_allowed);
   }
 
+  std::string updatesRejectedStatName() { return policy_map_->stats_.updates_rejected_.name(); }
+
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   std::shared_ptr<NetworkPolicyMap> policy_map_;
   NiceMock<Stats::TestUtil::TestStore> store_;
 };
+
+TEST_F(CiliumNetworkPolicyTest, UpdatesRejectedStatName) {
+  EXPECT_EQ("cilium.policy.updates_rejected", updatesRejectedStatName());
+}
 
 TEST_F(CiliumNetworkPolicyTest, EmptyPolicyUpdate) {
   EXPECT_TRUE(policy_map_->onConfigUpdate({}, "1").ok());


### PR DESCRIPTION
Simplify stats prefix so that this:

  cilium.policymap.127.0.0.1.3.policy.updates_rejected

becomes:

  cilium.policy.updates_rejected