### PR TITLE
policy: Atomic swap for policy map

### DIFF
--- a/cilium/api/bpf_metadata.proto
+++ b/cilium/api/bpf_metadata.proto
@@ -49,5 +49,6 @@ message BpfMetadata {
 
   // policy_update_warning_limit is the time in milliseconds after which a warning is logged if
   // network policy update took longer
+  // Deprecated, has no effect.
   google.protobuf.Duration policy_update_warning_limit = 9;
 }

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -189,13 +189,10 @@ createHostMap(Server::Configuration::ListenerFactoryContext& context) {
 }
 
 std::shared_ptr<const Cilium::NetworkPolicyMap>
-createPolicyMap(Server::Configuration::FactoryContext& context, Cilium::CtMapSharedPtr& ct,
-                std::chrono::milliseconds policy_update_warning_limit_ms) {
+createPolicyMap(Server::Configuration::FactoryContext& context, Cilium::CtMapSharedPtr& ct) {
   return context.serverFactoryContext().singletonManager().getTyped<const Cilium::NetworkPolicyMap>(
-      SINGLETON_MANAGER_REGISTERED_NAME(cilium_network_policy),
-      [&context, &ct, &policy_update_warning_limit_ms] {
-        auto map =
-            std::make_shared<Cilium::NetworkPolicyMap>(context, ct, policy_update_warning_limit_ms);
+      SINGLETON_MANAGER_REGISTERED_NAME(cilium_network_policy), [&context, &ct] {
+        auto map = std::make_shared<Cilium::NetworkPolicyMap>(context, ct);
         map->startSubscription();
         return map;
       });
@@ -212,14 +209,7 @@ Config::Config(const ::cilium::BpfMetadata& config,
           Network::Utility::parseInternetAddressNoThrow(config.ipv4_source_address())),
       ipv6_source_address_(
           Network::Utility::parseInternetAddressNoThrow(config.ipv6_source_address())),
-      enforce_policy_on_l7lb_(config.enforce_policy_on_l7lb()),
-      policy_update_warning_limit_ms_(std::chrono::milliseconds(100)) {
-
-  const uint64_t limit = DurationUtil::durationToMilliseconds(config.policy_update_warning_limit());
-  if (limit > 0) {
-    policy_update_warning_limit_ms_ = std::chrono::milliseconds(limit);
-  }
-
+      enforce_policy_on_l7lb_(config.enforce_policy_on_l7lb()) {
   if (is_l7lb_ && is_ingress_) {
     throw EnvoyException("cilium.bpf_metadata: is_l7lb may not be set with is_ingress");
   }
@@ -261,7 +251,7 @@ Config::Config(const ::cilium::BpfMetadata& config,
     // Get the shared policy provider, or create it if not already created.
     // Note that the API config source is assumed to be the same for all filter
     // instances!
-    npmap_ = createPolicyMap(context, ct_maps_, policy_update_warning_limit_ms_);
+    npmap_ = createPolicyMap(context, ct_maps_);
   }
 }
 

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -92,7 +92,7 @@ public:
 
   // PolicyResolver
   uint32_t resolvePolicyId(const Network::Address::Ip*) const override;
-  const PolicyInstanceConstSharedPtr getPolicy(const std::string&) const override;
+  const PolicyInstance& getPolicy(const std::string&) const override;
 
   virtual absl::optional<SocketMetadata> extractSocketMetadata(Network::ConnectionSocket& socket);
 
@@ -114,9 +114,8 @@ public:
   std::shared_ptr<const Cilium::PolicyHostMap> hosts_{};
 
 private:
-  uint32_t resolveSourceIdentity(const PolicyInstanceConstSharedPtr policy,
-                                 const Network::Address::Ip* sip, const Network::Address::Ip* dip,
-                                 bool ingress, bool isL7LB);
+  uint32_t resolveSourceIdentity(const PolicyInstance& policy, const Network::Address::Ip* sip,
+                                 const Network::Address::Ip* dip, bool ingress, bool isL7LB);
 
   IPAddressPair getIPAddressPairFrom(const Network::Address::InstanceConstSharedPtr sourceAddress,
                                      const IPAddressPair& addresses);

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -112,7 +112,6 @@ public:
   Cilium::CtMapSharedPtr ct_maps_{};
   Cilium::IPCacheSharedPtr ipcache_{};
   std::shared_ptr<const Cilium::PolicyHostMap> hosts_{};
-  std::chrono::milliseconds policy_update_warning_limit_ms_;
 
 private:
   uint32_t resolveSourceIdentity(const PolicyInstanceConstSharedPtr policy,

--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -159,10 +159,10 @@ CtMap::openMap6(const std::string& map_name) {
   return pair.first;
 }
 
-void CtMap::closeMaps(const std::shared_ptr<absl::flat_hash_set<std::string>>& to_be_closed) {
+void CtMap::closeMaps(const absl::flat_hash_set<std::string>& to_be_closed) {
   std::lock_guard<Thread::MutexBasicLockable> guard(maps_mutex_);
 
-  for (const auto& name : *to_be_closed) {
+  for (const auto& name : to_be_closed) {
     auto ct4 = ct_maps4_.find(name);
     if (ct4 != ct_maps4_.end()) {
       ct_maps4_.erase(ct4);

--- a/cilium/conntrack.h
+++ b/cilium/conntrack.h
@@ -63,7 +63,7 @@ public:
     CtMap6 ctmap6_tcp_;
     CtMap6 ctmap6_any_;
   };
-  void closeMaps(const std::shared_ptr<absl::flat_hash_set<std::string>>& to_be_closed);
+  void closeMaps(const absl::flat_hash_set<std::string>& to_be_closed);
 
 private:
   absl::flat_hash_map<const std::string, std::unique_ptr<CtMaps4>>::iterator

--- a/cilium/filter_state_cilium_policy.h
+++ b/cilium/filter_state_cilium_policy.h
@@ -27,7 +27,7 @@ public:
   virtual ~PolicyResolver() = default;
 
   virtual uint32_t resolvePolicyId(const Network::Address::Ip*) const PURE;
-  virtual const PolicyInstanceConstSharedPtr getPolicy(const std::string&) const PURE;
+  virtual const PolicyInstance& getPolicy(const std::string&) const PURE;
 };
 
 // FilterState that holds relevant connection & policy information that can be retrieved
@@ -55,11 +55,11 @@ public:
     return Cilium::ID::WORLD; // default to WORLD policy ID if resolver is no longer available
   }
 
-  const PolicyInstanceConstSharedPtr getPolicy() const {
+  const PolicyInstance& getPolicy() const {
     const auto resolver = policy_resolver_.lock();
     if (resolver)
       return resolver->getPolicy(pod_ip_);
-    return nullptr;
+    return NetworkPolicyMap::GetDenyAllPolicy();
   }
 
   // policyUseUpstreamDestinationAddress returns 'true' if policy enforcement should be done on the

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -1257,6 +1257,21 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
       stats_.update_latency_ms_, context_.timeSource());
   stats_.updates_total_.inc();
 
+  // Reopen IPcache for every new stream. Cilium agent re-creates IP cache on restart,
+  // and that is also when the old stream terminates and a new one is created.
+  // New security identities (e.g., for FQDN policies) only get inserted to the new IP cache,
+  // so open it before the workers get a chance to enforce policy on the new IDs.
+  if (isNewStream()) {
+    ENVOY_LOG(info, "New NetworkPolicy stream");
+
+    // Get ipcache singleton only if it was successfully created previously
+    IPCacheSharedPtr ipcache = IPCache::GetIPCache(context_);
+    if (ipcache != nullptr) {
+      ENVOY_LOG(info, "Reopening ipcache on new stream");
+      ipcache->Open();
+    }
+  }
+
   std::string version_name = fmt::format("NetworkPolicyMap version {}", version_info);
 
   absl::flat_hash_set<std::string> keeps;
@@ -1320,21 +1335,6 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
         cts_to_be_closed->find(ct_map_name) == cts_to_be_closed->end()) {
       ENVOY_LOG(debug, "Closing conntrack map {}", ct_map_name);
       cts_to_be_closed->insert(ct_map_name);
-    }
-  }
-
-  // Reopen IPcache for every new stream. Cilium agent re-creates IP cache on restart,
-  // and that is also when the old stream terminates and a new one is created.
-  // New security identities (e.g., for FQDN policies) only get inserted to the new IP cache,
-  // so open it before the workers get a chance to enforce policy on the new IDs.
-  if (isNewStream()) {
-    ENVOY_LOG(info, "New NetworkPolicy stream");
-
-    // Get ipcache singleton only if it was successfully created previously
-    IPCacheSharedPtr ipcache = IPCache::GetIPCache(context_);
-    if (ipcache != nullptr) {
-      ENVOY_LOG(info, "Reopening ipcache on new stream");
-      ipcache->Open();
     }
   }
 

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -4,10 +4,8 @@
 #include <openssl/mem.h>
 
 #include <algorithm>
-#include <chrono>
 #include <cstdint>
 #include <functional>
-#include <memory>
 #include <set>
 #include <string>
 #include <utility>
@@ -19,7 +17,6 @@
 #include "envoy/config/core/v3/address.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/subscription.h"
-#include "envoy/event/dispatcher.h"
 #include "envoy/http/header_map.h"
 #include "envoy/init/manager.h"
 #include "envoy/network/address.h"
@@ -27,6 +24,7 @@
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
 #include "envoy/stats/stats_macros.h"
+#include "envoy/thread_local/thread_local.h"
 #include "envoy/type/matcher/v3/metadata.pb.h"
 
 #include "source/common/common/assert.h"
@@ -40,13 +38,11 @@
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
-#include "source/common/stats/timespan_impl.h"
 #include "source/extensions/config_subscription/grpc/grpc_subscription_impl.h"
 #include "source/server/transport_socket_config_impl.h"
 
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_set.h"
-#include "absl/container/node_hash_map.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "cilium/accesslog.h"
@@ -1137,10 +1133,9 @@ private:
 // Common base constructor
 // This is used directly for testing with a file-based subscription
 NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& context)
-    : context_(context.serverFactoryContext()), tls_map_(context_.threadLocal()),
+    : context_(context.serverFactoryContext()), map_ptr_(nullptr),
       npds_stats_scope_(context_.serverScope().createScope("cilium.npds.")),
       policy_stats_scope_(context_.serverScope().createScope("cilium.policy.")),
-      policy_update_warning_limit_ms_(100),
       init_target_(fmt::format("Cilium Network Policy subscription start"),
                    [this]() {
                      subscription_->start({});
@@ -1157,8 +1152,9 @@ NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& contex
   // Use listener init manager for subscription initialization
   context.initManager().add(init_target_);
 
+  // Allocate an initial policy map so that the map pointer is never a nullptr
+  store(new RawPolicyMap());
   ENVOY_LOG(trace, "NetworkPolicyMap({}) created.", instance_id_);
-  tls_map_.set([&](Event::Dispatcher&) { return std::make_shared<ThreadLocalPolicyMap>(); });
 
   if (context_.admin().has_value()) {
     ENVOY_LOG(debug, "Registering NetworkPolicies to config tracker");
@@ -1172,11 +1168,19 @@ NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& contex
 
 // This is used in production
 NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& context,
-                                   Cilium::CtMapSharedPtr& ct,
-                                   std::chrono::milliseconds policy_update_warning_limit_ms)
+                                   Cilium::CtMapSharedPtr& ct)
     : NetworkPolicyMap(context) {
   ctmap_ = ct;
-  policy_update_warning_limit_ms_ = policy_update_warning_limit_ms;
+}
+
+NetworkPolicyMap::~NetworkPolicyMap() {
+  ENVOY_LOG(debug, "Cilium L7 NetworkPolicyMap({}): NetworkPolicyMap is deleted NOW!",
+            instance_id_);
+  // Policy map destruction happens when the last listener with the Cilium bpf_metadata listener
+  // filter has drained out and is finally removed. At this point the listener socket can no
+  // longer receive new traffic and we can simply delete the policy map without synchronizing with
+  // the worker threads.
+  delete load();
 }
 
 // Both subscribe() call and subscription_->start() use
@@ -1194,8 +1198,9 @@ static const std::shared_ptr<const PolicyInstanceImpl> null_instance_impl{nullpt
 
 const std::shared_ptr<const PolicyInstanceImpl>&
 NetworkPolicyMap::GetPolicyInstanceImpl(const std::string& endpoint_ip) const {
-  auto it = tls_map_->policies_.find(endpoint_ip);
-  if (it == tls_map_->policies_.end()) {
+  const auto* map = load();
+  auto it = map->find(endpoint_ip);
+  if (it == map->end()) {
     return null_instance_impl;
   }
   return it->second;
@@ -1205,15 +1210,6 @@ const PolicyInstanceConstSharedPtr
 NetworkPolicyMap::GetPolicyInstance(const std::string& endpoint_ip) const {
   return GetPolicyInstanceImpl(endpoint_ip);
 }
-
-void NetworkPolicyMap::pause() {
-  auto sub = dynamic_cast<Config::GrpcSubscriptionImpl*>(subscription_.get());
-  if (sub) {
-    resume_ = sub->pause();
-  }
-}
-
-void NetworkPolicyMap::resume() { resume_.reset(); }
 
 bool NetworkPolicyMap::isNewStream() {
   auto sub = dynamic_cast<Config::GrpcSubscriptionImpl*>(subscription_.get());
@@ -1229,38 +1225,6 @@ bool NetworkPolicyMap::isNewStream() {
   return mux->isNewStream();
 }
 
-void ThreadLocalPolicyMap::Update(std::vector<std::shared_ptr<PolicyInstanceImpl>>& added,
-                                  std::vector<std::string>& deleted,
-                                  const std::string& version_info) {
-  ENVOY_LOG(trace,
-            "Cilium L7 NetworkPolicyMap::onConfigUpdate(): Starting "
-            "updates on the {} thread for version {}",
-            Thread::MainThread::isMainThread() ? "main" : "worker", version_info);
-  for (const auto& policy_name : deleted) {
-    ENVOY_LOG(trace, "Cilium deleting removed network policy for endpoint {}", policy_name);
-    policies_.erase(policy_name);
-  }
-  for (const auto& new_policy : added) {
-    for (const auto& endpoint_ip : new_policy->policy_proto_.endpoint_ips()) {
-      ENVOY_LOG(trace, "Cilium updating network policy for endpoint {}", endpoint_ip);
-      policies_[endpoint_ip] = new_policy;
-    }
-  }
-}
-
-// updateInitManager must be called for each policy update before parsing the policy
-void NetworkPolicyMap::updateInitManager(const std::string& version_name) {
-  // Init manager for this version update.
-  // For the first initialization the listener's init manager is used.
-  // Setting the member here releases any previous manager as well.
-  version_init_manager_ = std::make_shared<Init::ManagerImpl>(version_name);
-
-  // Set the init manager to use via the transport factory context
-  // Must be set before the new network policy is parsed, as the parsed
-  // SDS secrets will use this!
-  transport_factory_context_->setInitManager(*version_init_manager_);
-}
-
 // removeInitManager must be called at the end of each each policy update
 void NetworkPolicyMap::removeInitManager() {
   // Remove the local init manager from the transport factory context
@@ -1270,109 +1234,15 @@ void NetworkPolicyMap::removeInitManager() {
 #pragma clang diagnostic pop
 }
 
-// executeUpdate is called for each policy update that has been successfully parsed
-// to execute the update on each worker thread. After the worker threads have updated
-// the update is also executed in the main thread and the cleanFn is called in the main thread.
-void NetworkPolicyMap::executeUpdate(const std::string& version_name,
-                                     std::function<void(ThreadLocalPolicyMap&)> updateFn,
-                                     std::function<void(NetworkPolicyMapSharedPtr)> cleanFn) {
-  // pause the subscription until the worker threads are done. No throws after this!
-  ENVOY_LOG(trace, "Pausing NPDS subscription");
-  pause();
-
-  // Create an init target to track network policy updates on worker threads.
-  // This is added to the version init manager below in order to wait for all worker
-  // threads to have applied policy updates before NPDS ACK is sent.
-  version_init_target_ = std::make_shared<Init::TargetImpl>(version_name, []() {});
-
-  // version init target is marked ready when all workers have updated.
-  version_init_manager_->add(*version_init_target_);
-
-  // 'this' may be already deleted when the worker threads get to execute the
-  // updates. Manage this by taking a shared_ptr on 'this' for the duration of
-  // the posted lambda.
-  std::shared_ptr<NetworkPolicyMap> shared_this = shared_from_this();
-
-  // Resume subscription via an Init::Watcher when fully initialized.
-  // This Watcher needs to be a member so that it exists after this function returns.
-  // It needs to be dynamically allocated so that we can initialize a new watcher for each
-  // network policy version.
-  // Since this is a member it must not hold a reference to the map to avoid a circular
-  // reference; so use a weak pointer instead.
-  // Setting the member here releases any previous watcher as well.
-  std::weak_ptr<NetworkPolicyMap> weak_this = shared_this;
-  version_init_watcher_ = std::make_shared<Init::WatcherImpl>(version_name, [weak_this]() {
-    if (std::shared_ptr<NetworkPolicyMap> shared_this = weak_this.lock()) {
-      // resume subscription when fully initialized
-      ENVOY_LOG(trace, "Resuming NPDS subscription");
-      shared_this->resume();
-    } else {
-      ENVOY_LOG(debug, "NetworkPolicyMap expired on watcher completion!");
-    }
-  });
-
-  // Execute update on all threads.
-  tls_map_.runOnAllThreads(
-      [version_name, updateFn](OptRef<ThreadLocalPolicyMap> npmap) {
-        // Main thread done after the worker threads
-        if (Thread::MainThread::isMainThread())
-          return;
-
-        if (!npmap.has_value()) {
-          ENVOY_LOG(
-              debug,
-              "Cilium L7 NetworkPolicyMap::onConfigUpdate(): Worker thread has no value for {}",
-              version_name);
-          return;
-        }
-        updateFn(npmap.value());
-      },
-      // Worker threads have executed updates, update & clean up on the main thread and
-      // mark the version init target ready.
-      [shared_this, version_name, updateFn, cleanFn]() {
-        // Update on the main thread last, so that deletes happen on the same thread as allocs
-        auto npmap = shared_this->tls_map_.get();
-        if (!npmap.has_value()) {
-          ENVOY_LOG(debug,
-                    "Cilium L7 NetworkPolicyMap::onConfigUpdate(): Main thread has no value for {}",
-                    version_name);
-        } else {
-          updateFn(npmap.value());
-        }
-
-        // Clean-up in the main thread
-        cleanFn(shared_this);
-
-        // Mark the init target as ready
-        shared_this->version_init_target_->ready();
-
-        // Compute update latency and log a warning if it took too long
-        shared_this->update_latency_ms_->complete();
-        auto duration = shared_this->update_latency_ms_->elapsed();
-        shared_this->update_latency_ms_.reset();
-
-        if (duration > shared_this->policy_update_warning_limit_ms_) {
-          shared_this->stats_.updates_timed_out_.inc();
-          ENVOY_LOG(warn,
-                    "Cilium L7 NetworkPolicyMap::onConfigUpdate(): Worker threads took longer "
-                    "than {}ms to update {} ({}ms)",
-                    shared_this->policy_update_warning_limit_ms_.count(), version_name,
-                    duration.count());
-        }
-      });
-
-  // Initialize SDS secrets, the watcher callback above will be called after all threads have
-  // updated policies and secrets have been fetched, or timeout (15 seconds) hits.
-  version_init_manager_->initialize(*version_init_watcher_);
-}
-
+// onConfigUpdate parses the new network policy resources, allocates a new policy map and atomically
+// swaps it in place of the old policy map. Throws if any of the 'resources' can not be
+// parsed. Otherwise an OK status is returned without pausing NPDS gRPC stream, causing a new
+// request (ACK) to be sent immediately, without waiting SDS secrets to be loaded.
 absl::Status
 NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourceRef>& resources,
                                  const std::string& version_info) {
   ENVOY_LOG(debug, "NetworkPolicyMap::onConfigUpdate({}), {} resources, version: {}", instance_id_,
             resources.size(), version_info);
-  update_latency_ms_ = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
-      stats_.update_latency_ms_, context_.timeSource());
   stats_.updates_total_.inc();
 
   // Reopen IPcache for every new stream. Cilium agent re-creates IP cache on restart,
@@ -1391,86 +1261,92 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
   }
 
   std::string version_name = fmt::format("NetworkPolicyMap version {}", version_info);
+  Init::ManagerImpl version_init_manager(version_name);
+  // Set the init manager to use via the transport factory context
+  // Must be set before the new network policy is parsed, as the parsed
+  // SDS secrets will use this!
+  transport_factory_context_->setInitManager(version_init_manager);
 
-  absl::flat_hash_set<std::string> keeps;
-  absl::flat_hash_set<std::string> ct_maps_to_keep;
+  const auto* old_map = load();
+  {
+    absl::flat_hash_set<std::string> ctmaps_to_keep;
+    auto new_map = new RawPolicyMap();
+    try {
+      for (const auto& resource : resources) {
+        const auto& config = dynamic_cast<const cilium::NetworkPolicy&>(resource.get().resource());
+        ENVOY_LOG(debug,
+                  "Received Network Policy for endpoint {} in onConfigUpdate() "
+                  "version {}",
+                  config.endpoint_id(), version_info);
+        if (config.endpoint_ips().size() == 0) {
+          throw EnvoyException("Network Policy has no endpoint ips");
+        }
+        ctmaps_to_keep.insert(config.conntrack_map_name());
+        ctmaps_to_be_closed_.erase(config.conntrack_map_name());
 
-  updateInitManager(version_name);
+        // First find the old config to figure out if an update is needed.
+        const uint64_t new_hash = MessageUtil::hash(config);
+        auto it = old_map->find(config.endpoint_ips()[0]);
+        if (it != old_map->cend()) {
+          const auto& old_policy = it->second;
+          if (old_policy && old_policy->hash_ == new_hash &&
+              Protobuf::util::MessageDifferencer::Equals(old_policy->policy_proto_, config)) {
+            ENVOY_LOG(trace, "New policy is equal to old one, not updating.");
+            for (const auto& endpoint_ip : config.endpoint_ips()) {
+              ENVOY_LOG(trace, "Cilium keeping network policy for endpoint {}", endpoint_ip);
+              new_map->emplace(endpoint_ip, old_policy);
+            }
+            continue;
+          }
+        }
 
-  // Collect a shared vector of policies to be added
-  auto to_be_added = std::make_shared<std::vector<std::shared_ptr<PolicyInstanceImpl>>>();
-  try {
-    for (const auto& resource : resources) {
-      const auto& config = dynamic_cast<const cilium::NetworkPolicy&>(resource.get().resource());
-      ENVOY_LOG(debug,
-                "Received Network Policy for endpoint {} in onConfigUpdate() "
-                "version {}",
-                config.endpoint_id(), version_info);
-      if (config.endpoint_ips().size() == 0) {
-        throw EnvoyException("Network Policy has no endpoint ips");
+        // May throw
+        auto new_policy = std::make_shared<const PolicyInstanceImpl>(*this, new_hash, config);
+
+        for (const auto& endpoint_ip : config.endpoint_ips()) {
+          ENVOY_LOG(trace, "Cilium updating network policy for endpoint {}", endpoint_ip);
+          // new_map is not exception safe, new_policy must be computed separately!
+          new_map->emplace(endpoint_ip, new_policy);
+        }
       }
-      for (const auto& endpoint_ip : config.endpoint_ips()) {
-        keeps.insert(endpoint_ip);
-      }
-      ct_maps_to_keep.insert(config.conntrack_map_name());
+    } catch (const EnvoyException& e) {
+      ENVOY_LOG(warn, "NetworkPolicy update for version {} failed: {}", version_info, e.what());
+      stats_.updates_rejected_.inc();
 
-      // First find the old config to figure out if an update is needed.
-      const uint64_t new_hash = MessageUtil::hash(config);
-      const auto& old_policy = GetPolicyInstanceImpl(config.endpoint_ips()[0]);
-      if (old_policy && old_policy->hash_ == new_hash &&
-          Protobuf::util::MessageDifferencer::Equals(old_policy->policy_proto_, config)) {
-        ENVOY_LOG(trace, "New policy is equal to old one, not updating.");
-        continue;
-      }
-
-      // May throw
-      to_be_added->emplace_back(std::make_shared<PolicyInstanceImpl>(*this, new_hash, config));
+      removeInitManager();
+      throw; // re-throw
     }
-  } catch (const EnvoyException& e) {
-    ENVOY_LOG(warn, "NetworkPolicy update for version {} failed: {}", version_info, e.what());
-    stats_.updates_rejected_.inc();
-
     removeInitManager();
 
-    throw; // re-throw
-  }
+    // Initialize SDS secrets. We do not wait for the completion.
+    version_init_manager.initialize(Init::WatcherImpl(version_name, []() {}));
 
-  removeInitManager();
-
-  // Collect a shared vector of policy names to be removed
-  auto to_be_deleted = std::make_shared<std::vector<std::string>>();
-  // Collect a shared vector of conntrack maps to close
-  auto cts_to_be_closed = std::make_shared<absl::flat_hash_set<std::string>>();
-  const auto& policies = tls_map_->policies_;
-  for (auto& pair : policies) {
-    if (keeps.find(pair.first) == keeps.end()) {
-      to_be_deleted->emplace_back(pair.first);
+    // Add old ctmaps to be closed
+    for (auto& pair : *old_map) {
+      // insert conntrack map names we don't want to keep
+      auto& ct_map_name = pair.second->conntrack_map_name_;
+      if (ctmaps_to_keep.find(ct_map_name) == ctmaps_to_keep.end()) {
+        ctmaps_to_be_closed_.insert(ct_map_name);
+      }
     }
-    // insert conntrack map names we don't want to keep and that have not been
-    // already inserted.
-    auto& ct_map_name = pair.second->conntrack_map_name_;
-    if (ct_maps_to_keep.find(ct_map_name) == ct_maps_to_keep.end() &&
-        cts_to_be_closed->find(ct_map_name) == cts_to_be_closed->end()) {
-      ENVOY_LOG(debug, "Closing conntrack map {}", ct_map_name);
-      cts_to_be_closed->insert(ct_map_name);
-    }
+
+    // Swap the new map in, new_map goes out of scope right after to eliminate accidental
+    // modification.
+    old_map = exchange(new_map);
   }
 
-  // Execute non-empty update on all threads
-  if (to_be_added->size() != 0 || to_be_deleted->size() != 0 || cts_to_be_closed->size() != 0) {
-    executeUpdate(
-        version_name,
-        [to_be_added, to_be_deleted, version_info](ThreadLocalPolicyMap& npmap) {
-          npmap.Update(*to_be_added, *to_be_deleted, version_info);
-        },
-        [cts_to_be_closed](NetworkPolicyMapSharedPtr shared_this) {
-          if (shared_this->ctmap_ && cts_to_be_closed->size() > 0) {
-            shared_this->ctmap_->closeMaps(cts_to_be_closed);
-          }
-        });
-  } else {
-    ENVOY_LOG(trace, "Skipping empty or duplicate policy update.");
-  }
+  // 'this' may be already deleted when the main thread gets to execute the cleanup.
+  // Manage this by taking a shared_ptr on 'this' for the duration of the posted lambda.
+  std::shared_ptr<NetworkPolicyMap> shared_this = shared_from_this();
+
+  runAfterAllThreads([shared_this, old_map]() {
+    // Clean-up in the main thread after all threads have scheduled
+    if (shared_this->ctmap_) {
+      shared_this->ctmap_->closeMaps(shared_this->ctmaps_to_be_closed_);
+    }
+    shared_this->ctmaps_to_be_closed_.clear();
+    delete old_map;
+  });
 
   return absl::OkStatus();
 }
@@ -1483,8 +1359,16 @@ void NetworkPolicyMap::onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureRe
 }
 
 void NetworkPolicyMap::runAfterAllThreads(std::function<void()> cb) const {
-  const_cast<NetworkPolicyMap*>(this)->tls_map_.runOnAllThreads([](OptRef<ThreadLocalPolicyMap>) {},
-                                                                cb);
+  // We can guarantee the callback 'cb' runs in the main thread after all worker threads have
+  // entered their event loop, and thus relinquished all state, such as policy lookup results that
+  // were stored in their call stack, by posting and empty function to their event queues and
+  // waiting until all of them have returned, as managed by 'runOnAllWorkerThreads'.
+  //
+  // For now we rely on the implementation dependent fact that the reference returned by
+  // context_.threadLocal() actually is a ThreadLocal::Instance reference, where
+  // runOnAllWorkerThreads() is exposed. Withtout this cast we'd need to use a dummy thread local
+  // variable that would take a thread local slot for no other purpose than to avoid this type cast.
+  dynamic_cast<ThreadLocal::Instance&>(context_.threadLocal()).runOnAllWorkerThreads([]() {}, cb);
 }
 
 ProtobufTypes::MessagePtr
@@ -1493,7 +1377,7 @@ NetworkPolicyMap::dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_m
 
   std::vector<uint64_t> policyEndpointIds;
   auto config_dump = std::make_unique<cilium::NetworkPoliciesConfigDump>();
-  for (const auto& item : tls_map_->policies_) {
+  for (const auto& item : *load()) {
     // filter duplicates (policies are stored per endpoint ip)
     if (std::find(policyEndpointIds.begin(), policyEndpointIds.end(),
                   item.second->policy_proto_.endpoint_id()) != policyEndpointIds.end()) {

--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -97,11 +97,7 @@ public:
 
     if (policy_socket_option) {
       const auto& policy = policy_socket_option->getPolicy();
-      if (!policy) {
-        ENVOY_LOG_MISC(warn, "cilium.tls_wrapper: No policy found for pod {}",
-                       policy_socket_option->pod_ip_);
-        return;
-      }
+
       // Resolve the destination security ID and port
       uint32_t destination_identity = 0;
       uint32_t destination_port = policy_socket_option->port_;
@@ -131,7 +127,7 @@ public:
 
       auto remote_id = policy_socket_option->ingress_ ? policy_socket_option->source_identity_
                                                       : destination_identity;
-      auto port_policy = policy->findPortPolicy(policy_socket_option->ingress_, destination_port);
+      auto port_policy = policy.findPortPolicy(policy_socket_option->ingress_, destination_port);
       const Envoy::Ssl::ContextConfig* config = nullptr;
       bool raw_socket_allowed = false;
       Envoy::Ssl::ContextSharedPtr ctx =
@@ -158,7 +154,7 @@ public:
         // Set the callbacks
         socket_->setTransportSocketCallbacks(*callbacks_);
       } else {
-        policy->tlsWrapperMissingPolicyInc();
+        policy.tlsWrapperMissingPolicyInc();
 
         std::string ipStr("<none>");
         if (policy_socket_option->ingress_) {

--- a/patches/0008-thread_local-reset-slot-in-worker-threads-first.patch
+++ b/patches/0008-thread_local-reset-slot-in-worker-threads-first.patch
@@ -1,4 +1,4 @@
-From 1a0f7e26bc8b2905d87c64f7fea9df42e874c28a Mon Sep 17 00:00:00 2001
+From b13c64877b55c1a645d3b6b1d18a566930ef519c Mon Sep 17 00:00:00 2001
 From: Jarno Rajahalme <jarno@isovalent.com>
 Date: Mon, 23 Dec 2024 22:43:15 +0100
 Subject: [PATCH 8/8] thread_local: reset slot in worker threads first
@@ -10,9 +10,33 @@ some random worker thread. This prevents xDS stream synchronization bugs
 if the slot happens to refer to an SDS secret.
 
 Signed-off-by: Jarno Rajahalme <jarno@isovalent.com>
+---
+ envoy/thread_local/thread_local.h             |  7 +++++
+ .../common/thread_local/thread_local_impl.cc  | 26 +++++++++++++++++--
+ .../common/thread_local/thread_local_impl.h   |  1 +
+ test/mocks/thread_local/mocks.h               |  4 +++
+ 4 files changed, 36 insertions(+), 2 deletions(-)
 
+diff --git a/envoy/thread_local/thread_local.h b/envoy/thread_local/thread_local.h
+index 13ff7496ff..da982ccea5 100644
+--- a/envoy/thread_local/thread_local.h
++++ b/envoy/thread_local/thread_local.h
+@@ -248,6 +248,13 @@ public:
+    * @return true if global threading has been shutdown or false if not.
+    */
+   virtual bool isShutdown() const PURE;
++
++  /**
++   * Run 'worker_cb' in all worker threads, and 'main_cb' in the main thread after all worker
++   * threads have executed.
++   */
++  virtual void runOnAllWorkerThreads(std::function<void()> worker_cb, std::function<void()> main_cb) const PURE;
++
+ };
+ 
+ } // namespace ThreadLocal
 diff --git a/source/common/thread_local/thread_local_impl.cc b/source/common/thread_local/thread_local_impl.cc
-index bd417164b1..34d1c0f1b2 100644
+index bd417164b1..ba3e98ab8c 100644
 --- a/source/common/thread_local/thread_local_impl.cc
 +++ b/source/common/thread_local/thread_local_impl.cc
 @@ -177,7 +177,8 @@ void InstanceImpl::removeSlot(uint32_t slot) {
@@ -44,7 +68,7 @@ index bd417164b1..34d1c0f1b2 100644
  }
  
 +void InstanceImpl::runOnAllWorkerThreads(std::function<void()> cb,
-+                                         std::function<void()> worker_threads_complete_cb) {
++                                         std::function<void()> worker_threads_complete_cb) const {
 +  ASSERT_IS_MAIN_OR_TEST_THREAD();
 +  ASSERT(!shutdown_);
 +
@@ -63,17 +87,32 @@ index bd417164b1..34d1c0f1b2 100644
    if (thread_local_data_.data_.size() <= index) {
      thread_local_data_.data_.resize(index + 1);
 diff --git a/source/common/thread_local/thread_local_impl.h b/source/common/thread_local/thread_local_impl.h
-index 90753101b6..108cf85152 100644
+index 90753101b6..bb87b9b502 100644
 --- a/source/common/thread_local/thread_local_impl.h
 +++ b/source/common/thread_local/thread_local_impl.h
-@@ -75,6 +75,7 @@ private:
-   void removeSlot(uint32_t slot);
-   void runOnAllThreads(std::function<void()> cb);
-   void runOnAllThreads(std::function<void()> cb, std::function<void()> main_callback);
-+  void runOnAllWorkerThreads(std::function<void()> cb, std::function<void()> main_callback);
-   static void setThreadLocal(uint32_t index, ThreadLocalObjectSharedPtr object);
+@@ -29,6 +29,7 @@ public:
+   void shutdownThread() override;
+   Event::Dispatcher& dispatcher() override;
+   bool isShutdown() const override { return shutdown_; }
++  void runOnAllWorkerThreads(std::function<void()> worker_cb, std::function<void()> main_cb) const override;
  
-   static thread_local ThreadLocalData thread_local_data_;
+ private:
+   // On destruction returns the slot index to the deferred delete queue (detaches it). This allows
+diff --git a/test/mocks/thread_local/mocks.h b/test/mocks/thread_local/mocks.h
+index 09dff23777..88d7cea1a9 100644
+--- a/test/mocks/thread_local/mocks.h
++++ b/test/mocks/thread_local/mocks.h
+@@ -27,6 +27,10 @@ public:
+   MOCK_METHOD(void, shutdownThread, ());
+   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
+   bool isShutdown() const override { return shutdown_; }
++  void runOnAllWorkerThreads(std::function<void()> worker_cb, std::function<void()> main_cb) const override {
++    worker_cb();
++    main_cb();
++  }
+ 
+   SlotPtr allocateSlotMock() { return SlotPtr{new SlotImpl(*this, current_slot_++)}; }
+   void runOnAllThreads1(std::function<void()> cb) { cb(); }
 -- 
-2.34.1
+2.47.1
 

--- a/tests/cilium_http_integration_test.cc
+++ b/tests/cilium_http_integration_test.cc
@@ -988,7 +988,7 @@ TEST_P(CiliumIntegrationPortRangeTest, InvalidRange) {
 
   uint64_t status;
   ASSERT_TRUE(absl::SimpleAtoi(response->headers().Status()->value().getStringView(), &status));
-  EXPECT_EQ(500, status);
+  EXPECT_EQ(403, status);
 }
 
 class CiliumIntegrationEgressTest : public CiliumIntegrationTest {

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -330,7 +330,7 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedMetadata) {
   EXPECT_EQ(12345678, policy_fs->ingress_source_identity_);
 
   // Expect policy accepts security ID 12345678 on ingress on port 80
-  auto port_policy = policy_fs->getPolicy()->findPortPolicy(true, 80);
+  auto port_policy = policy_fs->getPolicy().findPortPolicy(true, 80);
   EXPECT_TRUE(port_policy.allowed(12345678, ""));
 
   auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption();
@@ -373,7 +373,7 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedCIDRMetadata) {
   EXPECT_EQ(2, policy_fs->ingress_source_identity_);
 
   // Expect policy does not accept security ID 2 on ingress on port 80
-  auto port_policy = policy_fs->getPolicy()->findPortPolicy(true, 80);
+  auto port_policy = policy_fs->getPolicy().findPortPolicy(true, 80);
   EXPECT_FALSE(port_policy.allowed(2, ""));
 
   auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption();


### PR DESCRIPTION
Currently we must execute in all worker threads to be able to ACK the update back to Cilium agent. This has become a problem as Envoy logs show worker threads stalling for 10 seconds doing nothing, pausing the policy update progress long enough to cause problems for FQDN policies.

Change to create a new policy map for each update, sharing it as a const map for all worker threads using an atomic swap. Deletion of the old map is coordinated with the worker threads in RCU fashion, waiting until each worker thread has processed a new posted function, proving that they no longer use the policy lookop results they may have obtained. This can be done after ACK is already sent back to Cilium Agent.

There is a potentially significant functional change, we no longer wait at all for SDS secrets to be fetched. Network policy update is a node wide function, so it was questionable to stall it for a single secret used by some endpoint’s policy to begin with.

Unless Envoy main thread is too busy, this change should eliminate toFQDNs policy proxy wait timeouts sometimes seen in Cilium Agent.

Some high level design considerations:

Conceptually, we are changing the data synchronization model from (the old model):

- On policy update, compute diff to the current policy
- post the diff to all the worker threads, who independently apply the changes to their (thread) local policy map
  - When worker threads do this, by definition they can't be doing any policy lookups at the same time
- Main thread gets notified (via the 2nd callback to `runOnAllThreads()`) that the worker threads are finished, so it is safe to resume the gRPC stream, i.e., send the ACK

To a new model:
- On policy update, compute a new complete policy map (reusing unchanged parts from the previous one),
- publish the new (now const) map via an atomic pointer swap, making it immediately available to any policy lookups
  - worker thread may be doing anything at the same time, so it is important that:
    - pointer swap is atomic, using the `std::memory_order_release` memory model, so that no writes on the map can be reordered (by compiler or the processor's out-of-order-execution) to happen after the pointer swap, i.e., the map is actually immutable (const) when the worker threads get access to it.
    - pointer reads use the atomic load using the memory model `std::memory_order_acquire` so that the reads from the memory pointed to by the pointer can not be reordered to happen before the pointer read (by the compiler or by the processor's out-of-order-execution)
    - main thread obtain evidence that worker threads are not using any prior policy results, or that they are not in the middle of a policy lookup on the old map, before deleting the old policy map by
      - post an (empty) function to each worker thread after atomically swapping the map pointer, and get a callback after each worker thread has executed it. After this point no worker thread can still be accessing the old map, or using any results of prior policy lookups
        - The latter part is facilitated by changing policy lookup result to a const reference and not providing a copy constructor, so the worker threads can not copy the policy lookup result
  - `std::unique_ptr` can not generally be atomically swapped without locking, so we manage the map memory ourselves
    - Must `delete` the (old) map after the swap, and when the policy is destructed

The old model did not need to concern the code with low-level detail such as:
- manual memory management
- atomic operations
- memory model / ordering semantics
- policy possibly changing between two different policy lookups in contiguous the worker thread execution

The new model has benefits:
- Main thread can ACK the policy update without waiting for any feedback from the worker threads
- Less memory use due to only having one map
- Faster policy updates due to not having to compute and pass diffs to worker threads

And some cons:
- policy lookups on worker threads are now marginally slower due to the indirection via the atomic pointer
- Theoretically, a worker thread could be executing using the old policy after Cilium Agent has already been acknowledged of the new policy
  - But no *new* requests/connections *after the ACK has been received* can find/use the old policy.
- Since the main thread is no longer waiting for anything before ACKing the policy, it also can not wait for the SDS secrets to have been fetched

Why not use normal mutex instead of atomic pointer swap?
- main reason is that then the main thread could (theoretically) still stall on a worker thread holding the lock while not getting execution time
- the other reason is that atomic pointer swap is more efficient, as even taking a lock is a memory (read-modify-)write operation, and trashes the cache line holding the mutex for all CPUs

