### PR TITLE
Enable UDP listener & proxy support

### DIFF
--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/api/io_error.h"
 #include "envoy/json/json_object.h"
 #include "envoy/network/filter.h"
 #include "envoy/server/filter_config.h"
@@ -79,6 +80,24 @@ public:
 
   // Network::ListenerFilter
   size_t maxReadBytes() const override;
+
+private:
+  const ConfigSharedPtr config_;
+};
+
+/**
+ * Implementation of a UDP bpf metadata listener filter.
+ */
+class UdpInstance : public Network::UdpListenerReadFilter, Logger::Loggable<Logger::Id::filter> {
+public:
+  UdpInstance(const ConfigSharedPtr& config, Network::UdpReadFilterCallbacks& callbacks)
+      : UdpListenerReadFilter(callbacks), config_(config) {}
+
+  // Network::UdpListenerReadFilter
+  Network::FilterStatus onData(Network::UdpRecvData& data) override;
+
+  // Network::UdpListenerReadFilter
+  Network::FilterStatus onReceiveError(Api::IoError::IoErrorCode error_code) override;
 
 private:
   const ConfigSharedPtr config_;

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -223,14 +223,14 @@ EXTENSIONS = {
     #
 
     # "envoy.filters.udp.dns_filter":                     "//source/extensions/filters/udp/dns_filter:config",
-    # "envoy.filters.udp_listener.udp_proxy":             "//source/extensions/filters/udp/udp_proxy:config",
+    "envoy.filters.udp_listener.udp_proxy":             "//source/extensions/filters/udp/udp_proxy:config",
 
     #
     # UDP Session filters
     #
 
-    # "envoy.filters.udp.session.http_capsule":           "//source/extensions/filters/udp/udp_proxy/session_filters/http_capsule:config",
-    # "envoy.filters.udp.session.dynamic_forward_proxy":  "//source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy:config",
+    "envoy.filters.udp.session.http_capsule":           "//source/extensions/filters/udp/udp_proxy/session_filters/http_capsule:config",
+    "envoy.filters.udp.session.dynamic_forward_proxy":  "//source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy:config",
 
     #
     # Resource monitors


### PR DESCRIPTION
```
extensions: enable udp proxy

This commit enables the UDP proxy related envoy extensions.

* `UDPProxy` UDP listener filter
* `HTTPCapsule` UDP session filter
* `DynamicForwardProxy` UDP session filter
```

```
bpf_metadata: introduce udp bpf_metadata factory & instance

Currently, configuring a UDP listener (Envoy listener with socket
address protocol set to `udp`) with a UDPProxy in Envoy may
fail due to Envoy missing privileges to bind the listener
address.

The reason is that the Cilium Proxy uses a "starter" that drops all
privileged capabilities before forking the actual Envoy process
(See https://github.com/cilium/proxy/pull/315 for more details.) Setting up the necessary socket options
is part of the Cilium `BPFMetadata` listener filter.

The current `BPFMetadata` listener filter can't be used as UDP listener
filter (different factory). Therefore, this commit introduces a UDP
capable version of the `BPFMetadata` listener filter. It's only purpose
is to setup the UDP listener socket correctly (IP_TRANSPARENT, SO_REUSEADDR,
...). It's currently NOT adding any BPF metadata related information to the
socket. This is not necessary as the Cilium network filters aren't yet available
for UDP either.
```