### PR TITLE
code: cleanup includes - use "include what you use" model

### DIFF
--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -79,7 +79,7 @@ jobs:
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
             COPY_CACHE_EXT=.new
             BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.75"
-            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
+            BAZEL_TEST_OPTS=--test_timeout=600 --local_test_jobs=1 --flaky_test_attempts=3
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
 
@@ -104,7 +104,7 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
-            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
+            BAZEL_TEST_OPTS=--test_timeout=600 --local_test_jobs=1 --flaky_test_attempts=3
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy:latest-testlogs

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -18,23 +18,23 @@ jobs:
     name: Run unit tests for proxylib
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      with:
-        # renovate: datasource=golang-version depName=go
-        go-version: 1.23.4
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        persist-credentials: false
-    - name: Check module vendoring
-      run: |
-        go mod tidy
-        go mod vendor
-        test -z "$(git status --porcelain)" || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
-    - name: Run unit tests
-      run: |
-        make -C proxylib test
+      - name: Install Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.23.4
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Check module vendoring
+        run: |
+          go mod tidy
+          go mod vendor
+          test -z "$(git status --porcelain)" || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
+      - name: Run unit tests
+        run: |
+          make -C proxylib test
 
   tests:
     timeout-minutes: 360
@@ -104,6 +104,6 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:test-${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
-            BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
+            BAZEL_TEST_OPTS=--test_timeout=600 --local_test_jobs=1 --flaky_test_attempts=3
           cache-from: type=local,src=/tmp/buildx-cache
           push: false

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifdef BAZEL_REMOTE_CACHE
   BAZEL_BUILD_OPTS += --remote_cache=$(BAZEL_REMOTE_CACHE)
 endif
 
-BAZEL_TEST_OPTS ?= --jobs=HOST_RAM*.0003 --test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
+BAZEL_TEST_OPTS ?= --jobs=HOST_RAM*.0003 --test_timeout=600 --local_test_jobs=1 --flaky_test_attempts=3
 BAZEL_TEST_OPTS += --test_output=errors
 
 BUILDARCH := $(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))

--- a/cilium/accesslog.cc
+++ b/cilium/accesslog.cc
@@ -1,13 +1,32 @@
 #include "accesslog.h"
 
-#include <errno.h>
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "envoy/common/time.h"
+#include "envoy/http/header_map.h"
+#include "envoy/http/protocol.h"
+#include "envoy/network/address.h"
+#include "envoy/stream_info/stream_info.h"
+
 #include "source/common/common/lock_guard.h"
-#include "source/common/common/utility.h"
+#include "source/common/common/logger.h"
+#include "source/common/common/thread.h"
+#include "source/common/protobuf/utility.h"
+
+#include "absl/strings/numbers.h"
+#include "absl/strings/string_view.h"
+#include "cilium/api/accesslog.pb.h"
+#include "cilium/uds_client.h"
+#include "google/protobuf/struct.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/accesslog.cc
+++ b/cilium/accesslog.cc
@@ -20,13 +20,13 @@
 #include "source/common/common/lock_guard.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 
 #include "absl/strings/numbers.h"
 #include "absl/strings/string_view.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/uds_client.h"
-#include "google/protobuf/struct.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/accesslog.h
+++ b/cilium/accesslog.h
@@ -12,12 +12,12 @@
 #include "envoy/stream_info/stream_info.h"
 
 #include "source/common/common/thread.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 
 #include "absl/base/thread_annotations.h"
 #include "absl/strings/string_view.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/uds_client.h"
-#include "google/protobuf/struct.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/accesslog.h
+++ b/cilium/accesslog.h
@@ -1,15 +1,23 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
+#include <memory>
 #include <string>
 
+#include "envoy/common/time.h"
 #include "envoy/http/header_map.h"
-#include "envoy/network/connection.h"
-#include "envoy/router/router.h"
+#include "envoy/network/address.h"
+#include "envoy/stream_info/filter_state.h"
 #include "envoy/stream_info/stream_info.h"
 
+#include "source/common/common/thread.h"
+
+#include "absl/base/thread_annotations.h"
+#include "absl/strings/string_view.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/uds_client.h"
+#include "google/protobuf/struct.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/bpf.cc
+++ b/cilium/bpf.cc
@@ -1,7 +1,14 @@
 #include "cilium/bpf.h"
 
 #include <errno.h>
+#include <unistd.h>
 
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "source/common/common/logger.h"
 #include "source/common/common/utility.h"
 
 #include "cilium/privileged_service_client.h"

--- a/cilium/bpf.h
+++ b/cilium/bpf.h
@@ -1,15 +1,9 @@
 #pragma once
 
-#include <string.h>
 #include <unistd.h>
 
 #include <cstdint>
-#include <fstream>
-#include <iostream>
-#include <map>
-#include <sstream>
 #include <string>
-#include <vector>
 
 #include "source/common/common/logger.h"
 

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -31,7 +31,7 @@
 #include "source/common/network/address_impl.h"
 #include "source/common/network/upstream_socket_options_filter_state.h"
 #include "source/common/network/utility.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 
 #include "absl/strings/string_view.h"
@@ -43,7 +43,6 @@
 #include "cilium/network_policy.h"
 #include "cilium/policy_id.h"
 #include "cilium/socket_option.h"
-#include "google/protobuf/message.h"
 
 namespace Envoy {
 namespace Server {

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -1,9 +1,16 @@
 #pragma once
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/api/io_error.h"
-#include "envoy/json/json_object.h"
+#include "envoy/network/address.h"
 #include "envoy/network/filter.h"
-#include "envoy/server/filter_config.h"
+#include "envoy/network/listener_filter_buffer.h"
+#include "envoy/server/factory_context.h"
 
 #include "source/common/common/logger.h"
 

--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -1,17 +1,28 @@
 #include "conntrack.h"
 
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <string.h>
 
 #include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
 
 #include "envoy/common/platform.h"
+#include "envoy/network/address.h"
 
+#include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
 #include "source/common/common/utility.h"
-#include "source/common/network/address_impl.h"
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/numeric/int128.h"
+#include "cilium/bpf.h"
 #include "linux/bpf.h"
+#include "linux/type_mapper.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <utility>
 

--- a/cilium/conntrack.h
+++ b/cilium/conntrack.h
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <string>
 
 #include "envoy/network/address.h"

--- a/cilium/conntrack.h
+++ b/cilium/conntrack.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "envoy/network/address.h"
@@ -12,7 +15,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
-#include "bpf.h"
+#include "cilium/bpf.h"
 
 namespace std {
 template <> class hash<const string> {

--- a/cilium/grpc_subscription.cc
+++ b/cilium/grpc_subscription.cc
@@ -24,6 +24,7 @@
 #include "source/common/common/backoff_strategy.h"
 #include "source/common/config/utility.h"
 #include "source/common/grpc/common.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/extensions/config_subscription/grpc/grpc_mux_context.h"
 #include "source/extensions/config_subscription/grpc/grpc_subscription_impl.h"
 
@@ -32,8 +33,6 @@
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
-#include "google/protobuf/descriptor.h"
-#include "google/protobuf/repeated_ptr_field.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/grpc_subscription.h
+++ b/cilium/grpc_subscription.h
@@ -1,13 +1,18 @@
 #pragma once
 
-#include "envoy/config/grpc_mux.h"
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "envoy/common/random_generator.h"
+#include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
-#include "envoy/config/xds_resources_delegate.h"
 #include "envoy/event/dispatcher.h"
-#include "envoy/grpc/async_client.h"
 #include "envoy/local_info/local_info.h"
+#include "envoy/stats/scope.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "source/extensions/config_subscription/grpc/grpc_mux_context.h"
 #include "source/extensions/config_subscription/grpc/grpc_mux_impl.h"
 #include "source/extensions/config_subscription/grpc/grpc_subscription_impl.h"
 

--- a/cilium/health_check_sink.cc
+++ b/cilium/health_check_sink.cc
@@ -13,11 +13,11 @@
 #include "source/common/common/lock_guard.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 
 #include "cilium/api/health_check_sink.pb.h"
 #include "cilium/uds_client.h"
-#include "google/protobuf/any.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/health_check_sink.cc
+++ b/cilium/health_check_sink.cc
@@ -1,8 +1,23 @@
 #include "cilium/health_check_sink.h"
 
-#include "envoy/registry/registry.h"
+#include <map>
+#include <memory>
+#include <string>
 
+#include "envoy/common/time.h"
+#include "envoy/data/core/v3/health_check_event.pb.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/health_checker_config.h"
+#include "envoy/upstream/health_check_event_sink.h"
+
+#include "source/common/common/lock_guard.h"
+#include "source/common/common/logger.h"
+#include "source/common/common/thread.h"
 #include "source/common/protobuf/utility.h"
+
+#include "cilium/api/health_check_sink.pb.h"
+#include "cilium/uds_client.h"
+#include "google/protobuf/any.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/health_check_sink.h
+++ b/cilium/health_check_sink.h
@@ -10,13 +10,12 @@
 #include "envoy/upstream/health_check_event_sink.h"
 
 #include "source/common/common/thread.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 
 #include "absl/base/thread_annotations.h"
 #include "cilium/api/health_check_sink.pb.h"
 #include "cilium/api/health_check_sink.pb.validate.h" // IWYU pragma: keep
 #include "cilium/uds_client.h"
-#include "google/protobuf/any.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/health_check_sink.h
+++ b/cilium/health_check_sink.h
@@ -1,10 +1,22 @@
 #pragma once
 
+#include <map>
+#include <memory>
+#include <string>
+
+#include "envoy/common/time.h"
+#include "envoy/data/core/v3/health_check_event.pb.h"
+#include "envoy/server/health_checker_config.h"
 #include "envoy/upstream/health_check_event_sink.h"
 
+#include "source/common/common/thread.h"
+#include "source/common/protobuf/protobuf.h"
+
+#include "absl/base/thread_annotations.h"
 #include "cilium/api/health_check_sink.pb.h"
-#include "cilium/api/health_check_sink.pb.validate.h"
+#include "cilium/api/health_check_sink.pb.validate.h" // IWYU pragma: keep
 #include "cilium/uds_client.h"
+#include "google/protobuf/any.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/host_map.cc
+++ b/cilium/host_map.cc
@@ -1,11 +1,30 @@
 #include "cilium/host_map.h"
 
+#include <arpa/inet.h>
+#include <fmt/format.h>
+#include <sys/socket.h>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
 #include <string>
-#include <unordered_set>
+#include <utility>
+#include <vector>
 
-#include "source/common/config/utility.h"
-#include "source/common/protobuf/protobuf.h"
+#include "envoy/common/exception.h"
+#include "envoy/config/subscription.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/server/factory_context.h"
+#include "envoy/thread_local/thread_local.h"
+#include "envoy/thread_local/thread_local_object.h"
 
+#include "source/common/common/logger.h"
+#include "source/common/common/macros.h"
+
+#include "absl/numeric/int128.h"
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "cilium/api/nphds.pb.h"
 #include "cilium/grpc_subscription.h"
 
 namespace Envoy {

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -27,7 +27,7 @@
 #include "source/common/common/macros.h"
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 
 #include "absl/container/flat_hash_map.h"
@@ -36,8 +36,6 @@
 #include "cilium/api/nphds.pb.h"
 #include "cilium/api/nphds.pb.validate.h" // IWYU pragma: keep
 #include "cilium/policy_id.h"
-#include "google/protobuf/any.pb.h"
-#include "google/protobuf/repeated_ptr_field.h"
 
 // std::hash specialization for Abseil uint128, needed for unordered_map key.
 namespace std {

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -1,23 +1,43 @@
 #pragma once
 
 #include <arpa/inet.h>
+#include <fmt/format.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/common/exception.h"
 #include "envoy/config/subscription.h"
-#include "envoy/event/dispatcher.h"
-#include "envoy/local_info/local_info.h"
+#include "envoy/network/address.h"
+#include "envoy/protobuf/message_validator.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/singleton/instance.h"
+#include "envoy/stats/scope.h"
 #include "envoy/thread_local/thread_local.h"
-#include "envoy/upstream/cluster_manager.h"
+#include "envoy/thread_local/thread_local_object.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/common/macros.h"
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/message_validator_impl.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/utility.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/numeric/int128.h"
+#include "absl/status/status.h"
 #include "cilium/api/nphds.pb.h"
-#include "cilium/api/nphds.pb.validate.h"
+#include "cilium/api/nphds.pb.validate.h" // IWYU pragma: keep
 #include "cilium/policy_id.h"
+#include "google/protobuf/any.pb.h"
+#include "google/protobuf/repeated_ptr_field.h"
 
 // std::hash specialization for Abseil uint128, needed for unordered_map key.
 namespace std {

--- a/cilium/ipcache.cc
+++ b/cilium/ipcache.cc
@@ -1,13 +1,25 @@
 #include "ipcache.h"
 
 #include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
 
 #include "envoy/common/platform.h"
+#include "envoy/network/address.h"
+#include "envoy/server/factory_context.h"
 #include "envoy/singleton/manager.h"
 
+#include "source/common/common/logger.h"
 #include "source/common/common/utility.h"
 
+#include "absl/numeric/int128.h"
+#include "cilium/bpf.h"
 #include "linux/bpf.h"
+#include "linux/type_mapper.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/ipcache.h
+++ b/cilium/ipcache.h
@@ -1,12 +1,14 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #include "envoy/network/address.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/singleton/instance.h"
 
-#include "source/common/common/logger.h"
-
-#include "bpf.h"
+#include "cilium/bpf.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/l7policy.cc
+++ b/cilium/l7policy.cc
@@ -1,17 +1,36 @@
 #include "cilium/l7policy.h"
 
+#include <fmt/format.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <string>
+#include <utility>
 
+#include "envoy/common/time.h"
+#include "envoy/http/codes.h"
+#include "envoy/http/filter.h"
+#include "envoy/http/filter_factory.h"
+#include "envoy/http/header_map.h"
+#include "envoy/network/address.h"
+#include "envoy/network/socket.h"
 #include "envoy/registry/registry.h"
+#include "envoy/server/factory_context.h"
+#include "envoy/server/filter_config.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats_macros.h"
+#include "envoy/stream_info/filter_state.h"
+#include "envoy/stream_info/stream_info.h"
 
-#include "source/common/buffer/buffer_impl.h"
-#include "source/common/config/utility.h"
-#include "source/common/http/header_map_impl.h"
-#include "source/common/http/utility.h"
-#include "source/common/network/upstream_server_name.h"
-#include "source/common/network/upstream_subject_alt_names.h"
+#include "source/common/common/assert.h"
+#include "source/common/common/logger.h"
+#include "source/common/common/utility.h"
 #include "source/extensions/filters/http/common/factory_base.h"
 
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 #include "cilium/api/l7policy.pb.validate.h"
 #include "cilium/socket_option.h"
 

--- a/cilium/l7policy.h
+++ b/cilium/l7policy.h
@@ -1,14 +1,23 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
-#include "envoy/server/filter_config.h"
-#include "envoy/stats/stats_macros.h"
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/optref.h"
+#include "envoy/common/time.h"
+#include "envoy/http/filter.h"
+#include "envoy/http/header_map.h"
+#include "envoy/http/metadata_interface.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats_macros.h" // IWYU pragma: keep
 
 #include "source/common/common/logger.h"
 
+#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "cilium/accesslog.h"
+#include "cilium/api/accesslog.pb.h"
 #include "cilium/api/l7policy.pb.h"
 
 namespace Envoy {

--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -2,17 +2,38 @@
 
 #include <dlfcn.h>
 
-#include "envoy/network/listen_socket.h"
-#include "envoy/registry/registry.h"
-#include "envoy/server/filter_config.h"
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
-#include "source/common/common/assert.h"
-#include "source/common/common/fmt.h"
+#include "envoy/buffer/buffer.h"
+#include "envoy/network/address.h"
+#include "envoy/network/connection.h"
+#include "envoy/network/filter.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/factory_context.h"
+#include "envoy/server/filter_config.h"
+#include "envoy/stream_info/filter_state.h"
+#include "envoy/stream_info/stream_info.h"
+#include "envoy/upstream/host_description.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/logger.h"
 #include "source/common/network/upstream_server_name.h"
 #include "source/common/network/upstream_subject_alt_names.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/utility.h"
 
-#include "cilium/api/network_filter.pb.validate.h"
+#include "absl/status/statusor.h"
+#include "cilium/accesslog.h"
+#include "cilium/api/accesslog.pb.h"
+#include "cilium/api/network_filter.pb.h"
+#include "cilium/api/network_filter.pb.validate.h" // IWYU pragma: keep
+#include "cilium/proxylib.h"
 #include "cilium/socket_option.h"
+#include "google/protobuf/message.h"
+#include "proxylib/types.h"
 
 namespace Envoy {
 namespace Server {

--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -22,7 +22,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/network/upstream_server_name.h"
 #include "source/common/network/upstream_subject_alt_names.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 
 #include "absl/status/statusor.h"
@@ -32,7 +32,6 @@
 #include "cilium/api/network_filter.pb.validate.h" // IWYU pragma: keep
 #include "cilium/proxylib.h"
 #include "cilium/socket_option.h"
-#include "google/protobuf/message.h"
 #include "proxylib/types.h"
 
 namespace Envoy {

--- a/cilium/network_filter.h
+++ b/cilium/network_filter.h
@@ -1,16 +1,21 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/time.h"
 #include "envoy/json/json_object.h"
-#include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
-#include "envoy/server/filter_config.h"
+#include "envoy/server/factory_context.h"
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
 
 #include "cilium/accesslog.h"
+#include "cilium/api/accesslog.pb.h"
 #include "cilium/api/network_filter.pb.h"
-#include "cilium/conntrack.h"
 #include "cilium/network_policy.h"
 #include "cilium/proxylib.h"
 

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -38,7 +38,7 @@
 #include "source/common/init/target_impl.h"
 #include "source/common/init/watcher_impl.h"
 #include "source/common/network/utility.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 #include "source/common/stats/timespan_impl.h"
 #include "source/extensions/config_subscription/grpc/grpc_subscription_impl.h"
@@ -55,8 +55,6 @@
 #include "cilium/grpc_subscription.h"
 #include "cilium/ipcache.h"
 #include "cilium/secret_watcher.h"
-#include "google/protobuf/repeated_ptr_field.h"
-#include "google/protobuf/util/message_differencer.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -1,27 +1,58 @@
 #pragma once
 
+#include <fmt/format.h>
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/common/exception.h"
+#include "envoy/common/matchers.h"
+#include "envoy/common/pure.h"
+#include "envoy/config/core/v3/base.pb.h"
+#include "envoy/config/grpc_mux.h"
 #include "envoy/config/subscription.h"
 #include "envoy/http/header_map.h"
-#include "envoy/server/filter_config.h"
+#include "envoy/network/address.h"
+#include "envoy/protobuf/message_validator.h"
+#include "envoy/server/config_tracker.h"
+#include "envoy/server/factory_context.h"
+#include "envoy/server/transport_socket_config.h"
 #include "envoy/singleton/instance.h"
-#include "envoy/stats/stats_macros.h"
+#include "envoy/ssl/context.h"
+#include "envoy/ssl/context_config.h"
+#include "envoy/stats/scope.h"
 #include "envoy/stats/timespan.h"
 #include "envoy/thread_local/thread_local.h"
+#include "envoy/thread_local/thread_local_object.h"
 
+#include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
-#include "source/common/config/opaque_resource_decoder_impl.h"
-#include "source/common/http/header_utility.h"
+#include "source/common/common/macros.h"
+#include "source/common/common/thread.h"
 #include "source/common/init/manager_impl.h"
 #include "source/common/init/target_impl.h"
 #include "source/common/init/watcher_impl.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/tls/server_context_config_impl.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/utility.h"
 #include "source/server/transport_socket_config_impl.h"
 
+#include "absl/container/btree_map.h"
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 #include "cilium/accesslog.h"
 #include "cilium/api/npds.pb.h"
-#include "cilium/api/npds.pb.validate.h"
+#include "cilium/api/npds.pb.validate.h" // IWYU pragma: keep
 #include "cilium/conntrack.h"
+#include "google/protobuf/any.pb.h"
+#include "google/protobuf/repeated_ptr_field.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -40,7 +40,7 @@
 #include "source/common/init/target_impl.h"
 #include "source/common/init/watcher_impl.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 #include "source/server/transport_socket_config_impl.h"
 
@@ -51,8 +51,6 @@
 #include "cilium/api/npds.pb.h"
 #include "cilium/api/npds.pb.validate.h" // IWYU pragma: keep
 #include "cilium/conntrack.h"
-#include "google/protobuf/any.pb.h"
-#include "google/protobuf/repeated_ptr_field.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/proxylib.cc
+++ b/cilium/proxylib.cc
@@ -13,9 +13,9 @@
 
 #include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 
 #include "absl/container/fixed_array.h"
-#include "google/protobuf/map.h"
 #include "proxylib/types.h"
 
 namespace Envoy {

--- a/cilium/proxylib.cc
+++ b/cilium/proxylib.cc
@@ -1,13 +1,22 @@
 #include "cilium/proxylib.h"
 
 #include <dlfcn.h>
+#include <fmt/format.h>
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "envoy/buffer/buffer.h"
 #include "envoy/common/exception.h"
+#include "envoy/network/connection.h"
 
 #include "source/common/common/assert.h"
-#include "source/common/common/fmt.h"
+#include "source/common/common/logger.h"
 
 #include "absl/container/fixed_array.h"
+#include "google/protobuf/map.h"
+#include "proxylib/types.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -181,7 +190,7 @@ FilterResult GoFilter::Instance::OnIO(bool reply, Buffer::Instance& data, bool e
     dir.inject_slice_.reset();
   }
 
-  // Do nothing if we don't have enought input (partial input remains buffered)
+  // Do nothing if we don't have enough input (partial input remains buffered)
   if (input_len < dir.need_bytes_) {
     return FILTER_OK;
   }

--- a/cilium/proxylib.h
+++ b/cilium/proxylib.h
@@ -2,13 +2,18 @@
 
 #include <google/protobuf/map.h>
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "envoy/buffer/buffer.h"
 #include "envoy/network/connection.h"
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
-#include "source/common/protobuf/protobuf.h"
 
 #include "proxylib/libcilium.h"
+#include "proxylib/types.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/secret_watcher.cc
+++ b/cilium/secret_watcher.cc
@@ -1,8 +1,30 @@
 #include "cilium/secret_watcher.h"
 
-#include "source/common/config/datasource.h"
+#include <fmt/format.h>
 
+#include <atomic>
+#include <string>
+#include <utility>
+
+#include "envoy/api/api.h"
+#include "envoy/common/callback.h"
+#include "envoy/common/exception.h"
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
+#include "envoy/secret/secret_provider.h"
+#include "envoy/server/transport_socket_config.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/common/thread.h"
+#include "source/common/config/datasource.h"
+#include "source/common/tls/context_config_impl.h"
+#include "source/common/tls/server_context_config_impl.h"
+
+#include "absl/status/status.h"
+#include "absl/synchronization/mutex.h"
+#include "cilium/api/npds.pb.h"
 #include "cilium/grpc_subscription.h"
+#include "cilium/network_policy.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/secret_watcher.h
+++ b/cilium/secret_watcher.h
@@ -1,12 +1,25 @@
 #pragma once
 
+#include <atomic>
+#include <memory>
 #include <string>
+#include <vector>
 
+#include "envoy/common/callback.h"
+#include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/secret/secret_provider.h"
+#include "envoy/ssl/context.h"
+#include "envoy/ssl/context_config.h"
+#include "envoy/ssl/context_manager.h"
+#include "envoy/stats/scope.h"
 
+#include "source/common/common/logger.h"
 #include "source/common/init/target_impl.h"
-#include "source/common/tls/server_context_config_impl.h"
 
+#include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
+#include "absl/synchronization/mutex.h"
+#include "cilium/api/npds.pb.h"
 #include "cilium/network_policy.h"
 
 namespace Envoy {

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -1,12 +1,29 @@
 #pragma once
 
-#include "envoy/config/core/v3/base.pb.h"
-#include "envoy/network/listen_socket.h"
+#include <asm-generic/socket.h>
+#include <linux/in.h>
+#include <linux/in6.h>
+#include <netinet/in.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/common/pure.h"
+#include "envoy/config/core/v3/socket_option.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/network/socket.h"
 
 #include "source/common/common/hex.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/utility.h"
 
+#include "absl/numeric/int128.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 #include "cilium/conntrack.h"
 #include "cilium/network_policy.h"
 #include "cilium/policy_id.h"

--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -21,7 +21,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/network/raw_buffer_socket.h"
 #include "source/common/network/transport_socket_options_impl.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/tls/ssl_socket.h"
 
 #include "absl/status/statusor.h"

--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -1,12 +1,31 @@
 #include "cilium/tls_wrapper.h"
 
-#include "envoy/extensions/transport_sockets/tls/v3/cert.pb.validate.h"
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
+#include "envoy/buffer/buffer.h"
+#include "envoy/network/address.h"
+#include "envoy/network/post_io_action.h"
+#include "envoy/network/transport_socket.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/transport_socket_config.h"
+#include "envoy/ssl/connection.h"
+#include "envoy/ssl/context.h"
+#include "envoy/ssl/context_config.h"
+
+#include "source/common/common/empty_string.h"
+#include "source/common/common/logger.h"
 #include "source/common/network/raw_buffer_socket.h"
-#include "source/common/protobuf/utility.h"
-#include "source/common/tls/context_config_impl.h"
+#include "source/common/network/transport_socket_options_impl.h"
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/tls/ssl_socket.h"
 
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "cilium/api/tls_wrapper.pb.h"
 #include "cilium/network_policy.h"
 #include "cilium/socket_option.h"

--- a/cilium/tls_wrapper.h
+++ b/cilium/tls_wrapper.h
@@ -8,10 +8,9 @@
 #include "envoy/server/transport_socket_config.h"
 #include "envoy/stats/stats_macros.h" // IWYU pragma: keep
 
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 
 #include "absl/status/statusor.h"
-#include "google/protobuf/message.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/tls_wrapper.h
+++ b/cilium/tls_wrapper.h
@@ -1,9 +1,17 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
+#include "envoy/network/transport_socket.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/transport_socket_config.h"
-#include "envoy/stats/scope.h"
-#include "envoy/stats/stats_macros.h"
+#include "envoy/stats/stats_macros.h" // IWYU pragma: keep
+
+#include "source/common/protobuf/protobuf.h"
+
+#include "absl/status/statusor.h"
+#include "google/protobuf/message.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/uds_client.cc
+++ b/cilium/uds_client.cc
@@ -1,14 +1,23 @@
 #include "cilium/uds_client.h"
 
 #include <errno.h>
+#include <fmt/format.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
+#include <memory>
+#include <string>
+
 #include "envoy/common/exception.h"
+#include "envoy/common/time.h"
 
 #include "source/common/common/lock_guard.h"
+#include "source/common/common/logger.h"
+#include "source/common/common/token_bucket_impl.h"
 #include "source/common/common/utility.h"
+#include "source/common/network/address_impl.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/uds_client.h
+++ b/cilium/uds_client.h
@@ -1,12 +1,17 @@
 #pragma once
 
-#include <map>
+#include <memory>
 #include <string>
+
+#include "envoy/common/time.h"
 
 #include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
 #include "source/common/common/token_bucket_impl.h"
 #include "source/common/network/address_impl.h"
+
+#include "absl/base/thread_annotations.h"
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/websocket.cc
+++ b/cilium/websocket.cc
@@ -18,7 +18,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/http/headers.h"
 #include "source/common/network/utility.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 #include "source/common/stream_info/bool_accessor_impl.h"
 #include "source/common/tcp_proxy/tcp_proxy.h"
@@ -29,7 +29,6 @@
 #include "cilium/socket_option.h"
 #include "cilium/websocket_codec.h"
 #include "cilium/websocket_config.h"
-#include "google/protobuf/message.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/websocket.cc
+++ b/cilium/websocket.cc
@@ -2,28 +2,34 @@
 
 #include <http_parser.h>
 
+#include <cstdint>
+#include <memory>
 #include <string>
 
+#include "envoy/buffer/buffer.h"
+#include "envoy/http/header_map.h"
+#include "envoy/network/address.h"
+#include "envoy/network/filter.h"
 #include "envoy/registry/registry.h"
+#include "envoy/server/factory_context.h"
+#include "envoy/server/filter_config.h"
+#include "envoy/stream_info/filter_state.h"
 
-#include "source/common/buffer/buffer_impl.h"
-#include "source/common/common/assert.h"
-#include "source/common/common/base64.h"
-#include "source/common/common/enum_to_int.h"
-#include "source/common/common/hex.h"
-#include "source/common/crypto/crypto_impl.h"
-#include "source/common/crypto/utility.h"
-#include "source/common/http/header_map_impl.h"
-#include "source/common/http/header_utility.h"
-#include "source/common/http/utility.h"
-#include "source/common/network/filter_manager_impl.h"
+#include "source/common/common/logger.h"
+#include "source/common/http/headers.h"
 #include "source/common/network/utility.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/utility.h"
 #include "source/common/stream_info/bool_accessor_impl.h"
 #include "source/common/tcp_proxy/tcp_proxy.h"
 
-#include "cilium/api/websocket.pb.validate.h"
+#include "absl/status/statusor.h"
+#include "cilium/api/websocket.pb.h"
+#include "cilium/api/websocket.pb.validate.h" // IWYU pragma: keep
 #include "cilium/socket_option.h"
-#include "cilium/websocket_protocol.h"
+#include "cilium/websocket_codec.h"
+#include "cilium/websocket_config.h"
+#include "google/protobuf/message.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/websocket.h
+++ b/cilium/websocket.h
@@ -1,17 +1,16 @@
 #pragma once
 
-#include <string>
+#include "envoy/buffer/buffer.h"
+#include "envoy/event/schedulable_cb.h"
+#include "envoy/http/header_map.h"
+#include "envoy/network/address.h"
+#include "envoy/network/filter.h"
+#include "envoy/stats/stats_macros.h" // IWYU pragma: keep
 
-#include "envoy/common/random_generator.h"
-#include "envoy/event/dispatcher.h"
-#include "envoy/event/timer.h"
-#include "envoy/server/filter_config.h"
-#include "envoy/stats/stats_macros.h"
-
-#include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
 
 #include "cilium/accesslog.h"
+#include "cilium/api/accesslog.pb.h"
 #include "cilium/websocket_codec.h"
 #include "cilium/websocket_config.h"
 

--- a/cilium/websocket_codec.cc
+++ b/cilium/websocket_codec.cc
@@ -1,27 +1,38 @@
 #include "cilium/websocket_codec.h"
 
+#include <fmt/format.h>
 #include <http_parser.h>
+#include <sys/types.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <string>
+#include <utility>
 
-#include "envoy/registry/registry.h"
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/pure.h"
+#include "envoy/http/codes.h"
+#include "envoy/http/header_map.h"
+#include "envoy/network/address.h"
+#include "envoy/network/connection.h"
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/assert.h"
-#include "source/common/common/base64.h"
 #include "source/common/common/enum_to_int.h"
 #include "source/common/common/hex.h"
-#include "source/common/crypto/crypto_impl.h"
-#include "source/common/crypto/utility.h"
+#include "source/common/common/logger.h"
+#include "source/common/common/utility.h"
 #include "source/common/http/codes.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/header_utility.h"
+#include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
-#include "source/common/network/filter_manager_impl.h"
 #include "source/common/network/utility.h"
 
-#include "cilium/api/websocket.pb.validate.h"
-#include "cilium/socket_option.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/string_view.h"
+#include "cilium/websocket_config.h"
 #include "cilium/websocket_protocol.h"
 
 namespace Envoy {

--- a/cilium/websocket_codec.h
+++ b/cilium/websocket_codec.h
@@ -1,13 +1,21 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <string>
 
-#include "envoy/event/dispatcher.h"
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/pure.h"
 #include "envoy/event/timer.h"
+#include "envoy/http/header_map.h"
+#include "envoy/network/address.h"
+#include "envoy/network/connection.h"
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
 
+#include "absl/strings/string_view.h"
 #include "cilium/websocket_config.h"
 
 namespace Envoy {

--- a/cilium/websocket_config.cc
+++ b/cilium/websocket_config.cc
@@ -21,6 +21,7 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/base64.h"
 #include "source/common/http/request_id_extension_impl.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 
 #include "absl/strings/ascii.h"
@@ -29,7 +30,6 @@
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/api/websocket.pb.h"
 #include "cilium/websocket_protocol.h"
-#include "google/protobuf/duration.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/websocket_config.h
+++ b/cilium/websocket_config.h
@@ -1,17 +1,26 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <memory>
 #include <string>
+#include <vector>
 
+#include "envoy/buffer/buffer.h"
 #include "envoy/common/random_generator.h"
+#include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/request_id_extension.h"
-#include "envoy/server/filter_config.h"
-#include "envoy/stats/stats_macros.h"
+#include "envoy/server/factory_context.h"
+#include "envoy/stats/stats_macros.h" // IWYU pragma: keep
 
 #include "source/common/common/logger.h"
 
+#include "absl/strings/string_view.h"
 #include "cilium/accesslog.h"
+#include "cilium/api/accesslog.pb.h"
 #include "cilium/api/websocket.pb.h"
+#include "google/protobuf/duration.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/websocket_config.h
+++ b/cilium/websocket_config.h
@@ -15,12 +15,12 @@
 #include "envoy/stats/stats_macros.h" // IWYU pragma: keep
 
 #include "source/common/common/logger.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 
 #include "absl/strings/string_view.h"
 #include "cilium/accesslog.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/api/websocket.pb.h"
-#include "google/protobuf/duration.pb.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/starter/main.cc
+++ b/starter/main.cc
@@ -10,7 +10,18 @@
 #include <syscall.h>
 #include <unistd.h>
 #include <vector>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
 
+#include <linux/capability.h>
+#include <linux/limits.h>
+#include <linux/prctl.h>
+
+#include "starter/privileged_service_protocol.h"
 #include "starter/privileged_service_server.h"
 
 // NOLINT(namespace-envoy)
@@ -71,7 +82,7 @@ int main(int argc, char** argv) {
   envoy_args.push_back(path); // program
 
   if (!delimiter_present) {
-    // backwards compabitility: handle all args as Envoys if delimiter isn't present
+    // backwards compatibility: handle all args as Envoys if delimiter isn't present
     envoy_args.insert(envoy_args.end(), args.begin(), args.end());
   } else {
     // parse arguments and split by delimiter "--"
@@ -113,9 +124,7 @@ int main(int argc, char** argv) {
     close(fds[0]);
 
     // Unconditionally drop all capabilities
-    struct __user_cap_header_struct hdr {
-      _LINUX_CAPABILITY_VERSION_3, 0
-    };
+    struct __user_cap_header_struct hdr{_LINUX_CAPABILITY_VERSION_3, 0};
     struct __user_cap_data_struct data[2];
     memset(&data, 0, sizeof(data));
 

--- a/starter/privileged_service_protocol.cc
+++ b/starter/privileged_service_protocol.cc
@@ -7,12 +7,23 @@
 #include <errno.h>
 #include <sys/syscall.h>
 #include <sys/unistd.h>
+#include <asm-generic/socket.h>
+#include <bits/types/struct_iovec.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <linux/capability.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 namespace Envoy {
 namespace Cilium {
 namespace PrivilegedService {
 
-// Capabiilty names used in DumpCapabilites responses.
+// Capabiilty names used in DumpCapabilities responses.
 static const char* cap_names[64] = {
     "CAP_CHOWN",              //  0
     "CAP_DAC_OVERRIDE",       //  1
@@ -82,9 +93,7 @@ static const char* cap_names[64] = {
 
 // Get a 64-bit set of capabilities of the given kind
 uint64_t get_capabilities(cap_flag_t kind) {
-  struct __user_cap_header_struct hdr {
-    _LINUX_CAPABILITY_VERSION_3, 0
-  };
+  struct __user_cap_header_struct hdr{_LINUX_CAPABILITY_VERSION_3, 0};
   struct __user_cap_data_struct data[2];
   memset(&data, 0, sizeof(data));
   int rc = ::syscall(SYS_capget, &hdr, &data, sizeof(data));
@@ -148,7 +157,7 @@ namespace {
 
 static inline struct msghdr init_iov(struct iovec iov[2], const void* header, ssize_t headerlen,
                                      const void* data, ssize_t datalen) {
-  struct msghdr msg {};
+  struct msghdr msg{};
   msg.msg_iov = iov;
   msg.msg_iovlen = 1;
   iov[0].iov_base = const_cast<void*>(header);

--- a/starter/privileged_service_server.cc
+++ b/starter/privileged_service_server.cc
@@ -5,14 +5,19 @@
 #include "starter/privileged_service_server.h"
 
 #include <errno.h>
-#include <linux/bpf.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <syscall.h>
 #include <unistd.h>
-
 #include <algorithm>
+#include <climits>
+#include <cstdint>
+#include <stdio.h>
+
+#include "starter/privileged_service_protocol.h"
+
+#include <linux/bpf.h>
 
 namespace Envoy {
 namespace Cilium {
@@ -124,7 +129,7 @@ void ProtocolServer::serve() {
     // Form the response in place
     msg.response.hdr_.msg_type_ = TYPE_RESPONSE;
     if (fd_out != -1) {
-      // Pass a poitive but invalid fd in return_value_, to be replaced with the passed
+      // Pass a positive but invalid fd in return_value_, to be replaced with the passed
       // fd by the receiver.
       msg.response.return_value_ = INT_MAX;
       msg.response.errno_ = 0;

--- a/starter/privileged_service_server.h
+++ b/starter/privileged_service_server.h
@@ -4,7 +4,7 @@
 #error "Linux platform file is part of non-Linux build."
 #endif
 
-#include <limits.h>
+#include <linux/limits.h>
 
 #include "starter/privileged_service_protocol.h"
 
@@ -29,7 +29,7 @@ private:
     BpfLookupRequest bpf_lookup_req;
     SetSockOptRequest setsockopt_req;
 
-    // resposes use the same buffer, so they inherit the message sequence number from the request
+    // responses use the same buffer, so they inherit the message sequence number from the request
     Response response;
 
     // make space for the largest possible request

--- a/tests/accesslog_server.cc
+++ b/tests/accesslog_server.cc
@@ -1,9 +1,19 @@
 #include "tests/accesslog_server.h"
 
-#include <errno.h>
 #include <unistd.h>
 
+#include <chrono>
+#include <functional>
 #include <string>
+
+#include "source/common/common/logger.h"
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
+#include "absl/types/optional.h"
+#include "cilium/api/accesslog.pb.h"
+#include "tests/uds_server.h"
 
 namespace Envoy {
 

--- a/tests/accesslog_server.h
+++ b/tests/accesslog_server.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <atomic>
 #include <chrono>
 #include <string>
 #include <vector>
 
 #include "test/test_common/utility.h"
 
+#include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/optional.h"
 #include "cilium/api/accesslog.pb.h"

--- a/tests/accesslog_test.cc
+++ b/tests/accesslog_test.cc
@@ -1,14 +1,16 @@
-#include <cstdint>
+#include <memory>
 
 #include "envoy/http/protocol.h"
 
 #include "source/common/network/address_impl.h"
 
 #include "test/mocks/network/connection.h"
-#include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/upstream/cluster_info.h"
+#include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
 #include "cilium/accesslog.h"
+#include "cilium/api/accesslog.pb.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -1,17 +1,40 @@
 #include "tests/bpf_metadata.h"
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "envoy/common/exception.h"
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/config/subscription.h"
+#include "envoy/network/address.h"
+#include "envoy/network/filter.h"
+#include "envoy/network/listen_socket.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/factory_context.h"
+#include "envoy/server/filter_config.h"
 
 #include "source/common/common/logger.h"
 #include "source/common/config/utility.h"
+#include "source/common/protobuf/message_validator_impl.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/utility.h"
 #include "source/extensions/config_subscription/filesystem/filesystem_subscription_impl.h"
 
 #include "test/test_common/environment.h"
 
+#include "absl/strings/string_view.h"
+#include "cilium/api/bpf_metadata.pb.h"
+#include "cilium/bpf_metadata.h"
+#include "cilium/host_map.h"
+#include "cilium/network_policy.h"
 #include "cilium/secret_watcher.h"
 #include "cilium/socket_option.h"
 #include "fmt/printf.h"
-#include "tests/bpf_metadata.pb.validate.h"
+#include "tests/bpf_metadata.pb.h"
+#include "tests/bpf_metadata.pb.validate.h" // IWYU pragma: keep
 
 namespace Envoy {
 

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -19,7 +19,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/config/utility.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 #include "source/extensions/config_subscription/filesystem/filesystem_subscription_impl.h"
 

--- a/tests/bpf_metadata.h
+++ b/tests/bpf_metadata.h
@@ -2,6 +2,8 @@
 
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "envoy/network/address.h"
 #include "envoy/network/listen_socket.h"
@@ -10,6 +12,7 @@
 #include "cilium/bpf_metadata.h"
 #include "cilium/host_map.h"
 #include "cilium/network_policy.h"
+#include "cilium/socket_option.h"
 #include "tests/bpf_metadata.pb.h"
 
 namespace Envoy {

--- a/tests/cilium_http_integration.cc
+++ b/tests/cilium_http_integration.cc
@@ -1,8 +1,22 @@
 #include "tests/cilium_http_integration.h"
 
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <spdlog/common.h>
+
+#include <memory>
+#include <string>
+
 #include "envoy/network/address.h"
 
+#include "source/common/common/base_logger.h"
 #include "source/common/common/logger.h"
+#include "source/common/http/codec_client.h"
+#include "source/common/network/address_impl.h"
+
+#include "test/integration/http_integration.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/network_utility.h"
 
 #include "tests/bpf_metadata.h"
 

--- a/tests/cilium_http_integration.h
+++ b/tests/cilium_http_integration.h
@@ -1,7 +1,22 @@
 #pragma once
 
-#include "test/integration/http_integration.h"
+#include <gtest/gtest.h>
 
+#include <chrono>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/common/pure.h"
+#include "envoy/http/header_map.h"
+#include "envoy/network/address.h"
+
+#include "test/integration/http_integration.h"
+#include "test/test_common/utility.h"
+
+#include "absl/types/optional.h"
+#include "cilium/api/accesslog.pb.h"
+#include "google/protobuf/repeated_ptr_field.h"
 #include "tests/accesslog_server.h"
 
 namespace Envoy {

--- a/tests/cilium_http_integration.h
+++ b/tests/cilium_http_integration.h
@@ -11,12 +11,13 @@
 #include "envoy/http/header_map.h"
 #include "envoy/network/address.h"
 
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+
 #include "test/integration/http_integration.h"
 #include "test/test_common/utility.h"
 
 #include "absl/types/optional.h"
 #include "cilium/api/accesslog.pb.h"
-#include "google/protobuf/repeated_ptr_field.h"
 #include "tests/accesslog_server.h"
 
 namespace Envoy {

--- a/tests/cilium_http_integration_test.cc
+++ b/tests/cilium_http_integration_test.cc
@@ -1,9 +1,37 @@
 // <gtest.h> TEST
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/common/exception.h"
+#include "envoy/network/address.h"
+#include "envoy/service/discovery/v3/discovery.pb.h"
+
+#include "source/common/common/logger.h"
 #include "source/common/config/decoded_resource_impl.h"
 #include "source/common/network/address_impl.h"
-#include "source/common/protobuf/protobuf.h"
+#include "source/common/network/utility.h"
+#include "source/common/protobuf/message_validator_impl.h"
+#include "source/common/protobuf/utility.h"
 #include "source/common/thread_local/thread_local_impl.h"
 
+#include "test/integration/http_integration.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
+
+#include "absl/strings/numbers.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "absl/types/optional.h"
+#include "cilium/api/accesslog.pb.h"
+#include "cilium/host_map.h"
 #include "cilium/secret_watcher.h"
 #include "tests/bpf_metadata.h" // host_map_config
 #include "tests/cilium_http_integration.h"

--- a/tests/cilium_http_upstream_integration_test.cc
+++ b/tests/cilium_http_upstream_integration_test.cc
@@ -1,7 +1,25 @@
-#include "source/common/config/decoded_resource_impl.h"
-#include "source/common/network/address_impl.h"
-#include "source/common/thread_local/thread_local_impl.h"
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
 
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/network/address.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/network/utility.h"
+
+#include "test/integration/http_integration.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "absl/types/optional.h"
+#include "cilium/api/accesslog.pb.h"
 #include "cilium/secret_watcher.h"
 #include "tests/bpf_metadata.h" // host_map_config
 #include "tests/cilium_http_integration.h"

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -1,11 +1,33 @@
+#include <gmock/gmock-spec-builders.h>
+#include <spdlog/common.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "envoy/common/exception.h"
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/init/manager.h"
+#include "envoy/server/transport_socket_config.h"
+#include "envoy/service/discovery/v3/discovery.pb.h"
+#include "envoy/ssl/context.h"
+#include "envoy/ssl/context_config.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/common/base_logger.h"
 #include "source/common/common/logger.h"
 #include "source/common/config/decoded_resource_impl.h"
+#include "source/common/protobuf/message_validator_impl.h"
 #include "source/common/protobuf/utility.h"
-#include "source/common/secret/secret_provider_impl.h"
 
+#include "test/common/stats/stat_test_utility.h"
+#include "test/mocks/server/admin.h"
 #include "test/mocks/server/factory_context.h"
-#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
 
+#include "absl/strings/string_view.h"
+#include "cilium/accesslog.h"
 #include "cilium/network_policy.h"
 #include "gtest/gtest.h"
 

--- a/tests/cilium_tcp_integration.cc
+++ b/tests/cilium_tcp_integration.cc
@@ -1,8 +1,21 @@
 #include "tests/cilium_tcp_integration.h"
 
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <spdlog/common.h>
+
+#include <memory>
+#include <string>
+
 #include "envoy/network/address.h"
 
+#include "source/common/common/base_logger.h"
+#include "source/common/common/logger.h"
+#include "source/common/network/address_impl.h"
+
+#include "test/integration/base_integration_test.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/network_utility.h"
 
 #include "tests/bpf_metadata.h"
 

--- a/tests/cilium_tcp_integration.h
+++ b/tests/cilium_tcp_integration.h
@@ -1,6 +1,12 @@
 #pragma once
 
-#include "test/integration/integration.h"
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "envoy/network/address.h"
+
+#include "test/integration/base_integration_test.h"
 
 #include "tests/accesslog_server.h"
 

--- a/tests/cilium_tcp_integration_test.cc
+++ b/tests/cilium_tcp_integration_test.cc
@@ -1,7 +1,20 @@
-#include "test/integration/integration.h"
-#include "test/integration/utility.h"
-#include "test/test_common/environment.h"
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
 
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include "test/integration/fake_upstream.h"
+#include "test/integration/integration_tcp_client.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "tests/cilium_tcp_integration.h"
 
 namespace Envoy {

--- a/tests/cilium_tls_http_integration_test.cc
+++ b/tests/cilium_tls_http_integration_test.cc
@@ -1,7 +1,27 @@
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/common/exception.h"
+#include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/network/connection.h"
+#include "envoy/network/transport_socket.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/stats/isolated_store_impl.h"
 #include "source/common/tls/server_context_config_impl.h"
 #include "source/common/tls/server_ssl_socket.h"
 
+#include "test/integration/fake_upstream.h"
 #include "test/integration/ssl_utility.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
 
 #include "tests/cilium_http_integration.h"
 #include "tests/cilium_tls_integration.h"

--- a/tests/cilium_tls_integration.cc
+++ b/tests/cilium_tls_integration.cc
@@ -1,16 +1,25 @@
 #include "tests/cilium_tls_integration.h"
 
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-spec-builders.h>
+
+#include <string>
+#include <utility>
+
 #include "envoy/api/api.h"
+#include "envoy/common/exception.h"
+#include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
 #include "envoy/network/transport_socket.h"
+#include "envoy/ssl/context_manager.h"
 
 #include "source/common/tls/client_ssl_socket.h"
 #include "source/common/tls/context_config_impl.h"
 
 #include "test/integration/server.h"
+#include "test/mocks/server/admin.h"
 #include "test/mocks/server/transport_socket_factory_context.h"
 #include "test/test_common/environment.h"
-
-#include "gtest/gtest.h"
+#include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/tests/cilium_tls_tcp_integration_test.cc
+++ b/tests/cilium_tls_tcp_integration_test.cc
@@ -1,7 +1,41 @@
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <gmock/gmock-cardinalities.h>
+#include <gmock/gmock-spec-builders.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/exception.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/network/connection.h"
+#include "envoy/network/transport_socket.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/assert.h"
+#include "source/common/stats/isolated_store_impl.h"
 #include "source/common/tls/server_context_config_impl.h"
 #include "source/common/tls/server_ssl_socket.h"
 
+#include "test/integration/fake_upstream.h"
+#include "test/integration/integration_tcp_client.h"
 #include "test/integration/ssl_utility.h"
+#include "test/integration/utility.h"
+#include "test/mocks/buffer/mocks.h"
+#include "test/mocks/server/admin.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
 
 #include "tests/cilium_tcp_integration.h"
 #include "tests/cilium_tls_integration.h"

--- a/tests/cilium_websocket_codec_integration_test.cc
+++ b/tests/cilium_websocket_codec_integration_test.cc
@@ -1,5 +1,16 @@
-#include "test/integration/integration.h"
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+#include "test/integration/fake_upstream.h"
+#include "test/integration/integration_tcp_client.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
 
 #include "tests/cilium_tcp_integration.h"
 

--- a/tests/cilium_websocket_decap_integration_test.cc
+++ b/tests/cilium_websocket_decap_integration_test.cc
@@ -1,4 +1,3 @@
-#include <bits/basic_string.h>
 #include <fmt/base.h>
 #include <fmt/format.h>
 #include <gtest/gtest-param-test.h>
@@ -290,7 +289,7 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
 
   // Masked frames
   ASSERT_EQ(buf.length(), 0);
-  auto msg = "heello there\r\n"s;
+  auto msg = std::string{"heello there\r\n"};
   unsigned char mask[4] = {0x12, 0x34, 0x56, 0x78};
   auto masked = msg;
   for (size_t i = 0; i < msg.length(); i++) {
@@ -318,7 +317,7 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
 
   // 2nd masked frame
   ASSERT_EQ(buf.length(), 0);
-  auto msg2 = "hello there\r\n"s;
+  auto msg2 = std::string{"hello there\r\n"};
   unsigned char mask2[4] = {0x90, 0xab, 0xcd, 0xef};
   auto masked2 = msg2;
   for (size_t i = 0; i < msg2.length(); i++) {

--- a/tests/cilium_websocket_decap_integration_test.cc
+++ b/tests/cilium_websocket_decap_integration_test.cc
@@ -1,8 +1,22 @@
-#include "source/common/config/decoded_resource_impl.h"
-#include "source/common/network/address_impl.h"
-#include "source/common/protobuf/protobuf.h"
-#include "source/common/thread_local/thread_local_impl.h"
+#include <bits/basic_string.h>
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
 
+#include <cstddef>
+#include <string>
+
+#include "envoy/event/dispatcher.h"
+
+#include "source/common/buffer/buffer_impl.h"
+
+#include "test/integration/fake_upstream.h"
+#include "test/integration/integration_stream_decoder.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
+
+#include "absl/strings/string_view.h"
 #include "tests/bpf_metadata.h" // host_map_config, original_dst_address
 #include "tests/cilium_http_integration.h"
 

--- a/tests/cilium_websocket_encap_integration_test.cc
+++ b/tests/cilium_websocket_encap_integration_test.cc
@@ -1,6 +1,19 @@
-#include "test/integration/integration.h"
-#include "test/integration/utility.h"
+#include <bits/basic_string.h>
+#include <fmt/base.h>
+#include <fmt/format.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include "test/integration/fake_upstream.h"
+#include "test/integration/integration_tcp_client.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/utility.h"
 
 #include "cilium/websocket_protocol.h"
 #include "tests/bpf_metadata.h" // original_dst_address

--- a/tests/cilium_websocket_encap_integration_test.cc
+++ b/tests/cilium_websocket_encap_integration_test.cc
@@ -1,4 +1,3 @@
-#include <bits/basic_string.h>
 #include <fmt/base.h>
 #include <fmt/format.h>
 #include <gtest/gtest-param-test.h>
@@ -392,7 +391,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketLargeWrite) {
   ASSERT_EQ(received_data.substr(frame_offset, 16 * 1024), data.substr(16 * 1024, 16 * 1024));
 
   // writing data in one large chunk
-  ASSERT_TRUE(fake_upstream_connection->write("\x82\x7e\x80\x00"s));
+  ASSERT_TRUE(fake_upstream_connection->write(std::string{"\x82\x7e\x80\x00"}));
   ASSERT_TRUE(fake_upstream_connection->write(data));
   tcp_client->waitForData(data);
   tcp_client->close();
@@ -448,7 +447,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketDownstreamFlush) {
 
   // writing data in one large chunk
 
-  ASSERT_TRUE(fake_upstream_connection->write("\x82\x7f\x03\x20\0\0"s));
+  ASSERT_TRUE(fake_upstream_connection->write(std::string{"\x82\x7f\x03\x20\0\0"}));
   ASSERT_TRUE(fake_upstream_connection->write(data, true));
 
   test_server_->waitForCounterGe("cluster.cluster1.upstream_flow_control_paused_reading_total", 1);

--- a/tests/health_check_sink_server.cc
+++ b/tests/health_check_sink_server.cc
@@ -1,12 +1,23 @@
 #include "tests/health_check_sink_server.h"
 
-#include <errno.h>
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <chrono>
+#include <functional>
 #include <string>
+
+#include "envoy/data/core/v3/health_check_event.pb.h"
+
+#include "source/common/common/logger.h"
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
+#include "absl/types/optional.h"
+#include "tests/uds_server.h"
 
 namespace Envoy {
 

--- a/tests/health_check_sink_server.h
+++ b/tests/health_check_sink_server.h
@@ -1,18 +1,15 @@
 #pragma once
 
-#include <atomic>
 #include <chrono>
+#include <list>
 #include <string>
-#include <vector>
 
 #include "envoy/data/core/v3/health_check_event.pb.h"
-#include "envoy/data/core/v3/health_check_event.pb.validate.h"
-
-#include "source/common/common/logger.h"
-#include "source/common/common/thread.h"
+#include "envoy/data/core/v3/health_check_event.pb.validate.h" // IWYU pragma: keep
 
 #include "test/test_common/utility.h"
 
+#include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/optional.h"
 #include "tests/uds_server.h"

--- a/tests/health_check_sink_test.cc
+++ b/tests/health_check_sink_test.cc
@@ -8,6 +8,7 @@
 
 #include "source/common/common/base_logger.h"
 #include "source/common/common/logger.h"
+#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 
 #include "test/mocks/server/admin.h"
 #include "test/mocks/server/health_checker_factory_context.h"
@@ -15,8 +16,6 @@
 
 #include "cilium/api/health_check_sink.pb.h"
 #include "cilium/api/health_check_sink.pb.validate.h" // IWYU pragma: keep
-#include "google/protobuf/any.pb.h"
-#include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
 #include "tests/health_check_sink_server.h"
 

--- a/tests/health_check_sink_test.cc
+++ b/tests/health_check_sink_test.cc
@@ -1,17 +1,22 @@
+#include <spdlog/common.h>
+
+#include <string>
+
+#include "envoy/data/core/v3/health_check_event.pb.h"
 #include "envoy/registry/registry.h"
+#include "envoy/upstream/health_check_event_sink.h"
 
+#include "source/common/common/base_logger.h"
 #include "source/common/common/logger.h"
-#include "source/common/protobuf/message_validator_impl.h"
 
-#include "test/mocks/access_log/mocks.h"
-#include "test/mocks/event/mocks.h"
+#include "test/mocks/server/admin.h"
 #include "test/mocks/server/health_checker_factory_context.h"
 #include "test/test_common/utility.h"
 
 #include "cilium/api/health_check_sink.pb.h"
-#include "cilium/api/health_check_sink.pb.validate.h"
-#include "cilium/health_check_sink.h"
-#include "gmock/gmock.h"
+#include "cilium/api/health_check_sink.pb.validate.h" // IWYU pragma: keep
+#include "google/protobuf/any.pb.h"
+#include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
 #include "tests/health_check_sink_server.h"
 

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -1,11 +1,41 @@
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-spec-builders.h>
+#include <spdlog/common.h>
+
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "envoy/api/api.h"
+#include "envoy/common/exception.h"
+#include "envoy/filesystem/watcher.h"
+#include "envoy/init/target.h"
+#include "envoy/init/watcher.h"
+#include "envoy/network/address.h"
 #include "envoy/network/filter.h"
 #include "envoy/network/socket.h"
 
+#include "source/common/common/base_logger.h"
 #include "source/common/common/logger.h"
+#include "source/common/init/watcher_impl.h"
 #include "source/common/network/address_impl.h"
+#include "source/common/network/socket_impl.h"
+#include "source/common/stats/isolated_store_impl.h"
 
+#include "test/mocks/filesystem/mocks.h"
+#include "test/mocks/network/io_handle.h"
+#include "test/mocks/network/mocks.h"
 #include "test/mocks/server/listener_factory_context.h"
+#include "test/mocks/server/transport_socket_factory_context.h"
+#include "test/test_common/utility.h"
 
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "cilium/api/bpf_metadata.pb.h"
+#include "cilium/bpf_metadata.h"
+#include "cilium/socket_option.h"
 #include "gtest/gtest.h"
 #include "tests/bpf_metadata.h"
 

--- a/tests/uds_server.cc
+++ b/tests/uds_server.cc
@@ -5,12 +5,15 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <functional>
+#include <memory>
 #include <string>
 
 #include "envoy/common/exception.h"
 
-#include "source/common/common/lock_guard.h"
+#include "source/common/common/logger.h"
 #include "source/common/common/utility.h"
+#include "source/common/network/address_impl.h"
 
 #include "test/test_common/thread_factory_for_test.h"
 

--- a/tests/uds_server.h
+++ b/tests/uds_server.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
+#include <memory>
 #include <string>
 
+#include "envoy/thread/thread.h"
+
 #include "source/common/common/logger.h"
-#include "source/common/common/thread.h"
 #include "source/common/network/address_impl.h"
 
 namespace Envoy {


### PR DESCRIPTION
Currently, the C++ files are either including unused files or heavily rely on transtive includes and doesn't define the actual required includes.

Therefore, this commit fixes all includes so that all files are defining their includes according to their needs - following the model "include what you use".

See https://clangd.llvm.org/guides/include-cleaner

Advantages:

* Get rid of warnings when using clangd as LSP server
* Remove unused includes
* Define all direct includes helps understanding the code and the dependencies

Note: For the time being there will not be any validation in CI. It's more or less just a cleanup and a potential start to establish this pattern because I think this helps for others to familiarize with the codebase.

Related to https://github.com/cilium/proxy/pull/1087