### PR TITLE
stats: cleanup policy stats names

### DIFF
--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -1214,7 +1214,7 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
             resources.size(), version_info);
   update_latency_ms_ = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
       stats_.update_latency_ms_, context_.timeSource());
-  stats_.updates_.inc();
+  stats_.updates_total_.inc();
 
   absl::flat_hash_set<std::string> keeps;
   absl::flat_hash_set<std::string> ct_maps_to_keep;

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -269,7 +269,8 @@ private:
 
   Server::Configuration::ServerFactoryContext& context_;
   ThreadLocal::TypedSlot<ThreadLocalPolicyMap> tls_map_;
-  Stats::ScopeSharedPtr scope_;
+  Stats::ScopeSharedPtr npds_stats_scope_;
+  Stats::ScopeSharedPtr policy_stats_scope_;
   Stats::TimespanPtr update_latency_ms_;
   std::chrono::milliseconds policy_update_warning_limit_ms_;
 

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -183,7 +183,7 @@ private:
  */
 // clang-format off
 #define ALL_CILIUM_POLICY_STATS(COUNTER, HISTOGRAM)	\
-  COUNTER(updates)					\
+  COUNTER(updates_total)				\
   COUNTER(updates_rejected)				\
   COUNTER(updates_timed_out)				\
   HISTOGRAM(update_latency_ms, Milliseconds)		\


### PR DESCRIPTION
Changes

* stats: rename `updates` to `updates_total`
* stats: different scopes for NPDS & cilium policie stats (`cilium.npds.` & `cilium.policy.`)

Example listing of related metrics as prometheus export
```
root@kind-worker:/home/cilium# cilium envoy admin metrics -f 'npds|policy'
# TYPE envoy_cilium_npds_control_plane_rate_limit_enforced counter
envoy_cilium_npds_control_plane_rate_limit_enforced{} 0
# TYPE envoy_cilium_npds_init_fetch_timeout counter
envoy_cilium_npds_init_fetch_timeout{} 0
# TYPE envoy_cilium_npds_update_attempt counter
envoy_cilium_npds_update_attempt{} 2
# TYPE envoy_cilium_npds_update_failure counter
envoy_cilium_npds_update_failure{} 0
# TYPE envoy_cilium_npds_update_rejected counter
envoy_cilium_npds_update_rejected{} 0
# TYPE envoy_cilium_npds_update_success counter
envoy_cilium_npds_update_success{} 1
# TYPE envoy_cilium_policy_tls_wrapper_missing_policy counter
envoy_cilium_policy_tls_wrapper_missing_policy{} 0
# TYPE envoy_cilium_policy_updates_rejected counter
envoy_cilium_policy_updates_rejected{} 0
# TYPE envoy_cilium_policy_updates_timed_out counter
envoy_cilium_policy_updates_timed_out{} 0
# TYPE envoy_cilium_policy_updates_total counter
envoy_cilium_policy_updates_total{} 1
# TYPE envoy_cilium_npds_control_plane_connected_state gauge
envoy_cilium_npds_control_plane_connected_state{} 1
# TYPE envoy_cilium_npds_control_plane_pending_requests gauge
envoy_cilium_npds_control_plane_pending_requests{} 0
# TYPE envoy_cilium_npds_update_time gauge
envoy_cilium_npds_update_time{} 1734095858792
# TYPE envoy_cilium_npds_version gauge
envoy_cilium_npds_version{} 11379213638070101546
# TYPE envoy_cilium_npds_update_duration histogram
envoy_cilium_npds_update_duration_bucket{le="0.5"} 1
envoy_cilium_npds_update_duration_bucket{le="1"} 1
envoy_cilium_npds_update_duration_bucket{le="5"} 1
envoy_cilium_npds_update_duration_bucket{le="10"} 1
envoy_cilium_npds_update_duration_bucket{le="25"} 1
envoy_cilium_npds_update_duration_bucket{le="50"} 1
envoy_cilium_npds_update_duration_bucket{le="100"} 1
envoy_cilium_npds_update_duration_bucket{le="250"} 1
envoy_cilium_npds_update_duration_bucket{le="500"} 1
envoy_cilium_npds_update_duration_bucket{le="1000"} 1
envoy_cilium_npds_update_duration_bucket{le="2500"} 1
envoy_cilium_npds_update_duration_bucket{le="5000"} 1
envoy_cilium_npds_update_duration_bucket{le="10000"} 1
envoy_cilium_npds_update_duration_bucket{le="30000"} 1
envoy_cilium_npds_update_duration_bucket{le="60000"} 1
envoy_cilium_npds_update_duration_bucket{le="300000"} 1
envoy_cilium_npds_update_duration_bucket{le="600000"} 1
envoy_cilium_npds_update_duration_bucket{le="1800000"} 1
envoy_cilium_npds_update_duration_bucket{le="3600000"} 1
envoy_cilium_npds_update_duration_bucket{le="+Inf"} 1
envoy_cilium_npds_update_duration_sum{} 0
envoy_cilium_npds_update_duration_count{} 1
# TYPE envoy_cilium_policy_update_latency_ms histogram
envoy_cilium_policy_update_latency_ms_bucket{le="0.5"} 0
envoy_cilium_policy_update_latency_ms_bucket{le="1"} 0
envoy_cilium_policy_update_latency_ms_bucket{le="5"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="10"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="25"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="50"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="100"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="250"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="500"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="1000"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="2500"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="5000"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="10000"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="30000"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="60000"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="300000"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="600000"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="1800000"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="3600000"} 1
envoy_cilium_policy_update_latency_ms_bucket{le="+Inf"} 1
envoy_cilium_policy_update_latency_ms_sum{} 2.049999999999999822364316059975
envoy_cilium_policy_update_latency_ms_count{} 1
```

Follow up of: https://github.com/cilium/proxy/pull/1057
Fixes: https://github.com/cilium/proxy/pull/995