### PR TITLE
bazel: register c++ toolchains via build flag --extra_toolchains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ define add_clang_apt_source
 endef
 
 ifdef PKG_BUILD
+  $(info Registering C++ toolchains via BAZEL_BUILD_OPTS)
+  BAZEL_BUILD_OPTS += --extra_toolchains=//bazel/toolchains:all
+
   all: cilium-envoy-starter cilium-envoy
 
   .PHONY: install-bazelisk
@@ -87,6 +90,8 @@ ifdef PKG_BUILD
 	echo "Clang assumed to be installed in the builder image"
   endef
 else
+  $(info Skip registering C++ toolchains via BAZEL_BUILD_OPTS. Local C++ toolchain needs to be available!)
+
   all: precheck cilium-envoy-starter cilium-envoy
 
   include Makefile.docker

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,5 @@
 workspace(name = "cilium")
 
-register_toolchains("//bazel/toolchains:all")
-
 ENVOY_PROJECT = "envoyproxy"
 
 ENVOY_REPO = "envoy"


### PR DESCRIPTION
Currently, the C++ toolchains (defined in `bazel/toolchains`) are automatically registered in the `WORKSPACE` file via `register_toolchains`.

Problem with this approach is that this is tightly coupled to the Cilium Proxy CI environment (Ubuntu & expected paths in `/usr/bin/...`). If these requirements aren't met, compilation with the evaluated C++ toolchain fails - even though there might be an available and compatible local toolchain.

To provide more flexibility in terms of development environment and integration, this commit removes the hardcoded registration of the toolchains in the `WORKSPACE` file and replaces it with an explicit registration via bazel build argument `--extra_toolchains="//bazel/toolchains:all"` where required / builded in docker (switch in `Makefile` via `PKG_BUILD`).