### PR TITLE
gitignore: disallow dot files by default and enable explictly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
-.DS_Store
-.idea/
+# Dot files, disallow by default, and enable explicitly
+\.*
+!\.bazelrc
+!\.bazelversion
+!\.clang-format
+!\.github
+!\.gitignore
+
 *.plist
 
 *cscope.files
@@ -33,12 +39,6 @@
 
 # generated for docker builds via make
 /SOURCE_VERSION
-/.dockerignore
-
-# generated for Clion
-/.clwb
-
-/.vagrant
 
 /proxylib/libcilium.so*
 /proxylib/_obj*


### PR DESCRIPTION
Currently, dotfiles are explictly git-ignored via `.gitignore` file.

Instead of adding additional ignores (e.g. direnv' `.envrc`), this commit adopts the upstream pattern of disallowing all dot files by default, and enable explictly.

See: https://github.com/envoyproxy/envoy/blob/main/.gitignore#L1