### PR TITLE
bpf_metadata: cleanup socketoptions

### DIFF
--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -66,8 +66,8 @@ envoy_cc_library(
     name = "socket_option_lib",
     hdrs = [
         "policy_id.h",
-        "socket_option.h",
         "socket_option_cilium_mark.h",
+        "socket_option_cilium_policy.h",
         "socket_option_ip_transparent.h",
         "socket_option_source_address.h",
     ],

--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -69,6 +69,7 @@ envoy_cc_library(
         "socket_option.h",
         "socket_option_cilium_mark.h",
         "socket_option_ip_transparent.h",
+        "socket_option_source_address.h",
     ],
     repository = "@envoy",
     deps = [

--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -67,6 +67,7 @@ envoy_cc_library(
     hdrs = [
         "policy_id.h",
         "socket_option.h",
+        "socket_option_cilium_mark.h",
         "socket_option_ip_transparent.h",
     ],
     repository = "@envoy",

--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -67,6 +67,7 @@ envoy_cc_library(
     hdrs = [
         "policy_id.h",
         "socket_option.h",
+        "socket_option_ip_transparent.h",
     ],
     repository = "@envoy",
     deps = [

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -47,6 +47,7 @@
 #include "cilium/network_policy.h"
 #include "cilium/policy_id.h"
 #include "cilium/socket_option.h"
+#include "cilium/socket_option_ip_transparent.h"
 
 namespace Envoy {
 namespace Server {
@@ -77,6 +78,8 @@ public:
 
     uint32_t mark = (config->is_ingress_) ? 0x0A00 : 0x0B00;
     options->push_back(std::make_shared<Cilium::SocketMarkOption>(mark, 0));
+
+    options->push_back(std::make_shared<Cilium::IpTransparentSocketOption>());
 
     options->push_back(std::make_shared<Envoy::Network::SocketOptionImpl>(
         envoy::config::core::v3::SocketOption::STATE_PREBIND,
@@ -131,6 +134,8 @@ public:
 
     uint32_t mark = (config->is_ingress_) ? 0x0A00 : 0x0B00;
     options->push_back(std::make_shared<Cilium::SocketMarkOption>(mark, 0));
+
+    options->push_back(std::make_shared<Cilium::IpTransparentSocketOption>());
 
     options->push_back(std::make_shared<Envoy::Network::SocketOptionImpl>(
         envoy::config::core::v3::SocketOption::STATE_PREBIND,
@@ -580,6 +585,10 @@ Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {
               Network::UpstreamSocketOptionsFilterState::key())
           ->addOption(std::move(options));
     }
+  }
+
+  if (config_->addPrivilegedSocketOptions()) {
+    socket_options->push_back(std::make_shared<Envoy::Cilium::IpTransparentSocketOption>());
   }
 
   // allow reuse of the original source address by setting SO_REUSEADDR.

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -570,6 +570,8 @@ Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {
     auto bpf_metadata_socket_option = socket_metadata->buildBpfMetadataSocketOption();
     socket_options->push_back(bpf_metadata_socket_option);
 
+    socket_options->push_back(socket_metadata->buildSourceAddressSocketOption());
+
     if (config_->addPrivilegedSocketOptions()) {
       socket_options->push_back(socket_metadata->buildCiliumMarkSocketOption());
     }

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -47,6 +47,7 @@
 #include "cilium/network_policy.h"
 #include "cilium/policy_id.h"
 #include "cilium/socket_option.h"
+#include "cilium/socket_option_cilium_mark.h"
 #include "cilium/socket_option_ip_transparent.h"
 
 namespace Envoy {
@@ -76,8 +77,10 @@ public:
     std::shared_ptr<Envoy::Network::Socket::Options> options =
         std::make_shared<Envoy::Network::Socket::Options>();
 
+    options->push_back(std::make_shared<Cilium::SocketMarkOption>(0));
+
     uint32_t mark = (config->is_ingress_) ? 0x0A00 : 0x0B00;
-    options->push_back(std::make_shared<Cilium::SocketMarkOption>(mark, 0));
+    options->push_back(std::make_shared<Cilium::CiliumMarkSocketOption>(mark));
 
     options->push_back(std::make_shared<Cilium::IpTransparentSocketOption>());
 
@@ -132,8 +135,10 @@ public:
     std::shared_ptr<Envoy::Network::Socket::Options> options =
         std::make_shared<Envoy::Network::Socket::Options>();
 
+    options->push_back(std::make_shared<Cilium::SocketMarkOption>(0));
+
     uint32_t mark = (config->is_ingress_) ? 0x0A00 : 0x0B00;
-    options->push_back(std::make_shared<Cilium::SocketMarkOption>(mark, 0));
+    options->push_back(std::make_shared<Cilium::CiliumMarkSocketOption>(mark));
 
     options->push_back(std::make_shared<Cilium::IpTransparentSocketOption>());
 
@@ -564,6 +569,10 @@ Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {
 
     auto bpf_metadata_socket_option = socket_metadata->buildBpfMetadataSocketOption();
     socket_options->push_back(bpf_metadata_socket_option);
+
+    if (config_->addPrivilegedSocketOptions()) {
+      socket_options->push_back(socket_metadata->buildCiliumMarkSocketOption());
+    }
 
     // Make Cilium policy available to upstream filters when L7 LB
     if (config_->is_l7lb_) {

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -77,6 +77,8 @@ public:
 
     uint32_t mark = (config->is_ingress_) ? 0x0A00 : 0x0B00;
     options->push_back(std::make_shared<Cilium::SocketMarkOption>(mark, 0));
+    // SO_REUSEPORT for the listener socket is set via Envoy config
+
     context.addListenSocketOptions(options);
 
     return [listener_filter_matcher,
@@ -124,6 +126,8 @@ public:
 
     uint32_t mark = (config->is_ingress_) ? 0x0A00 : 0x0B00;
     options->push_back(std::make_shared<Cilium::SocketMarkOption>(mark, 0));
+    // SO_REUSEPORT for the listener socket is set via Envoy config
+
     context.addListenSocketOptions(options);
 
     return [config](Network::UdpListenerFilterManager& udp_listener_filter_manager,
@@ -567,6 +571,10 @@ Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {
           ->addOption(std::move(options));
     }
   }
+
+  // reuse port for forwarded client connections (SO_REUSEPORT)
+  Network::Socket::appendOptions(socket_options,
+                                 Network::SocketOptionFactory::buildReusePortOptions());
 
   // linger (SO_LINGER)
   struct linger linger;

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -77,6 +77,11 @@ public:
 
     uint32_t mark = (config->is_ingress_) ? 0x0A00 : 0x0B00;
     options->push_back(std::make_shared<Cilium::SocketMarkOption>(mark, 0));
+
+    options->push_back(std::make_shared<Envoy::Network::SocketOptionImpl>(
+        envoy::config::core::v3::SocketOption::STATE_PREBIND,
+        Envoy::Network::SocketOptionName(SOL_SOCKET, SO_REUSEADDR, "SO_REUSEADDR"), 1));
+
     // SO_REUSEPORT for the listener socket is set via Envoy config
 
     context.addListenSocketOptions(options);
@@ -126,6 +131,11 @@ public:
 
     uint32_t mark = (config->is_ingress_) ? 0x0A00 : 0x0B00;
     options->push_back(std::make_shared<Cilium::SocketMarkOption>(mark, 0));
+
+    options->push_back(std::make_shared<Envoy::Network::SocketOptionImpl>(
+        envoy::config::core::v3::SocketOption::STATE_PREBIND,
+        Envoy::Network::SocketOptionName(SOL_SOCKET, SO_REUSEADDR, "SO_REUSEADDR"), 1));
+
     // SO_REUSEPORT for the listener socket is set via Envoy config
 
     context.addListenSocketOptions(options);
@@ -571,6 +581,13 @@ Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {
           ->addOption(std::move(options));
     }
   }
+
+  // allow reuse of the original source address by setting SO_REUSEADDR.
+  // This may by needed for retries to not fail on "address already in use"
+  // when using a specifis source address and port.
+  socket_options->push_back(std::make_shared<Envoy::Network::SocketOptionImpl>(
+      envoy::config::core::v3::SocketOption::STATE_PREBIND,
+      Envoy::Network::SocketOptionName(SOL_SOCKET, SO_REUSEADDR, "SO_REUSEADDR"), 1));
 
   // reuse port for forwarded client connections (SO_REUSEPORT)
   Network::Socket::appendOptions(socket_options,

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -23,6 +23,7 @@
 #include "cilium/ipcache.h"
 #include "cilium/network_policy.h"
 #include "cilium/socket_option.h"
+#include "cilium/socket_option_cilium_mark.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -45,9 +46,13 @@ struct SocketMetadata {
 
   std::shared_ptr<Envoy::Cilium::SocketOption> buildBpfMetadataSocketOption() {
     return std::make_shared<Envoy::Cilium::SocketOption>(
-        mark_, ingress_source_identity_, source_identity_, ingress_, is_l7lb_, port_,
-        std::move(pod_ip_), original_source_address_, source_address_ipv4_, source_address_ipv6_,
-        policy_resolver_, proxy_id_, sni_);
+        ingress_source_identity_, source_identity_, ingress_, is_l7lb_, port_, std::move(pod_ip_),
+        original_source_address_, source_address_ipv4_, source_address_ipv6_, policy_resolver_,
+        proxy_id_, sni_);
+  };
+
+  std::shared_ptr<Envoy::Cilium::CiliumMarkSocketOption> buildCiliumMarkSocketOption() {
+    return std::make_shared<Envoy::Cilium::CiliumMarkSocketOption>(mark_);
   };
 
   uint32_t ingress_source_identity_;

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -22,8 +22,8 @@
 #include "cilium/host_map.h"
 #include "cilium/ipcache.h"
 #include "cilium/network_policy.h"
-#include "cilium/socket_option.h"
 #include "cilium/socket_option_cilium_mark.h"
+#include "cilium/socket_option_cilium_policy.h"
 #include "cilium/socket_option_source_address.h"
 
 namespace Envoy {
@@ -45,8 +45,8 @@ struct SocketMetadata {
         source_address_ipv4_(std::move(source_address_ipv4)),
         source_address_ipv6_(std::move(source_address_ipv6)) {}
 
-  std::shared_ptr<Envoy::Cilium::SocketOption> buildBpfMetadataSocketOption() {
-    return std::make_shared<Envoy::Cilium::SocketOption>(
+  std::shared_ptr<Envoy::Cilium::CiliumPolicySocketOption> buildCiliumPolicySocketOption() {
+    return std::make_shared<Envoy::Cilium::CiliumPolicySocketOption>(
         ingress_source_identity_, source_identity_, ingress_, is_l7lb_, port_, std::move(pod_ip_),
         policy_resolver_, proxy_id_, sni_);
   };

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -86,6 +86,10 @@ public:
 
   virtual absl::optional<SocketMetadata> extractSocketMetadata(Network::ConnectionSocket& socket);
 
+  // Possibility to prevent socket options that require
+  // NET_ADMIN privileges from being applied. Used by tests.
+  virtual bool addPrivilegedSocketOptions() { return true; };
+
   uint32_t proxy_id_;
   bool is_ingress_;
   bool use_original_source_address_;

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -24,6 +24,7 @@
 #include "cilium/network_policy.h"
 #include "cilium/socket_option.h"
 #include "cilium/socket_option_cilium_mark.h"
+#include "cilium/socket_option_source_address.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -47,12 +48,16 @@ struct SocketMetadata {
   std::shared_ptr<Envoy::Cilium::SocketOption> buildBpfMetadataSocketOption() {
     return std::make_shared<Envoy::Cilium::SocketOption>(
         ingress_source_identity_, source_identity_, ingress_, is_l7lb_, port_, std::move(pod_ip_),
-        original_source_address_, source_address_ipv4_, source_address_ipv6_, policy_resolver_,
-        proxy_id_, sni_);
+        policy_resolver_, proxy_id_, sni_);
   };
 
   std::shared_ptr<Envoy::Cilium::CiliumMarkSocketOption> buildCiliumMarkSocketOption() {
     return std::make_shared<Envoy::Cilium::CiliumMarkSocketOption>(mark_);
+  };
+
+  std::shared_ptr<Envoy::Cilium::SourceAddressSocketOption> buildSourceAddressSocketOption() {
+    return std::make_shared<Envoy::Cilium::SourceAddressSocketOption>(
+        source_identity_, original_source_address_, source_address_ipv4_, source_address_ipv6_);
   };
 
   uint32_t ingress_source_identity_;

--- a/cilium/l7policy.cc
+++ b/cilium/l7policy.cc
@@ -35,7 +35,7 @@
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/api/l7policy.pb.h"
 #include "cilium/api/l7policy.pb.validate.h" // IWYU pragma: keep
-#include "cilium/socket_option.h"
+#include "cilium/socket_option_cilium_policy.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -163,9 +163,9 @@ Http::FilterHeadersStatus AccessFilter::decodeHeaders(Http::RequestHeaderMap& he
   }
 
   const Network::Socket::OptionsSharedPtr socketOptions = conn->socketOptions();
-  const auto option = Cilium::GetSocketOption(socketOptions);
-  if (!option) {
-    sendLocalError("cilium.l7policy: Cilium Socket Option not found");
+  const auto policy_socket_option = Cilium::GetCiliumPolicySocketOption(socketOptions);
+  if (!policy_socket_option) {
+    sendLocalError("cilium.l7policy: Cilium Policy Socket Option not found");
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -189,12 +189,13 @@ Http::FilterHeadersStatus AccessFilter::decodeHeaders(Http::RequestHeaderMap& he
   }
 
   uint32_t destination_port = dip->port();
-  uint32_t destination_identity = option->resolvePolicyId(dip);
+  uint32_t destination_identity = policy_socket_option->resolvePolicyId(dip);
 
   // Policy may have changed since the connection was established, get fresh policy
-  const auto& policy = option->getPolicy();
+  const auto& policy = policy_socket_option->getPolicy();
   if (!policy) {
-    sendLocalError(fmt::format("cilium.l7policy: No policy found for pod {}", option->pod_ip_));
+    sendLocalError(
+        fmt::format("cilium.l7policy: No policy found for pod {}", policy_socket_option->pod_ip_));
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -207,37 +208,41 @@ Http::FilterHeadersStatus AccessFilter::decodeHeaders(Http::RequestHeaderMap& he
   // Enforce Ingress policy only in the downstream filter
   if (!config_->is_upstream_) {
     log_entry_->InitFromRequest(
-        option->pod_ip_, option->proxy_id_, option->ingress_, option->identity_,
+        policy_socket_option->pod_ip_, policy_socket_option->proxy_id_,
+        policy_socket_option->ingress_, policy_socket_option->source_identity_,
         callbacks_->streamInfo().downstreamAddressProvider().remoteAddress(), 0,
         callbacks_->streamInfo().downstreamAddressProvider().localAddress(),
         callbacks_->streamInfo(), headers);
 
-    if (option->ingress_source_identity_ != 0) {
-      allowed_ = policy->allowed(true, option->ingress_source_identity_, option->port_, headers,
-                                 *log_entry_);
+    if (policy_socket_option->ingress_source_identity_ != 0) {
+      allowed_ = policy->allowed(true, policy_socket_option->ingress_source_identity_,
+                                 policy_socket_option->port_, headers, *log_entry_);
       ENVOY_LOG(debug,
                 "cilium.l7policy: Ingress from {} policy lookup for endpoint {} for port {}: {}",
-                option->ingress_source_identity_, option->pod_ip_, option->port_,
-                allowed_ ? "ALLOW" : "DENY");
+                policy_socket_option->ingress_source_identity_, policy_socket_option->pod_ip_,
+                policy_socket_option->port_, allowed_ ? "ALLOW" : "DENY");
       denied = !allowed_;
     }
 
     // Downstream filter leaves L7 LB enforcement and access logging to the upstream
     // filter
-    if (!denied && option->is_l7lb_) {
+    if (!denied && policy_socket_option->is_l7lb_) {
       return Http::FilterHeadersStatus::Continue;
     }
   }
 
   if (!denied) {
-    allowed_ = policy->allowed(option->ingress_,
-                               option->ingress_ ? option->identity_ : destination_identity,
-                               destination_port, headers, *log_entry_);
+    allowed_ =
+        policy->allowed(policy_socket_option->ingress_,
+                        policy_socket_option->ingress_ ? policy_socket_option->source_identity_
+                                                       : destination_identity,
+                        destination_port, headers, *log_entry_);
   }
   ENVOY_LOG(debug, "cilium.l7policy: {} ({}->{}) {} policy lookup for endpoint {} for port {}: {}",
-            option->ingress_ ? "ingress" : "egress", option->identity_, destination_identity,
-            config_->is_upstream_ ? "upstream" : "downstream", option->pod_ip_, destination_port,
-            allowed_ ? "ALLOW" : "DENY");
+            policy_socket_option->ingress_ ? "ingress" : "egress",
+            policy_socket_option->source_identity_, destination_identity,
+            config_->is_upstream_ ? "upstream" : "downstream", policy_socket_option->pod_ip_,
+            destination_port, allowed_ ? "ALLOW" : "DENY");
 
   // Update the log entry with the chosen destination address and current headers, as remaining
   // filters, upstream, and/or policy may have altered headers.

--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -31,7 +31,7 @@
 #include "cilium/api/network_filter.pb.h"
 #include "cilium/api/network_filter.pb.validate.h" // IWYU pragma: keep
 #include "cilium/proxylib.h"
-#include "cilium/socket_option.h"
+#include "cilium/socket_option_cilium_policy.h"
 #include "proxylib/types.h"
 
 namespace Envoy {
@@ -103,15 +103,15 @@ Network::FilterStatus Instance::onNewConnection() {
 
   auto& conn = callbacks_->connection();
   const Network::Socket::OptionsSharedPtr socketOptions = conn.socketOptions();
-  const auto option = Cilium::GetSocketOption(socketOptions);
+  const auto policy_socket_option = Cilium::GetCiliumPolicySocketOption(socketOptions);
 
-  if (!option) {
-    ENVOY_CONN_LOG(warn, "cilium.network: Cilium Socket Option not found", conn);
+  if (!policy_socket_option) {
+    ENVOY_CONN_LOG(warn, "cilium.network: Cilium Policy Socket Option not found", conn);
     return Network::FilterStatus::StopIteration;
   }
 
   // Default to incoming destination port, may be changed for L7 LB
-  destination_port_ = option->port_;
+  destination_port_ = policy_socket_option->port_;
 
   // Pass SNI before the upstream callback so that it is available when upstream connection is
   // initialized.
@@ -139,8 +139,9 @@ Network::FilterStatus Instance::onNewConnection() {
     }
   }
 
-  callbacks_->addUpstreamCallback([this, option, sni](Upstream::HostDescriptionConstSharedPtr host,
-                                                      StreamInfo::StreamInfo& stream_info) -> bool {
+  callbacks_->addUpstreamCallback([this, policy_socket_option,
+                                   sni](Upstream::HostDescriptionConstSharedPtr host,
+                                        StreamInfo::StreamInfo& stream_info) -> bool {
     ENVOY_LOG(trace, "cilium.network: in upstream callback");
     auto& conn = callbacks_->connection();
 
@@ -148,19 +149,20 @@ Network::FilterStatus Instance::onNewConnection() {
     uint32_t destination_identity = 0;
 
     Network::Address::InstanceConstSharedPtr dst_address =
-        option->policyUseUpstreamDestinationAddress()
+        policy_socket_option->policyUseUpstreamDestinationAddress()
             ? host->address()
             : stream_info.downstreamAddressProvider().localAddress();
     if (nullptr == dst_address) {
       ENVOY_LOG(warn, "cilium.network (egress): No destination address ");
       return false;
     }
-    const auto& policy = option->getPolicy();
+    const auto& policy = policy_socket_option->getPolicy();
     if (!policy) {
-      ENVOY_LOG_MISC(warn, "cilium.network: No policy found for pod {}", option->pod_ip_);
+      ENVOY_LOG_MISC(warn, "cilium.network: No policy found for pod {}",
+                     policy_socket_option->pod_ip_);
       return false;
     }
-    if (!option->ingress_) {
+    if (!policy_socket_option->ingress_) {
       const auto dip = dst_address->ip();
       if (!dip) {
         ENVOY_LOG_MISC(warn, "cilium.network: Non-IP destination address: {}",
@@ -168,23 +170,24 @@ Network::FilterStatus Instance::onNewConnection() {
         return false;
       }
       destination_port_ = dip->port();
-      destination_identity = option->resolvePolicyId(dip);
+      destination_identity = policy_socket_option->resolvePolicyId(dip);
 
-      if (option->ingress_source_identity_ != 0) {
+      if (policy_socket_option->ingress_source_identity_ != 0) {
         auto ingress_port_policy = policy->findPortPolicy(true, destination_port_);
-        if (!ingress_port_policy.allowed(option->ingress_source_identity_, sni)) {
+        if (!ingress_port_policy.allowed(policy_socket_option->ingress_source_identity_, sni)) {
           ENVOY_CONN_LOG(
               debug,
               "cilium.network: ingress policy DROP for source identity: {} port: {} sni: \"{}\"",
-              conn, option->ingress_source_identity_, destination_port_, sni);
+              conn, policy_socket_option->ingress_source_identity_, destination_port_, sni);
           return false;
         }
       }
     }
 
-    auto port_policy = policy->findPortPolicy(option->ingress_, destination_port_);
+    auto port_policy = policy->findPortPolicy(policy_socket_option->ingress_, destination_port_);
 
-    remote_id_ = option->ingress_ ? option->identity_ : destination_identity;
+    remote_id_ = policy_socket_option->ingress_ ? policy_socket_option->source_identity_
+                                                : destination_identity;
     if (!port_policy.allowed(remote_id_, sni)) {
       // Connection not allowed by policy
       ENVOY_CONN_LOG(debug, "cilium.network: Policy DENY on id: {} port: {} sni: \"{}\"", conn,
@@ -196,13 +199,14 @@ Network::FilterStatus Instance::onNewConnection() {
                      remote_id_, destination_port_, sni);
     }
 
-    const std::string& policy_name = option->pod_ip_;
+    const std::string& policy_name = policy_socket_option->pod_ip_;
     // populate l7proto_ if available
     if (port_policy.useProxylib(remote_id_, l7proto_)) {
       // Initialize Go parser if requested
       if (config_->proxylib_.get() != nullptr) {
         go_parser_ = config_->proxylib_->NewInstance(
-            conn, l7proto_, option->ingress_, option->identity_, destination_identity,
+            conn, l7proto_, policy_socket_option->ingress_, policy_socket_option->source_identity_,
+            destination_identity,
             stream_info.downstreamAddressProvider().remoteAddress()->asString(),
             dst_address->asString(), policy_name);
         if (go_parser_.get() == nullptr) {
@@ -210,8 +214,9 @@ Network::FilterStatus Instance::onNewConnection() {
           return false;
         }
       } else { // no Go parser, initialize logging for metadata based access control
-        log_entry_.InitFromConnection(policy_name, option->proxy_id_, option->ingress_,
-                                      option->identity_,
+        log_entry_.InitFromConnection(policy_name, policy_socket_option->proxy_id_,
+                                      policy_socket_option->ingress_,
+                                      policy_socket_option->source_identity_,
                                       stream_info.downstreamAddressProvider().remoteAddress(),
                                       destination_identity, dst_address, &config_->time_source_);
       }
@@ -268,22 +273,23 @@ Network::FilterStatus Instance::onData(Buffer::Instance& data, bool end_stream) 
 
     // Policy may have changed since the connection was established, get fresh policy
     const Network::Socket::OptionsSharedPtr socketOptions = conn.socketOptions();
-    const auto option = Cilium::GetSocketOption(socketOptions);
-    if (!option) {
-      ENVOY_CONN_LOG(warn,
-                     "cilium.network: Cilium metadata not found for pod {}, defaulting to DENY",
-                     conn, option->pod_ip_);
+    const auto policy_socket_option = Cilium::GetCiliumPolicySocketOption(socketOptions);
+    if (!policy_socket_option) {
+      ENVOY_CONN_LOG(
+          warn,
+          "cilium.network: Cilium Policy Socket Option not found for pod {}, defaulting to DENY",
+          conn, policy_socket_option->pod_ip_);
       reason = "Cilium metadata lost";
       goto drop_close;
     }
-    const auto& policy = option->getPolicy();
+    const auto& policy = policy_socket_option->getPolicy();
     if (!policy) {
       ENVOY_CONN_LOG(warn, "cilium.network: No policy found for pod {}, defaulting to DENY", conn,
-                     option->pod_ip_);
+                     policy_socket_option->pod_ip_);
       reason = "Cilium policy not found";
       goto drop_close;
     }
-    auto port_policy = policy->findPortPolicy(option->ingress_, destination_port_);
+    auto port_policy = policy->findPortPolicy(policy_socket_option->ingress_, destination_port_);
     if (!port_policy.allowed(remote_id_, metadata)) {
       config_->Log(log_entry_, ::cilium::EntryType::Denied);
       reason = "metadata policy drop";

--- a/cilium/privileged_service_client.h
+++ b/cilium/privileged_service_client.h
@@ -28,15 +28,15 @@ public:
   friend class Envoy::Cilium::Bpf;
   friend class Envoy::Cilium::SocketMarkOption;
 
+  // Set a socket option
+  Envoy::Api::SysCallIntResult setsockopt(int sockfd, int level, int optname, const void* optval,
+                                          socklen_t optlen);
+
 protected:
   // Read-only bpf syscalls
   Envoy::Api::SysCallIntResult bpf_open(const char* path);
   Envoy::Api::SysCallIntResult bpf_lookup(int fd, const void* key, uint32_t key_size, void* value,
                                           uint32_t value_size);
-
-  // Set a socket option
-  Envoy::Api::SysCallIntResult setsockopt(int sockfd, int level, int optname, const void* optval,
-                                          socklen_t optlen);
 
 private:
   bool check_privileged_service();

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -99,41 +99,6 @@ public:
       }
     }
 
-    uint32_t one = 1;
-
-    // identity is zero for the listener socket itself, set transparent and reuse options also for
-    // the listener socket.
-    if (source_address || identity_ == 0) {
-      {
-        // Set ip transparent option based on the socket address family
-        auto ip_socket_level = SOL_IP;
-        auto ip_transparent_socket_option = IP_TRANSPARENT;
-        auto ip_transparent_socket_option_name = "IP_TRANSPARENT";
-        if (*ipVersion == Network::Address::IpVersion::v6) {
-          ip_socket_level = SOL_IPV6;
-          ip_transparent_socket_option = IPV6_TRANSPARENT;
-          ip_transparent_socket_option_name = "IPV6_TRANSPARENT";
-        }
-
-        auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), ip_socket_level,
-                                              ip_transparent_socket_option, &one, sizeof(one));
-        if (status.return_value_ < 0) {
-          if (status.errno_ == EPERM) {
-            // Do not assert out in this case so that we can run tests without
-            // CAP_NET_ADMIN.
-            ENVOY_LOG(critical,
-                      "Failed to set socket option {}, capability "
-                      "CAP_NET_ADMIN needed: {}",
-                      ip_transparent_socket_option_name, Envoy::errorDetails(status.errno_));
-          } else {
-            ENVOY_LOG(critical, "Socket option failure. Failed to set {}: {}",
-                      ip_transparent_socket_option_name, Envoy::errorDetails(status.errno_));
-            return false;
-          }
-        }
-      }
-    }
-
     ENVOY_LOG(trace,
               "Set socket ({}) option SO_MARK to {:x} (magic mark: {:x}, id: "
               "{}, cluster: {}), src: {}",

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -17,14 +17,12 @@
 
 #include "source/common/common/hex.h"
 #include "source/common/common/logger.h"
-#include "source/common/common/utility.h"
 
 #include "absl/numeric/int128.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "cilium/network_policy.h"
 #include "cilium/policy_id.h"
-#include "cilium/privileged_service_client.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -40,12 +38,11 @@ public:
 class SocketMarkOption : public Network::Socket::Option,
                          public Logger::Loggable<Logger::Id::filter> {
 public:
-  SocketMarkOption(uint32_t mark, uint32_t identity,
+  SocketMarkOption(uint32_t identity,
                    Network::Address::InstanceConstSharedPtr original_source_address = nullptr,
                    Network::Address::InstanceConstSharedPtr ipv4_source_address = nullptr,
                    Network::Address::InstanceConstSharedPtr ipv6_source_address = nullptr)
-      : identity_(identity), mark_(mark),
-        original_source_address_(std::move(original_source_address)),
+      : identity_(identity), original_source_address_(std::move(original_source_address)),
         ipv4_source_address_(std::move(ipv4_source_address)),
         ipv6_source_address_(std::move(ipv6_source_address)) {}
 
@@ -57,34 +54,12 @@ public:
 
   bool setOption(Network::Socket& socket,
                  envoy::config::core::v3::SocketOption::SocketState state) const override {
-    // don't set option for mark 0 -> tests rely on this (they fail due to missing capabilities)
-    if (mark_ == 0) {
-      return true;
-    }
     // Only set the option once per socket
     if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
       ENVOY_LOG(trace, "Skipping setting socket ({}) option SO_MARK, state != STATE_PREBIND",
                 socket.ioHandle().fdDoNotUse());
       return true;
     }
-    auto& cilium_calls = PrivilegedService::Singleton::get();
-    auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_SOCKET, SO_MARK,
-                                          &mark_, sizeof(mark_));
-    if (status.return_value_ < 0) {
-      if (status.errno_ == EPERM) {
-        // Do not assert out in this case so that we can run tests without
-        // CAP_NET_ADMIN.
-        ENVOY_LOG(critical,
-                  "Failed to set socket option SO_MARK to {}, capability "
-                  "CAP_NET_ADMIN needed: {}",
-                  mark_, Envoy::errorDetails(status.errno_));
-      } else {
-        ENVOY_LOG(critical, "Socket option failure. Failed to set SO_MARK to {}: {}", mark_,
-                  Envoy::errorDetails(status.errno_));
-        return false;
-      }
-    }
-
     auto ipVersion = socket.ipVersion();
     if (!ipVersion.has_value()) {
       ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
@@ -99,12 +74,6 @@ public:
       }
     }
 
-    ENVOY_LOG(trace,
-              "Set socket ({}) option SO_MARK to {:x} (magic mark: {:x}, id: "
-              "{}, cluster: {}), src: {}",
-              socket.ioHandle().fdDoNotUse(), mark_, mark_ & 0xff00, mark_ >> 16, mark_ & 0xff,
-              source_address ? source_address->asString() : "");
-
     if (source_address) {
       socket.connectionInfoProvider().setLocalAddress(std::move(source_address));
     }
@@ -118,10 +87,6 @@ public:
   }
 
   void hashKey(std::vector<uint8_t>& key) const override {
-    // don't calculate hash key for mark 0
-    if (mark_ == 0) {
-      return;
-    }
     // Source address is more specific than policy ID. If using an original
     // source address, we do not need to also add the source security ID to the
     // hash key. Note that since the identity is 3 bytes it will not collide
@@ -156,7 +121,6 @@ public:
   bool isSupported() const override { return true; }
 
   uint32_t identity_;
-  uint32_t mark_;
   Network::Address::InstanceConstSharedPtr original_source_address_;
   // Version specific source addresses are only used if original source address is not used.
   // Selection is made based on the socket domain, which is selected based on the destination
@@ -168,27 +132,26 @@ public:
 
 class SocketOption : public SocketMarkOption {
 public:
-  SocketOption(uint32_t mark, uint32_t ingress_source_identity, uint32_t source_identity,
-               bool ingress, bool l7lb, uint16_t port, std::string&& pod_ip,
+  SocketOption(uint32_t ingress_source_identity, uint32_t source_identity, bool ingress, bool l7lb,
+               uint16_t port, std::string&& pod_ip,
                Network::Address::InstanceConstSharedPtr original_source_address,
                Network::Address::InstanceConstSharedPtr ipv4_source_address,
                Network::Address::InstanceConstSharedPtr ipv6_source_address,
                const std::weak_ptr<PolicyResolver>& policy_resolver, uint32_t proxy_id,
                absl::string_view sni)
-      : SocketMarkOption(mark, source_identity, original_source_address, ipv4_source_address,
+      : SocketMarkOption(source_identity, original_source_address, ipv4_source_address,
                          ipv6_source_address),
         ingress_source_identity_(ingress_source_identity), ingress_(ingress), is_l7lb_(l7lb),
         port_(port), pod_ip_(std::move(pod_ip)), proxy_id_(proxy_id), sni_(sni),
         policy_resolver_(policy_resolver) {
-    ENVOY_LOG(debug,
-              "Cilium SocketOption(): source_identity: {}, "
-              "ingress: {}, port: {}, pod_ip: {}, source_addresses: {}/{}/{}, mark: {:x} (magic "
-              "mark: {:x}, cluster: {}, ID: {}), proxy_id: {}, sni: \"{}\"",
-              identity_, ingress_, port_, pod_ip_,
-              original_source_address_ ? original_source_address_->asString() : "",
-              ipv4_source_address_ ? ipv4_source_address_->asString() : "",
-              ipv6_source_address_ ? ipv6_source_address_->asString() : "", mark_, mark & 0xff00,
-              mark & 0xff, mark >> 16, proxy_id_, sni_);
+    ENVOY_LOG(
+        debug,
+        "Cilium SocketOption(): source_identity: {}, "
+        "ingress: {}, port: {}, pod_ip: {}, source_addresses: {}/{}/{}, proxy_id: {}, sni: \"{}\"",
+        identity_, ingress_, port_, pod_ip_,
+        original_source_address_ ? original_source_address_->asString() : "",
+        ipv4_source_address_ ? ipv4_source_address_->asString() : "",
+        ipv6_source_address_ ? ipv6_source_address_->asString() : "", proxy_id_, sni_);
   }
 
   uint32_t resolvePolicyId(const Network::Address::Ip* ip) const {

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -146,19 +146,6 @@ public:
       }
     }
 
-    if (identity_ != 0) {
-      // Set SO_REUSEPORT socket option for forwarded client connections.
-      // The same option on the listener socket is controlled via the Envoy Listener option
-      // enable_reuse_port.
-      ENVOY_LOG(trace, "Set socket ({}) option SO_REUSEPORT", socket.ioHandle().fdDoNotUse());
-      status = socket.setSocketOption(SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
-      if (status.return_value_ < 0) {
-        ENVOY_LOG(critical, "Failed to set socket option SO_REUSEPORT: {}",
-                  Envoy::errorDetails(status.errno_));
-        return false;
-      }
-    }
-
     ENVOY_LOG(trace,
               "Set socket ({}) option SO_MARK to {:x} (magic mark: {:x}, id: "
               "{}, cluster: {}), src: {}",

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -132,18 +132,6 @@ public:
           }
         }
       }
-
-      // Allow reuse of the original source address. This may by needed for
-      // retries to not fail on "address already in use" when using a specific
-      // source address and port.
-      {
-        auto status = socket.setSocketOption(SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
-        if (status.return_value_ < 0) {
-          ENVOY_LOG(critical, "Failed to set socket option SO_REUSEADDR: {}",
-                    Envoy::errorDetails(status.errno_));
-          return false;
-        }
-      }
     }
 
     ENVOY_LOG(trace,

--- a/cilium/socket_option.h
+++ b/cilium/socket_option.h
@@ -15,10 +15,8 @@
 #include "envoy/network/address.h"
 #include "envoy/network/socket.h"
 
-#include "source/common/common/hex.h"
 #include "source/common/common/logger.h"
 
-#include "absl/numeric/int128.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "cilium/network_policy.h"
@@ -38,13 +36,7 @@ public:
 class SocketMarkOption : public Network::Socket::Option,
                          public Logger::Loggable<Logger::Id::filter> {
 public:
-  SocketMarkOption(uint32_t identity,
-                   Network::Address::InstanceConstSharedPtr original_source_address = nullptr,
-                   Network::Address::InstanceConstSharedPtr ipv4_source_address = nullptr,
-                   Network::Address::InstanceConstSharedPtr ipv6_source_address = nullptr)
-      : identity_(identity), original_source_address_(std::move(original_source_address)),
-        ipv4_source_address_(std::move(ipv4_source_address)),
-        ipv6_source_address_(std::move(ipv6_source_address)) {}
+  SocketMarkOption(uint32_t identity) : identity_(identity) {}
 
   absl::optional<Network::Socket::Option::Details>
   getOptionDetails(const Network::Socket&,
@@ -52,106 +44,33 @@ public:
     return absl::nullopt;
   }
 
-  bool setOption(Network::Socket& socket,
-                 envoy::config::core::v3::SocketOption::SocketState state) const override {
-    // Only set the option once per socket
-    if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
-      ENVOY_LOG(trace, "Skipping setting socket ({}) option SO_MARK, state != STATE_PREBIND",
-                socket.ioHandle().fdDoNotUse());
-      return true;
-    }
-    auto ipVersion = socket.ipVersion();
-    if (!ipVersion.has_value()) {
-      ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
-      return false;
-    }
-    Network::Address::InstanceConstSharedPtr source_address = original_source_address_;
-    if (!source_address && (ipv4_source_address_ || ipv6_source_address_)) {
-      // Select source address based on the socket address family
-      source_address = ipv6_source_address_;
-      if (*ipVersion == Network::Address::IpVersion::v4) {
-        source_address = ipv4_source_address_;
-      }
-    }
-
-    if (source_address) {
-      socket.connectionInfoProvider().setLocalAddress(std::move(source_address));
-    }
+  bool setOption(
+      [[maybe_unused]] Network::Socket& socket,
+      [[maybe_unused]] envoy::config::core::v3::SocketOption::SocketState state) const override {
 
     return true;
   }
 
-  template <typename T> void addressIntoVector(std::vector<uint8_t>& vec, const T& address) const {
-    const uint8_t* byte_array = reinterpret_cast<const uint8_t*>(&address);
-    vec.insert(vec.end(), byte_array, byte_array + sizeof(T));
-  }
-
-  void hashKey(std::vector<uint8_t>& key) const override {
-    // Source address is more specific than policy ID. If using an original
-    // source address, we do not need to also add the source security ID to the
-    // hash key. Note that since the identity is 3 bytes it will not collide
-    // with neither an IPv4 nor IPv6 address.
-    if (original_source_address_) {
-      const auto& ip = original_source_address_->ip();
-      uint16_t port = ip->port();
-      if (ip->version() == Network::Address::IpVersion::v4) {
-        uint32_t raw_address = ip->ipv4()->address();
-        addressIntoVector(key, raw_address);
-      } else if (ip->version() == Network::Address::IpVersion::v6) {
-        absl::uint128 raw_address = ip->ipv6()->address();
-        addressIntoVector(key, raw_address);
-      }
-      // Add source port to the hash key if defined
-      if (port != 0) {
-        ENVOY_LOG(trace, "hashKey port: {:x}", port);
-        key.emplace_back(uint8_t(port >> 8));
-        key.emplace_back(uint8_t(port));
-      }
-      ENVOY_LOG(trace, "hashKey after Cilium: {}, source: {}", Hex::encode(key),
-                original_source_address_->asString());
-    } else {
-      // Add the source identity to the hash key. This will separate upstream
-      // connection pools per security ID.
-      key.emplace_back(uint8_t(identity_ >> 16));
-      key.emplace_back(uint8_t(identity_ >> 8));
-      key.emplace_back(uint8_t(identity_));
-    }
-  }
+  void hashKey([[maybe_unused]] std::vector<uint8_t>& key) const override {}
 
   bool isSupported() const override { return true; }
 
   uint32_t identity_;
-  Network::Address::InstanceConstSharedPtr original_source_address_;
-  // Version specific source addresses are only used if original source address is not used.
-  // Selection is made based on the socket domain, which is selected based on the destination
-  // address. This makes sure we don't try to bind IPv4 or IPv6 source address to a socket
-  // connecting to IPv6 or IPv4 address, respectively.
-  Network::Address::InstanceConstSharedPtr ipv4_source_address_;
-  Network::Address::InstanceConstSharedPtr ipv6_source_address_;
 };
 
 class SocketOption : public SocketMarkOption {
 public:
   SocketOption(uint32_t ingress_source_identity, uint32_t source_identity, bool ingress, bool l7lb,
                uint16_t port, std::string&& pod_ip,
-               Network::Address::InstanceConstSharedPtr original_source_address,
-               Network::Address::InstanceConstSharedPtr ipv4_source_address,
-               Network::Address::InstanceConstSharedPtr ipv6_source_address,
                const std::weak_ptr<PolicyResolver>& policy_resolver, uint32_t proxy_id,
                absl::string_view sni)
-      : SocketMarkOption(source_identity, original_source_address, ipv4_source_address,
-                         ipv6_source_address),
-        ingress_source_identity_(ingress_source_identity), ingress_(ingress), is_l7lb_(l7lb),
-        port_(port), pod_ip_(std::move(pod_ip)), proxy_id_(proxy_id), sni_(sni),
-        policy_resolver_(policy_resolver) {
-    ENVOY_LOG(
-        debug,
-        "Cilium SocketOption(): source_identity: {}, "
-        "ingress: {}, port: {}, pod_ip: {}, source_addresses: {}/{}/{}, proxy_id: {}, sni: \"{}\"",
-        identity_, ingress_, port_, pod_ip_,
-        original_source_address_ ? original_source_address_->asString() : "",
-        ipv4_source_address_ ? ipv4_source_address_->asString() : "",
-        ipv6_source_address_ ? ipv6_source_address_->asString() : "", proxy_id_, sni_);
+      : SocketMarkOption(source_identity), ingress_source_identity_(ingress_source_identity),
+        ingress_(ingress), is_l7lb_(l7lb), port_(port), pod_ip_(std::move(pod_ip)),
+        proxy_id_(proxy_id), sni_(sni), policy_resolver_(policy_resolver) {
+    ENVOY_LOG(debug,
+              "Cilium SocketOption(): source_identity: {}, "
+              "ingress: {}, port: {}, pod_ip: {}, proxy_id: {}, sni: \"{}\"",
+              identity_, ingress_, port_, pod_ip_, proxy_id_, sni_);
   }
 
   uint32_t resolvePolicyId(const Network::Address::Ip* ip) const {

--- a/cilium/socket_option_cilium_mark.h
+++ b/cilium/socket_option_cilium_mark.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <asm-generic/socket.h>
+#include <netinet/in.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <vector>
+
+#include "envoy/config/core/v3/socket_option.pb.h"
+#include "envoy/network/socket.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/common/utility.h"
+
+#include "absl/types/optional.h"
+#include "cilium/privileged_service_client.h"
+
+namespace Envoy {
+namespace Cilium {
+
+// Socket Option that sets the socket option SO_MARK on the socket.
+// The mark contains the Cilium magic mark, cluster and security identity.
+// It uses the Cilium Privileged Service to call out to the starter process to do the actual
+// privileged syscall - as the Envoy process itself doesn't have the required capabilities.
+class CiliumMarkSocketOption : public Network::Socket::Option,
+                               public Logger::Loggable<Logger::Id::filter> {
+public:
+  CiliumMarkSocketOption(uint32_t mark) : mark_(mark) {
+    ENVOY_LOG(debug,
+              "Cilium CiliumMarkSocketOption(): mark: {:x} (magic mark: {:x}, cluster: {}, ID: {})",
+              mark_, mark & 0xff00, mark & 0xff, mark >> 16);
+  }
+
+  absl::optional<Network::Socket::Option::Details>
+  getOptionDetails(const Network::Socket&,
+                   envoy::config::core::v3::SocketOption::SocketState) const override {
+    return absl::nullopt;
+  }
+
+  bool setOption(Network::Socket& socket,
+                 envoy::config::core::v3::SocketOption::SocketState state) const override {
+    // Only set the option once per socket
+    if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
+      ENVOY_LOG(trace, "Skipping setting socket ({}) option SO_MARK, state != STATE_PREBIND",
+                socket.ioHandle().fdDoNotUse());
+      return true;
+    }
+
+    auto& cilium_calls = PrivilegedService::Singleton::get();
+    auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_SOCKET, SO_MARK,
+                                          &mark_, sizeof(mark_));
+    if (status.return_value_ < 0) {
+      if (status.errno_ == EPERM) {
+        // Do not assert out in this case so that we can run tests without
+        // CAP_NET_ADMIN.
+        ENVOY_LOG(critical,
+                  "Failed to set socket option SO_MARK to {}, capability "
+                  "CAP_NET_ADMIN needed: {}",
+                  mark_, Envoy::errorDetails(status.errno_));
+      } else {
+        ENVOY_LOG(critical, "Socket option failure. Failed to set SO_MARK to {}: {}", mark_,
+                  Envoy::errorDetails(status.errno_));
+        return false;
+      }
+    }
+
+    ENVOY_LOG(trace,
+              "Set socket ({}) option SO_MARK to {:x} (magic mark: {:x}, id: "
+              "{}, cluster: {})",
+              socket.ioHandle().fdDoNotUse(), mark_, mark_ & 0xff00, mark_ >> 16, mark_ & 0xff);
+
+    return true;
+  }
+
+  void hashKey([[maybe_unused]] std::vector<uint8_t>& key) const override {}
+
+  bool isSupported() const override { return true; }
+
+  uint32_t mark_;
+};
+
+} // namespace Cilium
+} // namespace Envoy

--- a/cilium/socket_option_ip_transparent.h
+++ b/cilium/socket_option_ip_transparent.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <asm-generic/socket.h>
+#include <netinet/in.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <vector>
+
+#include "envoy/config/core/v3/socket_option.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/network/socket.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/common/utility.h"
+
+#include "absl/types/optional.h"
+#include "cilium/privileged_service_client.h"
+
+namespace Envoy {
+namespace Cilium {
+
+// Socket Option that sets the socket option IP_TRANSPARENT (IPV6_TRANSPARENT) on the socket.
+// It uses the Cilium Privileged Service to call out to the starter process to do the actual
+// privileged syscall - as the Envoy process itself doesn't have the required capabilities.
+class IpTransparentSocketOption : public Network::Socket::Option,
+                                  public Logger::Loggable<Logger::Id::filter> {
+public:
+  IpTransparentSocketOption() { ENVOY_LOG(debug, "Cilium IpTransparentSocketOption()"); }
+
+  absl::optional<Network::Socket::Option::Details>
+  getOptionDetails(const Network::Socket&,
+                   envoy::config::core::v3::SocketOption::SocketState) const override {
+    return absl::nullopt;
+  }
+
+  bool setOption(Network::Socket& socket,
+                 envoy::config::core::v3::SocketOption::SocketState state) const override {
+    // Only set the option once per socket
+    if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
+      ENVOY_LOG(trace, "Skipping setting socket ({}) option IP_TRANSPARENT, state != STATE_PREBIND",
+                socket.ioHandle().fdDoNotUse());
+      return true;
+    }
+
+    auto& cilium_calls = PrivilegedService::Singleton::get();
+
+    auto ipVersion = socket.ipVersion();
+    if (!ipVersion.has_value()) {
+      ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
+      return false;
+    }
+
+    uint32_t one = 1;
+
+    // Set ip transparent option based on the socket address family
+    auto ip_socket_level = SOL_IP;
+    auto ip_transparent_socket_option = IP_TRANSPARENT;
+    auto ip_transparent_socket_option_name = "IP_TRANSPARENT";
+    if (*ipVersion == Network::Address::IpVersion::v6) {
+      ip_socket_level = SOL_IPV6;
+      ip_transparent_socket_option = IPV6_TRANSPARENT;
+      ip_transparent_socket_option_name = "IPV6_TRANSPARENT";
+    }
+
+    auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), ip_socket_level,
+                                          ip_transparent_socket_option, &one, sizeof(one));
+    if (status.return_value_ < 0) {
+      if (status.errno_ == EPERM) {
+        // Do not assert out in this case so that we can run tests without
+        // CAP_NET_ADMIN.
+        ENVOY_LOG(critical,
+                  "Failed to set socket option {}, capability "
+                  "CAP_NET_ADMIN needed: {}",
+                  ip_transparent_socket_option_name, Envoy::errorDetails(status.errno_));
+      } else {
+        ENVOY_LOG(critical, "Socket option failure. Failed to set {}: {}",
+                  ip_transparent_socket_option_name, Envoy::errorDetails(status.errno_));
+        return false;
+      }
+    }
+
+    ENVOY_LOG(trace, "Successfully set socket option {} on socket: {}",
+              ip_transparent_socket_option_name, socket.ioHandle().fdDoNotUse());
+
+    return true;
+  }
+
+  void hashKey([[maybe_unused]] std::vector<uint8_t>& key) const override {}
+
+  bool isSupported() const override { return true; }
+};
+
+} // namespace Cilium
+} // namespace Envoy

--- a/cilium/socket_option_source_address.h
+++ b/cilium/socket_option_source_address.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <asm-generic/socket.h>
+#include <netinet/in.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/config/core/v3/socket_option.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/network/socket.h"
+
+#include "source/common/common/hex.h"
+#include "source/common/common/logger.h"
+
+#include "absl/numeric/int128.h"
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Cilium {
+
+// Socket Option that restores the local address of the socket with the relevant
+// source address which is either the original source address or a configured
+// source address (used for Ingress - N/S load balancing).
+// In addition its hashKey implementation is also responsible to introduct Envoy
+// to separate upstream connection pools per source address or source security ID.
+class SourceAddressSocketOption : public Network::Socket::Option,
+                                  public Logger::Loggable<Logger::Id::filter> {
+public:
+  SourceAddressSocketOption(
+      uint32_t source_identity,
+      Network::Address::InstanceConstSharedPtr original_source_address = nullptr,
+      Network::Address::InstanceConstSharedPtr ipv4_source_address = nullptr,
+      Network::Address::InstanceConstSharedPtr ipv6_source_address = nullptr)
+      : source_identity_(source_identity),
+        original_source_address_(std::move(original_source_address)),
+        ipv4_source_address_(std::move(ipv4_source_address)),
+        ipv6_source_address_(std::move(ipv6_source_address)) {
+    ENVOY_LOG(debug,
+              "Cilium SourceAddressSocketOption(): source_identity: {}, source_addresses: {}/{}/{}",
+              source_identity, original_source_address_ ? original_source_address_->asString() : "",
+              ipv4_source_address_ ? ipv4_source_address_->asString() : "",
+              ipv6_source_address_ ? ipv6_source_address_->asString() : "");
+  }
+
+  absl::optional<Network::Socket::Option::Details>
+  getOptionDetails(const Network::Socket&,
+                   envoy::config::core::v3::SocketOption::SocketState) const override {
+    return absl::nullopt;
+  }
+
+  bool setOption(Network::Socket& socket,
+                 envoy::config::core::v3::SocketOption::SocketState state) const override {
+    // Only set the option once per socket
+    if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
+      ENVOY_LOG(trace, "Skipping setting socket ({}) source address, state != STATE_PREBIND",
+                socket.ioHandle().fdDoNotUse());
+      return true;
+    }
+
+    auto ipVersion = socket.ipVersion();
+    if (!ipVersion.has_value()) {
+      ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
+      return false;
+    }
+
+    Network::Address::InstanceConstSharedPtr source_address = original_source_address_;
+    if (!source_address && (ipv4_source_address_ || ipv6_source_address_)) {
+      // Select source address based on the socket address family
+      source_address = ipv6_source_address_;
+      if (*ipVersion == Network::Address::IpVersion::v4) {
+        source_address = ipv4_source_address_;
+      }
+    }
+
+    if (!source_address) {
+      ENVOY_LOG(trace, "Skipping restore of local address on socket: {} - no source address",
+                socket.ioHandle().fdDoNotUse());
+      return true;
+    }
+
+    // Note: we don't expect this to change the behaviour of the socket. We expect it to be copied
+    // into the upstream connection later.
+    socket.connectionInfoProvider().setLocalAddress(std::move(source_address));
+    ENVOY_LOG(trace, "Successfully restored local address on socket: {}",
+              socket.ioHandle().fdDoNotUse());
+
+    return true;
+  }
+
+  template <typename T> void addressIntoVector(std::vector<uint8_t>& vec, const T& address) const {
+    const uint8_t* byte_array = reinterpret_cast<const uint8_t*>(&address);
+    vec.insert(vec.end(), byte_array, byte_array + sizeof(T));
+  }
+
+  void hashKey(std::vector<uint8_t>& key) const override {
+    // Source address is more specific than policy ID. If using an original
+    // source address, we do not need to also add the source security ID to the
+    // hash key. Note that since the identity is 3 bytes it will not collide
+    // with neither an IPv4 nor IPv6 address.
+    if (original_source_address_) {
+      const auto& ip = original_source_address_->ip();
+      uint16_t port = ip->port();
+      if (ip->version() == Network::Address::IpVersion::v4) {
+        uint32_t raw_address = ip->ipv4()->address();
+        addressIntoVector(key, raw_address);
+      } else if (ip->version() == Network::Address::IpVersion::v6) {
+        absl::uint128 raw_address = ip->ipv6()->address();
+        addressIntoVector(key, raw_address);
+      }
+      // Add source port to the hash key if defined
+      if (port != 0) {
+        ENVOY_LOG(trace, "hashKey port: {:x}", port);
+        key.emplace_back(uint8_t(port >> 8));
+        key.emplace_back(uint8_t(port));
+      }
+      ENVOY_LOG(trace,
+                "hashKey after with original source address: {}, original_source_address: {}",
+                Hex::encode(key), original_source_address_->asString());
+    } else {
+      // Add the source identity to the hash key. This will separate upstream
+      // connection pools per security ID.
+      key.emplace_back(uint8_t(source_identity_ >> 16));
+      key.emplace_back(uint8_t(source_identity_ >> 8));
+      key.emplace_back(uint8_t(source_identity_));
+      ENVOY_LOG(trace, "hashKey with source identity: {}, source_identity: {}", Hex::encode(key),
+                source_identity_);
+    }
+  }
+
+  bool isSupported() const override { return true; }
+
+  uint32_t source_identity_;
+
+  Network::Address::InstanceConstSharedPtr original_source_address_;
+  // Version specific source addresses are only used if original source address is not used.
+  // Selection is made based on the socket domain, which is selected based on the destination
+  // address. This makes sure we don't try to bind IPv4 or IPv6 source address to a socket
+  // connecting to IPv6 or IPv4 address, respectively.
+  Network::Address::InstanceConstSharedPtr ipv4_source_address_;
+  Network::Address::InstanceConstSharedPtr ipv6_source_address_;
+};
+
+} // namespace Cilium
+} // namespace Envoy

--- a/tests/bpf_metadata.h
+++ b/tests/bpf_metadata.h
@@ -40,6 +40,10 @@ public:
 
   absl::optional<Cilium::BpfMetadata::SocketMetadata>
   extractSocketMetadata(Network::ConnectionSocket& socket) override;
+
+  // Prevent socket options that require NET_ADMIN privileges from being applied during test
+  // execution.
+  bool addPrivilegedSocketOptions() override { return false; };
 };
 
 } // namespace BpfMetadata

--- a/tests/bpf_metadata.h
+++ b/tests/bpf_metadata.h
@@ -9,10 +9,10 @@
 #include "envoy/network/listen_socket.h"
 #include "envoy/server/factory_context.h"
 
+#include "absl/types/optional.h"
 #include "cilium/bpf_metadata.h"
 #include "cilium/host_map.h"
 #include "cilium/network_policy.h"
-#include "cilium/socket_option.h"
 #include "tests/bpf_metadata.pb.h"
 
 namespace Envoy {
@@ -38,7 +38,8 @@ public:
              Server::Configuration::ListenerFactoryContext& context);
   ~TestConfig();
 
-  Cilium::SocketOptionSharedPtr getMetadata(Network::ConnectionSocket& socket) override;
+  absl::optional<Cilium::BpfMetadata::SocketMetadata>
+  extractSocketMetadata(Network::ConnectionSocket& socket) override;
 };
 
 } // namespace BpfMetadata

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -288,12 +288,16 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbMetadata) {
   EXPECT_EQ(8, option->identity_);
   EXPECT_EQ(false, option->ingress_);
   EXPECT_EQ(true, option->is_l7lb_);
-  EXPECT_EQ(nullptr, option->original_source_address_);
-  EXPECT_EQ("10.1.1.42:0", option->ipv4_source_address_->asString());
-  EXPECT_EQ("[face::42]:0", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
   EXPECT_EQ(0, option->ingress_source_identity_);
+
+  auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption();
+  EXPECT_NE(nullptr, source_addresses_socket_option);
+
+  EXPECT_EQ(nullptr, source_addresses_socket_option->original_source_address_);
+  EXPECT_EQ("10.1.1.42:0", source_addresses_socket_option->ipv4_source_address_->asString());
+  EXPECT_EQ("[face::42]:0", source_addresses_socket_option->ipv6_source_address_->asString());
 
   auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
   EXPECT_NE(nullptr, cilium_mark_socket_option);
@@ -324,12 +328,16 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedMetadata) {
   EXPECT_EQ(8, option->identity_);
   EXPECT_EQ(false, option->ingress_);
   EXPECT_EQ(true, option->is_l7lb_);
-  EXPECT_EQ(nullptr, option->original_source_address_);
-  EXPECT_EQ("10.1.1.42:0", option->ipv4_source_address_->asString());
-  EXPECT_EQ("[face::42]:0", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
   EXPECT_EQ(12345678, option->ingress_source_identity_);
+
+  auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption();
+  EXPECT_NE(nullptr, source_addresses_socket_option);
+
+  EXPECT_EQ(nullptr, source_addresses_socket_option->original_source_address_);
+  EXPECT_EQ("10.1.1.42:0", source_addresses_socket_option->ipv4_source_address_->asString());
+  EXPECT_EQ("[face::42]:0", source_addresses_socket_option->ipv6_source_address_->asString());
 
   auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
   EXPECT_NE(nullptr, cilium_mark_socket_option);
@@ -364,12 +372,16 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedCIDRMetadata) {
   EXPECT_EQ(8, option->identity_);
   EXPECT_EQ(false, option->ingress_);
   EXPECT_EQ(true, option->is_l7lb_);
-  EXPECT_EQ(nullptr, option->original_source_address_);
-  EXPECT_EQ("10.1.1.42:0", option->ipv4_source_address_->asString());
-  EXPECT_EQ("[face::42]:0", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
   EXPECT_EQ(2, option->ingress_source_identity_);
+
+  auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption();
+  EXPECT_NE(nullptr, source_addresses_socket_option);
+
+  EXPECT_EQ(nullptr, source_addresses_socket_option->original_source_address_);
+  EXPECT_EQ("10.1.1.42:0", source_addresses_socket_option->ipv4_source_address_->asString());
+  EXPECT_EQ("[face::42]:0", source_addresses_socket_option->ipv6_source_address_->asString());
 
   auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
   EXPECT_NE(nullptr, cilium_mark_socket_option);
@@ -421,11 +433,16 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadata) {
   EXPECT_EQ(111, option->identity_);
   EXPECT_EQ(false, option->ingress_);
   EXPECT_EQ(true, option->is_l7lb_);
-  EXPECT_EQ(nullptr, option->original_source_address_);
-  EXPECT_EQ("10.1.1.1:41234", option->ipv4_source_address_->asString());
-  EXPECT_EQ("[face::1:1:1]:41234", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.1", option->pod_ip_);
+
+  auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption();
+  EXPECT_NE(nullptr, source_addresses_socket_option);
+
+  EXPECT_EQ(nullptr, source_addresses_socket_option->original_source_address_);
+  EXPECT_EQ("10.1.1.1:41234", source_addresses_socket_option->ipv4_source_address_->asString());
+  EXPECT_EQ("[face::1:1:1]:41234",
+            source_addresses_socket_option->ipv6_source_address_->asString());
 
   auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
   EXPECT_NE(nullptr, cilium_mark_socket_option);
@@ -454,12 +471,16 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadataNoOriginalSource) {
   EXPECT_EQ(8, option->identity_);
   EXPECT_EQ(false, option->ingress_);
   EXPECT_EQ(true, option->is_l7lb_);
-  EXPECT_EQ(nullptr, option->original_source_address_);
-  EXPECT_EQ("10.1.1.42:0", option->ipv4_source_address_->asString());
-  EXPECT_EQ("[face::42]:0", option->ipv6_source_address_->asString());
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
   EXPECT_EQ(0, option->ingress_source_identity_);
+
+  auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption();
+  EXPECT_NE(nullptr, source_addresses_socket_option);
+
+  EXPECT_EQ(nullptr, source_addresses_socket_option->original_source_address_);
+  EXPECT_EQ("10.1.1.42:0", source_addresses_socket_option->ipv4_source_address_->asString());
+  EXPECT_EQ("[face::42]:0", source_addresses_socket_option->ipv6_source_address_->asString());
 
   auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
   EXPECT_NE(nullptr, cilium_mark_socket_option);

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -295,8 +295,12 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbMetadata) {
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
   EXPECT_EQ(0, option->ingress_source_identity_);
 
+  auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
+  EXPECT_NE(nullptr, cilium_mark_socket_option);
+
   // Check that Ingress security ID is used in the socket mark
-  EXPECT_TRUE((option->mark_ & 0xffff) == 0x0B00 && (option->mark_ >> 16) == 8);
+  EXPECT_TRUE((cilium_mark_socket_option->mark_ & 0xffff) == 0x0B00 &&
+              (cilium_mark_socket_option->mark_ >> 16) == 8);
 }
 
 TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedMetadata) {
@@ -327,8 +331,12 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedMetadata) {
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
   EXPECT_EQ(12345678, option->ingress_source_identity_);
 
+  auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
+  EXPECT_NE(nullptr, cilium_mark_socket_option);
+
   // Check that Ingress security ID is used in the socket mark
-  EXPECT_TRUE((option->mark_ & 0xffff) == 0x0B00 && (option->mark_ >> 16) == 8);
+  EXPECT_TRUE((cilium_mark_socket_option->mark_ & 0xffff) == 0x0B00 &&
+              (cilium_mark_socket_option->mark_ >> 16) == 8);
 
   // Expect policy accepts security ID 12345678 on ingress on port 80
   auto port_policy = option->getPolicy()->findPortPolicy(true, 80);
@@ -363,8 +371,12 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedCIDRMetadata) {
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
   EXPECT_EQ(2, option->ingress_source_identity_);
 
+  auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
+  EXPECT_NE(nullptr, cilium_mark_socket_option);
+
   // Check that Ingress security ID is used in the socket mark
-  EXPECT_TRUE((option->mark_ & 0xffff) == 0x0B00 && (option->mark_ >> 16) == 8);
+  EXPECT_TRUE((cilium_mark_socket_option->mark_ & 0xffff) == 0x0B00 &&
+              (cilium_mark_socket_option->mark_ >> 16) == 8);
 
   // Expect policy does not accept security ID 2 on ingress on port 80
   auto port_policy = option->getPolicy()->findPortPolicy(true, 80);
@@ -415,8 +427,12 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadata) {
   EXPECT_EQ(80, option->port_);
   EXPECT_EQ("10.1.1.1", option->pod_ip_);
 
+  auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
+  EXPECT_NE(nullptr, cilium_mark_socket_option);
+
   // Check that Endpoint's ID is used in the socket mark
-  EXPECT_TRUE((option->mark_ & 0xffff) == 0x0900 && (option->mark_ >> 16) == 2048);
+  EXPECT_TRUE((cilium_mark_socket_option->mark_ & 0xffff) == 0x0900 &&
+              (cilium_mark_socket_option->mark_ >> 16) == 2048);
 }
 
 // When original source is not configured to be used, east/west traffic takes the north/south path
@@ -445,8 +461,12 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadataNoOriginalSource) {
   EXPECT_EQ("10.1.1.42", option->pod_ip_);
   EXPECT_EQ(0, option->ingress_source_identity_);
 
+  auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
+  EXPECT_NE(nullptr, cilium_mark_socket_option);
+
   // Check that Ingress ID is used in the socket mark
-  EXPECT_TRUE((option->mark_ & 0xffff) == 0x0B00 && (option->mark_ >> 16) == 8);
+  EXPECT_TRUE((cilium_mark_socket_option->mark_ & 0xffff) == 0x0B00 &&
+              (cilium_mark_socket_option->mark_ >> 16) == 8);
 }
 
 } // namespace

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -278,9 +278,9 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbMetadata) {
 
   EXPECT_NO_THROW(initialize(config));
 
-  auto socket_option = config_->getMetadata(socket_);
-  EXPECT_NE(nullptr, socket_option);
-  socket_.addOption(socket_option);
+  auto socket_metadata = config_->extractSocketMetadata(socket_);
+  EXPECT_TRUE(socket_metadata);
+  socket_.addOption(socket_metadata->buildBpfMetadataSocketOption());
 
   const auto option = Cilium::GetSocketOption(socket_.options());
   EXPECT_NE(nullptr, option);
@@ -310,9 +310,9 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedMetadata) {
   config.set_enforce_policy_on_l7lb(true);
   EXPECT_NO_THROW(initialize(config));
 
-  auto socket_option = config_->getMetadata(socket_);
-  EXPECT_NE(nullptr, socket_option);
-  socket_.addOption(socket_option);
+  auto socket_metadata = config_->extractSocketMetadata(socket_);
+  EXPECT_TRUE(socket_metadata);
+  socket_.addOption(socket_metadata->buildBpfMetadataSocketOption());
 
   const auto option = Cilium::GetSocketOption(socket_.options());
   EXPECT_NE(nullptr, option);
@@ -346,9 +346,9 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedCIDRMetadata) {
   config.set_enforce_policy_on_l7lb(true);
   EXPECT_NO_THROW(initialize(config));
 
-  auto socket_option = config_->getMetadata(socket_);
-  EXPECT_NE(nullptr, socket_option);
-  socket_.addOption(socket_option);
+  auto socket_metadata = config_->extractSocketMetadata(socket_);
+  EXPECT_TRUE(socket_metadata);
+  socket_.addOption(socket_metadata->buildBpfMetadataSocketOption());
 
   const auto option = Cilium::GetSocketOption(socket_.options());
   EXPECT_NE(nullptr, option);
@@ -383,8 +383,8 @@ TEST_F(MetadataConfigTest, ExternalUseOriginalSourceL7LbMetadata) {
 
   EXPECT_NO_THROW(initialize(config));
 
-  auto socket_option = config_->getMetadata(socket_);
-  EXPECT_EQ(nullptr, socket_option);
+  auto socket_metadata = config_->extractSocketMetadata(socket_);
+  EXPECT_FALSE(socket_metadata);
 
   const auto option = Cilium::GetSocketOption(socket_.options());
   EXPECT_EQ(nullptr, option);
@@ -399,9 +399,9 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadata) {
 
   EXPECT_NO_THROW(initialize(config));
 
-  auto socket_option = config_->getMetadata(socket_);
-  EXPECT_NE(nullptr, socket_option);
-  socket_.addOption(socket_option);
+  auto socket_metadata = config_->extractSocketMetadata(socket_);
+  EXPECT_TRUE(socket_metadata);
+  socket_.addOption(socket_metadata->buildBpfMetadataSocketOption());
 
   const auto option = Cilium::GetSocketOption(socket_.options());
   EXPECT_NE(nullptr, option);
@@ -428,9 +428,9 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadataNoOriginalSource) {
 
   EXPECT_NO_THROW(initialize(config));
 
-  auto socket_option = config_->getMetadata(socket_);
-  EXPECT_NE(nullptr, socket_option);
-  socket_.addOption(socket_option);
+  auto socket_metadata = config_->extractSocketMetadata(socket_);
+  EXPECT_TRUE(socket_metadata);
+  socket_.addOption(socket_metadata->buildBpfMetadataSocketOption());
 
   const auto option = Cilium::GetSocketOption(socket_.options());
   EXPECT_NE(nullptr, option);


### PR DESCRIPTION
This PR split the existing 2 socket options (SocketMarkOption & SocketOption (inherits from the first one)) into more fine-grain and cohesive socket options. In addition, upstream Envoy socket options are used where possible.

Please see the individual commits for details.

This split has the following advantages:

* Separate configuration of the individual socket options for listener- and connection sockets (instead of doing an in-socket-option decision based on the security id (0 = listener socket))
* Scope and responsibility of the socket options is clear and easier to understand (currently the all-in-one socket option is responsible to pass information to filters (via filter state), pass information to Cilium network- and http filters (via Envoy socket option functionality), configure the upstream connection pool separation, setting actual options on the socket, restoring the socket's local address)
* Remove the additional complexity due to the inheritance of the socket options
* Proper names for the socket options (as the global one added more and more functionality that we're no longer aligned with the name)

**Note: A follow up PR will convert the `CiliumPolicySocketOption` into a Envoy filter state object. https://github.com/cilium/proxy/pull/1116**