### PR TITLE
build: Add debug build step

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -1,7 +1,8 @@
 name: CI Build & Push
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+#  pull_request_target:
+#    types: [opened, synchronize, reopened]
+  pull_request: {}
 
 permissions:
   # To be able to access the repository with `actions/checkout`
@@ -9,9 +10,9 @@ permissions:
   # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
   id-token: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+#  cancel-in-progress: true
 
 jobs:
   build-and-push-prs:

--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -78,6 +78,24 @@ jobs:
           echo "Digests:"
           echo "quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}@${{ steps.docker_build_builder_ci.outputs.digest }}"
 
+      - name: PR Multi-arch build & push of cilium-envoy (debug)
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        id: docker_build_ci_debug
+        with:
+          provenance: false
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            BUILDER_BASE=quay.io/cilium/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:main-archive-latest
+            BAZEL_BUILD_OPTS=--remote_upload_local_results=false
+            DEBUG=true
+          cache-from: type=local,src=/tmp/buildx-cache
+          cache-to: type=local,dest=/tmp/buildx-cache,mode=max
+          push: true
+          tags: quay.io/${{ github.repository_owner }}/cilium-envoy-dev:debug-${{ github.event.pull_request.head.sha }}
+
       - name: PR Multi-arch build & push of cilium-envoy
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
         id: docker_build_ci

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -183,6 +183,28 @@ jobs:
           rm -rf /tmp/buildx-cache/*
           docker buildx prune -f
 
+      - name: Multi-arch build & push main latest (debug)
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        id: docker_build_cd_debug
+        with:
+          provenance: false
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.BUILDER_DOCKER_HASH }}
+            BAZEL_BUILD_OPTS=--remote_upload_local_results=false
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:main-archive-latest
+            DEBUG=true
+          cache-to: type=local,dest=/tmp/buildx-cache,mode=max
+          push: true
+          tags: |
+            quay.io/${{ github.repository_owner }}/cilium-envoy:debug-latest
+            quay.io/${{ github.repository_owner }}/cilium-envoy:debug-${{ github.sha }}
+            quay.io/${{ github.repository_owner }}/cilium-envoy:debug-${{ env.ENVOY_MINOR_RELEASE }}-${{ github.sha }}
+            quay.io/${{ github.repository_owner }}/cilium-envoy:debug-${{ env.ENVOY_PATCH_RELEASE }}-${{ github.sha }}
+            quay.io/${{ github.repository_owner }}/cilium-envoy:debug-${{ env.ENVOY_PATCH_RELEASE }}-${{ env.SOURCE_TIMESTAMP }}-${{ github.sha }}
+
       - name: Multi-arch build & push main latest
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
         id: docker_build_cd

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,6 +48,7 @@ git_repository(
         "@//patches:0005-original_dst_cluster-Avoid-multiple-hosts-for-the-sa.patch",
         "@//patches:0006-liburing.patch",
         "@//patches:0007-tcp_proxy-Check-for-nullptr-in-watermark-ASSERTs.patch",
+        "@//patches:0008-thread_local-reset-slot-in-worker-threads-first.patch",
     ],
     # // clang-format off: Envoy's format check: Only repository_locations.bzl may contains URL references
     remote = "https://github.com/envoyproxy/envoy.git",

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -608,8 +608,8 @@ public:
 
   ~PortNetworkPolicyRules() {
     if (!Thread::MainThread::isMainOrTestThread()) {
-      ENVOY_LOG(error, "PortNetworkPolicyRules: Destructor executing in a worker thread, while "
-                       "only main thread should destruct xDS resources");
+      IS_ENVOY_BUG("PortNetworkPolicyRules: Destructor executing in a worker thread, while "
+                   "only main thread should destruct xDS resources");
     }
   }
 

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -113,6 +113,9 @@ public:
     if (!Thread::MainThread::isMainOrTestThread()) {
       ENVOY_LOG_MISC(error, "PolicyInstance: Destructor executing in a worker thread, while "
                             "only main thread should destruct xDS resources");
+      Assert::EnvoyBugStackTrace st;
+      st.capture();
+      st.logStackTrace();
     }
   };
 

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -111,8 +111,8 @@ class PolicyInstance {
 public:
   virtual ~PolicyInstance() {
     if (!Thread::MainThread::isMainOrTestThread()) {
-      ENVOY_LOG_MISC(error, "PolicyInstance: Destructor executing in a worker thread, while "
-                            "only main thread should destruct xDS resources");
+      IS_ENVOY_BUG("PolicyInstance: Destructor executing in a worker thread, while "
+                   "only main thread should destruct xDS resources");
       Assert::EnvoyBugStackTrace st;
       st.capture();
       st.logStackTrace();

--- a/cilium/secret_watcher.cc
+++ b/cilium/secret_watcher.cc
@@ -38,6 +38,9 @@ SecretWatcher::~SecretWatcher() {
   if (!Thread::MainThread::isMainOrTestThread()) {
     ENVOY_LOG(error, "SecretWatcher: Destructor executing in a worker thread, while "
                      "only main thread should destruct xDS resources");
+    Assert::EnvoyBugStackTrace st;
+    st.capture();
+    st.logStackTrace();
   }
   delete load();
 }

--- a/patches/0007-tcp_proxy-Check-for-nullptr-in-watermark-ASSERTs.patch
+++ b/patches/0007-tcp_proxy-Check-for-nullptr-in-watermark-ASSERTs.patch
@@ -1,7 +1,7 @@
 From 1e054ee1e266386fc53026c327ff915232f76ece Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
 Date: Mon, 2 Dec 2024 08:58:54 +0100
-Subject: [PATCH] tcp_proxy: Check for nullptr in watermark ASSERTs
+Subject: [PATCH 7/8] tcp_proxy: Check for nullptr in watermark ASSERTs
 
 Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
 
@@ -28,5 +28,5 @@ index f28bf3f2ec..e8a37bdbda 100644
  
    if (parent_ != nullptr) {
 -- 
-2.47.0
+2.34.1
 

--- a/patches/0008-thread_local-reset-slot-in-worker-threads-first.patch
+++ b/patches/0008-thread_local-reset-slot-in-worker-threads-first.patch
@@ -1,0 +1,79 @@
+From 1a0f7e26bc8b2905d87c64f7fea9df42e874c28a Mon Sep 17 00:00:00 2001
+From: Jarno Rajahalme <jarno@isovalent.com>
+Date: Mon, 23 Dec 2024 22:43:15 +0100
+Subject: [PATCH 8/8] thread_local: reset slot in worker threads first
+
+Thread local slots refer to their data via shared pointers. Reset the
+shared pointer first in the worker threads, and last in the main thread
+so that the referred object is destructed in the main thread instead of
+some random worker thread. This prevents xDS stream synchronization bugs
+if the slot happens to refer to an SDS secret.
+
+Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
+
+diff --git a/source/common/thread_local/thread_local_impl.cc b/source/common/thread_local/thread_local_impl.cc
+index bd417164b1..34d1c0f1b2 100644
+--- a/source/common/thread_local/thread_local_impl.cc
++++ b/source/common/thread_local/thread_local_impl.cc
+@@ -177,7 +177,8 @@ void InstanceImpl::removeSlot(uint32_t slot) {
+              free_slot_indexes_.end(),
+          fmt::format("slot index {} already in free slot set!", slot));
+   free_slot_indexes_.push_back(slot);
+-  runOnAllThreads([slot]() -> void {
++
++  auto cb = [slot]() -> void {
+     // This runs on each thread and clears the slot, making it available for a new allocations.
+     // This is safe even if a new allocation comes in, because everything happens with post() and
+     // will be sequenced after this removal. It is also safe if there are callbacks pending on
+@@ -185,7 +186,12 @@ void InstanceImpl::removeSlot(uint32_t slot) {
+     if (slot < thread_local_data_.data_.size()) {
+       thread_local_data_.data_[slot] = nullptr;
+     }
+-  });
++  };
++  // 'cb' is called in the main thread after it has been called on all worker threads.
++  // This makes sure the last shared pointer reference is released in the main thread,
++  // so that the thread local data is destructed in the main thread instead of some random
++  // worker thread.
++  runOnAllWorkerThreads(cb, cb);
+ }
+ 
+ void InstanceImpl::runOnAllThreads(std::function<void()> cb) {
+@@ -220,6 +226,22 @@ void InstanceImpl::runOnAllThreads(std::function<void()> cb,
+   }
+ }
+ 
++void InstanceImpl::runOnAllWorkerThreads(std::function<void()> cb,
++                                         std::function<void()> worker_threads_complete_cb) {
++  ASSERT_IS_MAIN_OR_TEST_THREAD();
++  ASSERT(!shutdown_);
++
++  std::shared_ptr<std::function<void()>> cb_guard(
++      new std::function<void()>(cb), [this, worker_threads_complete_cb](std::function<void()>* cb) {
++        main_thread_dispatcher_->post(worker_threads_complete_cb);
++        delete cb;
++      });
++
++  for (Event::Dispatcher& dispatcher : registered_threads_) {
++    dispatcher.post([cb_guard]() -> void { (*cb_guard)(); });
++  }
++}
++
+ void InstanceImpl::setThreadLocal(uint32_t index, ThreadLocalObjectSharedPtr object) {
+   if (thread_local_data_.data_.size() <= index) {
+     thread_local_data_.data_.resize(index + 1);
+diff --git a/source/common/thread_local/thread_local_impl.h b/source/common/thread_local/thread_local_impl.h
+index 90753101b6..108cf85152 100644
+--- a/source/common/thread_local/thread_local_impl.h
++++ b/source/common/thread_local/thread_local_impl.h
+@@ -75,6 +75,7 @@ private:
+   void removeSlot(uint32_t slot);
+   void runOnAllThreads(std::function<void()> cb);
+   void runOnAllThreads(std::function<void()> cb, std::function<void()> main_callback);
++  void runOnAllWorkerThreads(std::function<void()> cb, std::function<void()> main_callback);
+   static void setThreadLocal(uint32_t index, ThreadLocalObjectSharedPtr object);
+ 
+   static thread_local ThreadLocalData thread_local_data_;
+-- 
+2.34.1
+


### PR DESCRIPTION
This is not optimal as the build is running twice, ideally, we can build with debug symbols and then strip later. Just for quick testing purpose.