### PR TITLE
bazel: register c++ toolchain via build flag --extra_toolchains

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -89,7 +89,7 @@ jobs:
           build-args: |
             BUILDER_BASE=quay.io/cilium/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:main-archive-latest
-            BAZEL_BUILD_OPTS=--remote_upload_local_results=false
+            BAZEL_BUILD_OPTS=--remote_upload_local_results=false --extra_toolchains=//bazel/toolchains:all
           cache-from: type=local,src=/tmp/buildx-cache
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max
           push: true

--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -1,6 +1,6 @@
 name: CI Build & Push
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -78,7 +78,7 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
             COPY_CACHE_EXT=.new
-            BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.75"
+            BAZEL_BUILD_OPTS=--jobs=HOST_CPUS*.75 --extra_toolchains=//bazel/toolchains:all
             BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
@@ -103,7 +103,7 @@ jobs:
           build-args: |
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
-            BAZEL_BUILD_OPTS=--remote_upload_local_results=false
+            BAZEL_BUILD_OPTS=--remote_upload_local_results=false --extra_toolchains=//bazel/toolchains:all
             BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max
           push: true
@@ -168,7 +168,7 @@ jobs:
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:main-archive-latest
             COPY_CACHE_EXT=.new
-            BAZEL_BUILD_OPTS="--jobs=HOST_CPUS*.75"
+            BAZEL_BUILD_OPTS=--jobs=HOST_CPUS*.75 --extra_toolchains=//bazel/toolchains:all
           push: true
           tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:main-archive-latest
 
@@ -193,7 +193,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ env.BUILDER_DOCKER_HASH }}
-            BAZEL_BUILD_OPTS=--remote_upload_local_results=false
+            BAZEL_BUILD_OPTS=--remote_upload_local_results=false  --extra_toolchains=//bazel/toolchains:all
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:main-archive-latest
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max
           push: true

--- a/.github/workflows/ci-check-format.yaml
+++ b/.github/workflows/ci-check-format.yaml
@@ -47,6 +47,7 @@ jobs:
           outputs: type=local,dest=check-format-results
           build-args: |
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
+            BAZEL_BUILD_OPTS=--extra_toolchains=//bazel/toolchains:all
           cache-from: type=local,src=/tmp/buildx-cache
           push: false
 

--- a/.github/workflows/ci-check-format.yaml
+++ b/.github/workflows/ci-check-format.yaml
@@ -1,6 +1,6 @@
 name: CI check format
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 # By specifying the access of one of the scopes, all of those that are not specified are set to 'none'.

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -1,6 +1,6 @@
 name: CI run integration tests
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 # By specifying the access of one of the scopes, all of those that are not specified are set to 'none'.

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -18,23 +18,23 @@ jobs:
     name: Run unit tests for proxylib
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      with:
-        # renovate: datasource=golang-version depName=go
-        go-version: 1.23.4
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        persist-credentials: false
-    - name: Check module vendoring
-      run: |
-        go mod tidy
-        go mod vendor
-        test -z "$(git status --porcelain)" || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
-    - name: Run unit tests
-      run: |
-        make -C proxylib test
+      - name: Install Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.23.4
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Check module vendoring
+        run: |
+          go mod tidy
+          go mod vendor
+          test -z "$(git status --porcelain)" || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
+      - name: Run unit tests
+        run: |
+          make -C proxylib test
 
   tests:
     timeout-minutes: 360
@@ -103,7 +103,7 @@ jobs:
           build-args: |
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:test-${{ env.BUILDER_DOCKER_HASH }}
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
-            BAZEL_BUILD_OPTS=--remote_upload_local_results=false
+            BAZEL_BUILD_OPTS=--remote_upload_local_results=false --extra_toolchains=//bazel/toolchains:all
             BAZEL_TEST_OPTS=--test_timeout=300 --local_test_jobs=1 --flaky_test_attempts=3
           cache-from: type=local,src=/tmp/buildx-cache
           push: false

--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -79,8 +79,8 @@ jobs:
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           version: ${{ env.KIND_VERSION }}
-          config: '.github/kind-config.yaml'
-          cluster_name: 'kind'
+          config: ".github/kind-config.yaml"
+          cluster_name: "kind"
 
       - name: Patch Cilium Agent Dockerfile
         shell: bash
@@ -166,7 +166,6 @@ jobs:
         if: failure()
         shell: bash
         run: cilium sysdump --output-filename cilium-integration-test-sysdump
-
 
       - name: Upload Cilium system dump
         if: failure()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,5 @@
 workspace(name = "cilium")
 
-register_toolchains("//bazel/toolchains:all")
-
 ENVOY_PROJECT = "envoyproxy"
 
 ENVOY_REPO = "envoy"


### PR DESCRIPTION
Currently, the C++ toolchains (defined in `bazel/toolchains`) are
registered in the `WORKSPACE` file via `register_toolchains`.

Problem with this approach is that this is tightly coupled to the Cilium Proxy
CI environment (Ubuntu & expected paths in `/usr/bin/...`). If these requirements
aren't met, compilation with the evaluated C++ toolchain  fails - even though 
there might be an available and compatible local toolchain.

To provide more flexibility in terms of development environment and integration,
this commit removes the hardcoded registration of the toolchains in the `WORKSPACE`
file and replaces it with an explicit registration via bazel build argument
`--extra_toolchains="//bazel/toolchains:all"` where required (e.g. CI).

Example: Using a downloaded and extracted Clang&LLVM as [documented in upstream Envoy](https://github.com/envoyproxy/envoy/blob/main/bazel/README.md#linux) doesn't work as expected due to the hardcoded tool  paths in the defined Cilium Proxy C++ toolchains. Hence it would be nice to rely on the local toolchain in this case.