### PR TITLE
clangd: prevent include of private headers that lead to problems

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -8,6 +8,7 @@ Diagnostics:
     IgnoreHeader:
       - "linux/in\\.h"
       - "linux/in6\\.h"
+      - "bits/basic_string\\.h"
 # CompileFlags:
 #   CompilationDatabase: ./compile_commands.json
 #   # Unfortunately, above config isn't working as expected.

--- a/.clangd
+++ b/.clangd
@@ -4,6 +4,10 @@ Index:
 Diagnostics:
   UnusedIncludes: Strict
   MissingIncludes: Strict
+  Includes:
+    IgnoreHeader:
+      - "linux/in\\.h"
+      - "linux/in6\\.h"
 # CompileFlags:
 #   CompilationDatabase: ./compile_commands.json
 #   # Unfortunately, above config isn't working as expected.

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -24,7 +24,6 @@
 #include "absl/numeric/int128.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
-#include "cilium/conntrack.h"
 #include "cilium/network_policy.h"
 #include "cilium/policy_id.h"
 #include "cilium/privileged_service_client.h"

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <asm-generic/socket.h>
-#include <linux/in.h>
-#include <linux/in6.h>
 #include <netinet/in.h>
 
 #include <cerrno>


### PR DESCRIPTION
Follow up of: https://github.com/cilium/proxy/pull/1100