### PR TITLE
conntrack: replace std::mutex with Thread::MutexBasicLockable

### DIFF
--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -7,6 +7,7 @@
 
 #include "envoy/common/platform.h"
 
+#include "source/common/common/thread.h"
 #include "source/common/common/utility.h"
 #include "source/common/network/address_impl.h"
 
@@ -149,7 +150,7 @@ CtMap::openMap6(const std::string& map_name) {
 }
 
 void CtMap::closeMaps(const std::shared_ptr<absl::flat_hash_set<std::string>>& to_be_closed) {
-  std::lock_guard<std::mutex> guard(maps_mutex_);
+  std::lock_guard<Thread::MutexBasicLockable> guard(maps_mutex_);
 
   for (const auto& name : *to_be_closed) {
     auto ct4 = ct_maps4_.find(name);
@@ -213,7 +214,7 @@ uint32_t CtMap::lookupSrcIdentity(const std::string& map_name, const Network::Ad
 
   if (dip->version() == Network::Address::IpVersion::v4) {
     // Lock for the duration of the map lookup and conntrack lookup
-    std::lock_guard<std::mutex> guard(maps_mutex_);
+    std::lock_guard<Thread::MutexBasicLockable> guard(maps_mutex_);
     auto it = ct_maps4_.find(map_name);
     if (it == ct_maps4_.end()) {
       it = openMap4(map_name);
@@ -231,7 +232,7 @@ uint32_t CtMap::lookupSrcIdentity(const std::string& map_name, const Network::Ad
     }
   } else {
     // Lock for the duration of the map lookup and conntrack lookup
-    std::lock_guard<std::mutex> guard(maps_mutex_);
+    std::lock_guard<Thread::MutexBasicLockable> guard(maps_mutex_);
     auto it = ct_maps6_.find(map_name);
     if (it == ct_maps6_.end()) {
       it = openMap6(map_name);

--- a/cilium/conntrack.h
+++ b/cilium/conntrack.h
@@ -8,6 +8,7 @@
 #include "envoy/singleton/instance.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/common/thread.h"
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
@@ -70,7 +71,7 @@ private:
 
   // All known conntrack maps. Populated with the "global" maps at startup,
   // further maps are opened and inserted on demand.
-  std::mutex maps_mutex_;
+  Thread::MutexBasicLockable maps_mutex_;
   absl::flat_hash_map<const std::string, std::unique_ptr<CtMaps4>> ct_maps4_;
   absl::flat_hash_map<const std::string, std::unique_ptr<CtMaps6>> ct_maps6_;
   std::string bpf_root_;


### PR DESCRIPTION
Upstream Envoy linting prevents usages of `std::mutex` in favor of `Thread::MutexBasicLockable`.

This error occurred while trying to cleanup the imports - and therefore adding the direct dependency to `<mutex>`.

```
ERROR: From ./cilium/conntrack.h
ERROR: ./cilium/conntrack.h:7: Don't use <mutex> or <condition_variable*>, switch to Thread::MutexBasicLockable in source/common/common/thread.h
ERROR: From ./cilium/conntrack.cc
ERROR: ./cilium/conntrack.cc:9: Don't use <mutex> or <condition_variable*>, switch to Thread::MutexBasicLockable in source/common/common/thread.h
ERROR: check format failed. diff has been applied'
```

See https://github.com/envoyproxy/envoy/blob/main/tools/code_format/check_format.py#L605-L610

```
report_error(
  "Don't use <mutex> or <condition_variable*>, switch to "
  "Thread::MutexBasicLockable in source/common/common/thread.h")
```

See https://github.com/cilium/proxy/pull/1089