### PR TITLE
build: `socket_option_lib` depends on `network_policy_lib`

### DIFF
--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -71,6 +71,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         "//cilium:conntrack_lib",
+        "//cilium:network_policy_lib",
         "@envoy//envoy/network:listen_socket_interface",
         "@envoy//source/common/common:logger_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/cilium/l7policy.cc
+++ b/cilium/l7policy.cc
@@ -13,7 +13,6 @@
 #include "source/extensions/filters/http/common/factory_base.h"
 
 #include "cilium/api/l7policy.pb.validate.h"
-#include "cilium/network_policy.h"
 #include "cilium/socket_option.h"
 
 namespace Envoy {

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -8,14 +8,12 @@
 #include "source/common/common/utility.h"
 
 #include "cilium/conntrack.h"
+#include "cilium/network_policy.h"
 #include "cilium/policy_id.h"
 #include "cilium/privileged_service_client.h"
 
 namespace Envoy {
 namespace Cilium {
-
-class PolicyInstance;
-using PolicyInstanceConstSharedPtr = std::shared_ptr<const PolicyInstance>;
 
 class PolicyResolver {
 public:


### PR DESCRIPTION
Currently, the dependency from `socket_option_lib` to `network_policy_lib` isn't explicitly declared in the `BUILD` file.

As a consequence, forward declarations for the types `PolicyInstance` & `PolicyInstanceConstSharedPtr` exist in `socket_option.h`.

Therefore, this commit is defining an explit module depencency and gets rid of the unnecessary forward declarations.