### PR TITLE
socket_options: small cleanup regarding setting socket options (IP_TRANSPARENT & SO_REUSEADDR)

### DIFF
--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -92,10 +92,6 @@ public:
     // identity is zero for the listener socket itself, set transparent and reuse options also for
     // the listener socket.
     if (source_address || identity_ == 0) {
-      // Allow reuse of the original source address. This may by needed for
-      // retries to not fail on "address already in use" when using a specific
-      // source address and port.
-
       {
         // Set ip transparent option based on the socket address family
         auto ip_socket_level = SOL_IP;
@@ -125,6 +121,9 @@ public:
         }
       }
 
+      // Allow reuse of the original source address. This may by needed for
+      // retries to not fail on "address already in use" when using a specific
+      // source address and port.
       {
         auto status = socket.setSocketOption(SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
         if (status.return_value_ < 0) {


### PR DESCRIPTION
```
socket_options: combine setting IP_TRANSPARENT for ipv4 & ipv6

This commit reduces boilerplate by reducing the different codepaths
for setting the IP_TRANSPARENT socket option for IPv4 & IPv6.
```

```
socket_options: move comment for SO_REUSEADDR

This commit moves the comment about setting SO_REUSEADDR
socket option to the code that is actually setting the option.
```