### PR TITLE
build: support clang tidy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,3 +30,6 @@ build:release --define manual_stamp=manual_stamp
 # Always have LD_LIBRARY_PATH=/usr/cross-compat/lib defined in the test environment.
 # The path does not need to exist, but can be created when needed for running tests.
 build --test_env=LD_LIBRARY_PATH=/usr/cilium-cross-compat/lib
+
+# use same env option for query as upstream is using for build
+query --incompatible_merge_fixed_and_default_shell_env

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,120 @@
+Checks: >
+  -clang-analyzer-core.NonNullParamChecker,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  abseil-duration-*,
+  abseil-faster-strsplit-delimiter,
+  abseil-no-namespace,
+  abseil-redundant-strcat-calls,
+  abseil-str-cat-append,
+  abseil-string-find-startswith,
+  abseil-upgrade-duration-conversions,
+  bugprone-assert-side-effect,
+  bugprone-unused-raii,
+  bugprone-use-after-move,
+  clang-analyzer-core.DivideZero,
+  misc-unused-using-decls,
+  modernize-deprecated-headers,
+  modernize-loop-convert,
+  modernize-make-shared,
+  modernize-make-unique,
+  modernize-return-braced-init-list,
+  modernize-use-default-member-init,
+  modernize-use-equals-default,
+  modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-using,
+  performance-faster-string-find,
+  performance-for-range-copy,
+  performance-inefficient-algorithm,
+  performance-inefficient-vector-operation,
+  performance-noexcept-move-constructor,
+  performance-move-constructor-init,
+  performance-type-promotion-in-math-fn,
+  performance-unnecessary-copy-initialization,
+  readability-braces-around-statements,
+  readability-container-size-empty,
+  readability-identifier-naming,
+  readability-redundant-control-flow,
+  readability-redundant-member-init,
+  readability-redundant-smartptr-get,
+  readability-redundant-string-cstr
+
+CheckOptions:
+- key: cppcoreguidelines-unused-variable.IgnorePattern
+  value: "^_$"
+- key: bugprone-assert-side-effect.AssertMacros
+  value: 'ASSERT'
+- key: bugprone-dangling-handle.HandleClasses
+  value: 'std::basic_string_view;std::experimental::basic_string_view;absl::string_view'
+- key: misc-include-cleaner.IgnoreHeaders
+  value: 'fmt/format\.h;fmt/compile\.h;asm-generic/socket\.h;asm/unistd_32\.h;asm/unistd_64\.h;bits/.*;google/protobuf/.*;linux/in\.h;linux/in6\.h;mutex'
+- key: modernize-use-auto.MinTypeNameLength
+  value: '10'
+- key: readability-identifier-naming.ClassCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.EnumCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.EnumConstantCase
+  value: 'CamelCase'
+# Ignore GoogleTest function macros.
+- key: readability-identifier-naming.FunctionIgnoredRegexp
+  # To have the regex chomped correctly fence all items with `|` (other than first/last)
+  value: >-
+    (^AbslHashValue$|
+    |^called_count$|
+    |^case_sensitive$|
+    |^Create$|
+    |^envoy_resolve_dns$|
+    |^evconnlistener_free$|
+    |^event_base_free$|
+    |^(get|set)EVP_PKEY$|
+    |^has_value$|
+    |^Ip6(ntohl|htonl)$|
+    |^get_$|
+    |^HeaderHasValue(Ref)?$|
+    |^HeaderValueOf$|
+    |^Is(Superset|Subset)OfHeaders$|
+    |^LLVMFuzzerInitialize$|
+    |^LLVMFuzzerTestOneInput$|
+    |^Locality$|
+    |^MOCK_METHOD$|
+    |^PrepareCall$|
+    |^PrintTo$|
+    |^resolve_dns$|
+    |^result_type$|
+    |Returns(Default)?WorkerId$|
+    |^sched_getaffinity$|
+    |^shutdownThread_$|
+    |^envoy_dynamic_module(.*)$|
+    |TEST|
+    |^use_count$)
+- key: readability-identifier-naming.ParameterCase
+  value: 'lower_case'
+- key: readability-identifier-naming.ParameterIgnoredRegexp
+  value: (^cname_ttl_$)
+- key: readability-identifier-naming.PrivateMemberCase
+  value: 'lower_case'
+- key: readability-identifier-naming.PrivateMemberSuffix
+  value: '_'
+- key: readability-identifier-naming.StructCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.TypeAliasCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.TypeAliasIgnoredRegexp
+  value: '(result_type)'
+- key: readability-identifier-naming.UnionCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.FunctionCase
+  value: 'camelBack'
+
+HeaderFilterRegex: '^./source/.*|^./contrib/.*|^./test/.*|^./envoy/.*'
+
+UseColor: true
+
+WarningsAsErrors: '*'
+
+## The version here is arbitrary since any change to this file will
+## trigger a full run of clang-tidy against all files.
+## It can be useful as it seems some header changes may not trigger the
+## expected rerun.
+# v0

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -106,6 +106,8 @@ CheckOptions:
   value: 'CamelCase'
 - key: readability-identifier-naming.FunctionCase
   value: 'camelBack'
+- key: readability-identifier-naming.LocalVariableCase
+  value: 'lower_case'
 
 HeaderFilterRegex: '^./source/.*|^./contrib/.*|^./test/.*|^./envoy/.*'
 

--- a/.clangd
+++ b/.clangd
@@ -6,12 +6,15 @@ Diagnostics:
   MissingIncludes: Strict
   Includes:
     IgnoreHeader:
-      - "asm/unistd_32.h" # private -> use unistd.h
-      - "asm/unistd_64.h" # private -> use unistd.h
-      - "bits/basic_string\\.h" # private -> use string
+      - "fmt/format\.h" # Do not remove or add this
+      - "fmt/compile\.h" # private -> use fmt/format.h
+      - "asm-generic/socket\.h" # private -> use sys/socket.h
+      - "asm/unistd_32\.h" # private -> use unistd.h
+      - "asm/unistd_64\.h" # private -> use unistd.h
+      - "bits/.*" # private -> use standard headers like <string>, etc.
       - "google/protobuf/.*" # checked by envoy linting -> use source/common/protobuf/protobuf.h
-      - "linux/in\\.h" # private -> use netinet/in.h
-      - "linux/in6\\.h" # private -> use netinet/in.h
+      - "linux/in\.h" # private -> use netinet/in.h
+      - "linux/in6\.h" # private -> use netinet/in.h
       - "mutex" # checked by envoy linting -> use source/common/common/thread.h
 # CompileFlags:
 #   CompilationDatabase: ./compile_commands.json

--- a/.github/workflows/ci-clang-tidy.yaml
+++ b/.github/workflows/ci-clang-tidy.yaml
@@ -1,0 +1,69 @@
+name: CI clang-tidy
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# By specifying the access of one of the scopes, all of those that are not specified are set to 'none'.
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
+jobs:
+  tidy:
+    timeout-minutes: 60
+    name: Lint source style
+    runs-on: ubuntu-latest-64-cores-256gb
+    steps:
+      - name: Checkout PR Source Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 2
+
+      - name: Prep for build
+        run: |
+          echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
+          echo "ENVOY_VERSION=$(cat ENVOY_VERSION)" >> $GITHUB_ENV
+          echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
+          # git diff filter has everything else than deleted files (those need not be tidied)
+          echo "TIDY_SOURCES=$(git diff --name-only --diff-filter=ACMRTUXB main | grep -E '(.h$|.cc$)' | tr '\n' ' ')" >> $GITHUB_ENV
+
+      - name: Wait for cilium-envoy-builder to be available
+        timeout-minutes: 45
+        shell: bash
+        run: until docker manifest inspect quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }} &> /dev/null; do sleep 15s; done
+
+      - name: Run clang-tidy
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        id: docker_clang_tidy
+        with:
+          target: clang-tidy
+          provenance: false
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          outputs: type=local,dest=clang-tidy-results
+          build-args: |
+            BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
+          cache-from: type=local,src=/tmp/buildx-cache
+          push: false
+
+      - name: Check for failure
+        run: |
+          if grep -q "^make:.*Error" clang-tidy-results/clang-tidy-output.txt; then
+            git diff > clang-tidy-results/clang-tidy.diff
+            exit 1
+          fi
+
+      - name: Upload clang-tidy results
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: clang-tidy-results
+          path: clang-tidy-results/
+          retention-days: 5

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !\.bazelversion
 !\.clangd
 !\.clang-format
+!\.clang-tidy
 !\.github
 !\.gitignore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ ENV TARGETARCH=$TARGETARCH
 #
 # Check format
 #
-RUN BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS}" PKG_BUILD=1 V=$V DEBUG=$DEBUG make V=1 check > format-output.txt
+RUN BAZEL_BUILD_OPTS="${BAZEL_BUILD_OPTS}" PKG_BUILD=1 V=$V DEBUG=$DEBUG make V=1 format > format-output.txt
 
 FROM scratch AS format
 COPY --from=check-format /cilium/proxy/format-output.txt /

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -30,7 +30,7 @@ RUN apt-get update && \
     apt-add-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-      clang-17 clang-tools-17 llvm-17-dev lldb-17 lld-17 clang-format-17 libc++-17-dev libc++abi-17-dev && \
+      clang-17 clang-tidy-17 clang-tools-17 llvm-17-dev lldb-17 lld-17 clang-format-17 libc++-17-dev libc++abi-17-dev && \
     apt-get purge --auto-remove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ else
   # Install clang if needed
   define install_clang
 	$(SUDO) apt info clang-17 || $(call add_clang_apt_source,$(shell lsb_release -cs))
-	$(SUDO) apt install -y clang-17 llvm-17-dev lld-17 clang-format-17
+	$(SUDO) apt install -y clang-17 clangd-17 llvm-17-dev lld-17 lldb-17 clang-format-17 clang-tools-17 clang-tidy-17
   endef
 endif
 

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -66,10 +66,10 @@ tidy-fix: compile_commands.json force-non-root
 	echo "clang-tidy fix results can contain duplicate includes, check before committing!"
 	run-clang-tidy-17 -fix -format -style=file -quiet -extra-arg="-Wno-unknown-pragmas" -checks=misc-include-cleaner -j $(TIDY_JOBS) $(TIDY_SOURCES)
 
-check: force-non-root
+format: force-non-root
 	$(BAZEL) $(BAZEL_OPTS) run $(BAZEL_BUILD_OPTS) @envoy//tools/code_format:check_format -- --path "$(PWD)" --skip_envoy_build_rule_check --add-excluded-prefixes $(FORMAT_EXCLUDED_PREFIXES) --bazel_tools_check_excluded_paths="./" --build_fixer_check_excluded_paths="./" check || echo "Format check failed, run 'make fix' locally to fix formatting errors."
 
-fix: force-non-root
+format-fix: force-non-root
 	$(BAZEL) $(BAZEL_OPTS) run $(BAZEL_BUILD_OPTS) @envoy//tools/code_format:check_format -- --path "$(PWD)" --skip_envoy_build_rule_check --add-excluded-prefixes $(FORMAT_EXCLUDED_PREFIXES) --bazel_tools_check_excluded_paths="." --build_fixer_check_excluded_paths="./" fix
 
 # Run tests without debug by default.

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -44,11 +44,33 @@ precheck: force-non-root
 
 FORMAT_EXCLUDED_PREFIXES = "./linux/" "./proxylib/" "./starter/"  "./vendor/" "./go/" "./envoy_build_config/"
 
+# The default set of sources assumes all relevant sources are dependecies of some tests!
+TIDY_SOURCES ?= $(shell bazel query 'kind("source file", deps(//tests/...))' 2>/dev/null | sed -n "s/\/\/cilium:/cilium\//p; s/\/\/tests:/tests\//p")
+
+# Must pass our bazel options to avoid discarding the analysis cache due to different options
+# between this, check and build!
+# Depend on the WORKSPACE and TIDY_SOURCES so that the database will be re-built if
+# Envoy dependency or any of the source files has changed.
+compile_commands.json: WORKSPACE $(TIDY_SOURCES) force-non-root
+	BAZEL_STARTUP_OPTION_LIST="$(BAZEL_OPTS)" BAZEL_BUILD_OPTION_LIST="$(BAZEL_BUILD_OPTS)" tools/gen_compilation_database.py --include_all //cilium/... //starter/... //tests/... @com_google_absl//absl/...
+
+# Default number of jobs, derived from available memory
+TIDY_JOBS ?= $$(( $(shell sed -n "s/^MemAvailable: *\([0-9]*\).*\$$/\1/p" /proc/meminfo) / 4500000 ))
+
+# tidy uses clang-tidy-17, .clang-tidy must be present in the project directory and configured to
+# ignore the same headers as .clangd. Unfortunately the configuration format is different.
+tidy: compile_commands.json force-non-root
+	run-clang-tidy-17 -quiet -extra-arg="-Wno-unknown-pragmas" -checks=misc-include-cleaner -j $(TIDY_JOBS) $(TIDY_SOURCES)
+
+tidy-fix: compile_commands.json force-non-root
+	echo "clang-tidy fix results can contain duplicate includes, check before committing!"
+	run-clang-tidy-17 -fix -format -style=file -quiet -extra-arg="-Wno-unknown-pragmas" -checks=misc-include-cleaner -j $(TIDY_JOBS) $(TIDY_SOURCES)
+
 check: force-non-root
-	$(BAZEL) $(BAZEL_OPTS) run @envoy//tools/code_format:check_format -- --path "$(PWD)" --skip_envoy_build_rule_check --add-excluded-prefixes $(FORMAT_EXCLUDED_PREFIXES) --bazel_tools_check_excluded_paths="./" --build_fixer_check_excluded_paths="./" check || echo "Format check failed, run 'make fix' locally to fix formatting errors."
+	$(BAZEL) $(BAZEL_OPTS) run $(BAZEL_BUILD_OPTS) @envoy//tools/code_format:check_format -- --path "$(PWD)" --skip_envoy_build_rule_check --add-excluded-prefixes $(FORMAT_EXCLUDED_PREFIXES) --bazel_tools_check_excluded_paths="./" --build_fixer_check_excluded_paths="./" check || echo "Format check failed, run 'make fix' locally to fix formatting errors."
 
 fix: force-non-root
-	$(BAZEL) $(BAZEL_OPTS) run @envoy//tools/code_format:check_format -- --path "$(PWD)" --skip_envoy_build_rule_check --add-excluded-prefixes $(FORMAT_EXCLUDED_PREFIXES) --bazel_tools_check_excluded_paths="." --build_fixer_check_excluded_paths="./" fix
+	$(BAZEL) $(BAZEL_OPTS) run $(BAZEL_BUILD_OPTS) @envoy//tools/code_format:check_format -- --path "$(PWD)" --skip_envoy_build_rule_check --add-excluded-prefixes $(FORMAT_EXCLUDED_PREFIXES) --bazel_tools_check_excluded_paths="." --build_fixer_check_excluded_paths="./" fix
 
 # Run tests without debug by default.
 tests:  $(COMPILER_DEP) force-non-root SOURCE_VERSION proxylib/libcilium.so install-bazelisk

--- a/cilium/accesslog.cc
+++ b/cilium/accesslog.cc
@@ -1,10 +1,5 @@
 #include "accesslog.h"
 
-#include <stdlib.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
-
 #include <chrono>
 #include <cstdint>
 #include <map>
@@ -20,7 +15,6 @@
 #include "source/common/common/lock_guard.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 
 #include "absl/strings/numbers.h"

--- a/cilium/accesslog.cc
+++ b/cilium/accesslog.cc
@@ -57,15 +57,15 @@ AccessLog::~AccessLog() {
   logs.erase(path_);
 }
 
-void AccessLog::Log(AccessLog::Entry& entry__, ::cilium::EntryType entry_type) {
-  ::cilium::LogEntry& entry = entry__.entry_;
+void AccessLog::Log(AccessLog::Entry& log_entry, ::cilium::EntryType entry_type) {
+  ::cilium::LogEntry& entry = log_entry.entry_;
   entry.set_entry_type(entry_type);
 
   if (entry_type != ::cilium::EntryType::Response) {
-    if (entry__.request_logged_) {
+    if (log_entry.request_logged_) {
       ENVOY_LOG_MISC(warn, "cilium.AccessLog: Request is logged twice");
     }
-    entry__.request_logged_ = true;
+    log_entry.request_logged_ = true;
   }
 
   // encode protobuf

--- a/cilium/accesslog.h
+++ b/cilium/accesslog.h
@@ -26,38 +26,38 @@ constexpr absl::string_view AccessLogKey = "cilium.accesslog.entry";
 
 class AccessLog : public UDSClient {
 public:
-  static std::shared_ptr<AccessLog> Open(const std::string& path, TimeSource& time_source);
+  static std::shared_ptr<AccessLog> open(const std::string& path, TimeSource& time_source);
   ~AccessLog();
 
   // wrapper for protobuf
   class Entry : public StreamInfo::FilterState::Object {
   public:
-    void InitFromRequest(const std::string& policy_name, uint32_t proxy_id, bool ingress,
+    void initFromRequest(const std::string& policy_name, uint32_t proxy_id, bool ingress,
                          uint32_t source_identity,
                          const Network::Address::InstanceConstSharedPtr& source_address,
                          uint32_t destination_identity,
                          const Network::Address::InstanceConstSharedPtr& destination_address,
                          const StreamInfo::StreamInfo&, const Http::RequestHeaderMap&);
-    void UpdateFromRequest(uint32_t destination_identity,
+    void updateFromRequest(uint32_t destination_identity,
                            const Network::Address::InstanceConstSharedPtr& destination_address,
                            const Http::RequestHeaderMap&);
-    void UpdateFromResponse(const Http::ResponseHeaderMap&, TimeSource&);
+    void updateFromResponse(const Http::ResponseHeaderMap&, TimeSource&);
 
-    void InitFromConnection(const std::string& policy_name, uint32_t proxy_id, bool ingress,
+    void initFromConnection(const std::string& policy_name, uint32_t proxy_id, bool ingress,
                             uint32_t source_identity,
                             const Network::Address::InstanceConstSharedPtr& source_address,
                             uint32_t destination_identity,
                             const Network::Address::InstanceConstSharedPtr& destination_address,
                             TimeSource* time_source);
-    bool UpdateFromMetadata(const std::string& l7proto, const ProtobufWkt::Struct& metadata);
-    void AddRejected(absl::string_view key, absl::string_view value);
-    void AddMissing(absl::string_view key, absl::string_view value);
+    bool updateFromMetadata(const std::string& l7proto, const ProtobufWkt::Struct& metadata);
+    void addRejected(absl::string_view key, absl::string_view value);
+    void addMissing(absl::string_view key, absl::string_view value);
 
     ::cilium::LogEntry entry_{};
     bool request_logged_ = false;
   };
 
-  void Log(Entry& entry, ::cilium::EntryType);
+  void log(Entry& entry, ::cilium::EntryType);
 
 private:
   explicit AccessLog(const std::string& path, TimeSource& time_source)

--- a/cilium/accesslog.h
+++ b/cilium/accesslog.h
@@ -68,7 +68,7 @@ private:
 
   const std::string path_;
 };
-typedef std::shared_ptr<AccessLog> AccessLogSharedPtr;
+using AccessLogSharedPtr = std::shared_ptr<AccessLog>;
 
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/bpf.cc
+++ b/cilium/bpf.cc
@@ -1,8 +1,8 @@
 #include "cilium/bpf.h"
 
-#include <errno.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstdint>
 #include <fstream>
 #include <sstream>

--- a/cilium/bpf.cc
+++ b/cilium/bpf.cc
@@ -18,7 +18,7 @@ namespace Envoy {
 namespace Cilium {
 
 enum {
-  BPF_KEY_MAX_LEN = 64,
+  BpfKeyMaxLen = 64,
 };
 
 Bpf::Bpf(uint32_t map_type, uint32_t key_size, uint32_t min_value_size, uint32_t max_value_size)
@@ -32,9 +32,9 @@ Bpf::Bpf(uint32_t map_type, uint32_t key_size, uint32_t min_value_size, uint32_t
 Bpf::~Bpf() { close(); }
 
 void Bpf::close() {
-  if (fd_ >= 0)
+  if (fd_ >= 0) {
     ::close(fd_);
-
+  }
   fd_ = -1;
   real_value_size_ = 0;
 }
@@ -46,11 +46,12 @@ bool Bpf::open(const std::string& path) {
   close();
 
   // store the path for later
-  if (path != path_)
+  if (path != path_) {
     path_ = path;
+  }
 
   auto& cilium_calls = PrivilegedService::Singleton::get();
-  auto ret = cilium_calls.bpf_open(path.c_str());
+  auto ret = cilium_calls.bpfOpen(path.c_str());
   fd_ = ret.return_value_;
   if (fd_ >= 0) {
     // Open fdinfo to check the map type and key and value size.
@@ -126,12 +127,13 @@ bool Bpf::open(const std::string& path) {
 bool Bpf::lookup(const void* key, void* value) {
   // Try reopen if open failed previously
   if (fd_ < 0) {
-    if (!open(path_))
+    if (!open(path_)) {
       return false;
+    }
   }
 
   auto& cilium_calls = PrivilegedService::Singleton::get();
-  auto result = cilium_calls.bpf_lookup(fd_, key, key_size_, value, real_value_size_);
+  auto result = cilium_calls.bpfLookup(fd_, key, key_size_, value, real_value_size_);
 
   if (result.return_value_ == 0) {
     return true;

--- a/cilium/bpf.h
+++ b/cilium/bpf.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <unistd.h>
-
 #include <cstdint>
 #include <string>
 

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -1,10 +1,8 @@
 #include "cilium/bpf_metadata.h"
 
-#include <asm-generic/socket.h>
 #include <fmt/format.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <sys/socket.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -33,7 +31,7 @@
 #include "source/common/network/socket_option_factory.h"
 #include "source/common/network/socket_option_impl.h"
 #include "source/common/network/utility.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/utility.h"
 
 #include "absl/strings/string_view.h"

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -311,28 +311,28 @@ uint32_t Config::resolveSourceIdentity(const PolicyInstance& policy,
 IPAddressPair
 Config::getIPAddressPairFrom(const Network::Address::InstanceConstSharedPtr source_address,
                              const IPAddressPair& addresses) {
-  auto addressPair = IPAddressPair();
+  auto address_pair = IPAddressPair();
 
   switch (source_address->ip()->version()) {
   case Network::Address::IpVersion::v4:
-    addressPair.ipv4_ = source_address;
+    address_pair.ipv4_ = source_address;
     if (addresses.ipv6_) {
       sockaddr_in6 sa6 = *reinterpret_cast<const sockaddr_in6*>(addresses.ipv6_->sockAddr());
       sa6.sin6_port = htons(source_address->ip()->port());
-      addressPair.ipv6_ = std::make_shared<Network::Address::Ipv6Instance>(sa6);
+      address_pair.ipv6_ = std::make_shared<Network::Address::Ipv6Instance>(sa6);
     }
     break;
   case Network::Address::IpVersion::v6:
-    addressPair.ipv6_ = source_address;
+    address_pair.ipv6_ = source_address;
     if (addresses.ipv4_) {
       sockaddr_in sa4 = *reinterpret_cast<const sockaddr_in*>(addresses.ipv4_->sockAddr());
       sa4.sin_port = htons(source_address->ip()->port());
-      addressPair.ipv4_ = std::make_shared<Network::Address::Ipv4Instance>(&sa4);
+      address_pair.ipv4_ = std::make_shared<Network::Address::Ipv4Instance>(&sa4);
     }
     break;
   }
 
-  return addressPair;
+  return address_pair;
 }
 
 const Network::Address::Ip* Config::selectIPVersion(const Network::Address::IpVersion version,

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -171,7 +171,7 @@ private:
                                               const IPAddressPair& sourceAddresses);
 };
 
-typedef std::shared_ptr<Config> ConfigSharedPtr;
+using ConfigSharedPtr = std::shared_ptr<Config>;
 
 /**
  * Implementation of a bpf metadata listener filter.

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -72,6 +72,7 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
     if (!proxylib_l7_proto_.empty()) {
       const auto& old_protocols = socket.requestedApplicationProtocols();
       std::vector<absl::string_view> protocols;
+      protocols.reserve(old_protocols.size());
       for (const auto& old_protocol : old_protocols) {
         protocols.emplace_back(old_protocol);
       }
@@ -133,7 +134,7 @@ class Config : public Cilium::PolicyResolver,
 public:
   Config(const ::cilium::BpfMetadata& config,
          Server::Configuration::ListenerFactoryContext& context);
-  virtual ~Config() {}
+  ~Config() override = default;
 
   // PolicyResolver
   uint32_t resolvePolicyId(const Network::Address::Ip*) const override;
@@ -162,13 +163,13 @@ public:
 
 private:
   uint32_t resolveSourceIdentity(const PolicyInstance& policy, const Network::Address::Ip* sip,
-                                 const Network::Address::Ip* dip, bool ingress, bool isL7LB);
+                                 const Network::Address::Ip* dip, bool ingress, bool is_l7_lb);
 
-  IPAddressPair getIPAddressPairFrom(const Network::Address::InstanceConstSharedPtr sourceAddress,
+  IPAddressPair getIPAddressPairFrom(const Network::Address::InstanceConstSharedPtr source_address,
                                      const IPAddressPair& addresses);
 
   const Network::Address::Ip* selectIPVersion(const Network::Address::IpVersion version,
-                                              const IPAddressPair& sourceAddresses);
+                                              const IPAddressPair& source_addresses);
 };
 
 using ConfigSharedPtr = std::shared_ptr<Config>;

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -158,18 +158,18 @@ public:
 
   std::shared_ptr<const Cilium::NetworkPolicyMap> npmap_{};
   Cilium::CtMapSharedPtr ct_maps_{};
-  Cilium::IPCacheSharedPtr ipcache_{};
+  Cilium::IpCacheSharedPtr ipcache_{};
   std::shared_ptr<const Cilium::PolicyHostMap> hosts_{};
 
 private:
   uint32_t resolveSourceIdentity(const PolicyInstance& policy, const Network::Address::Ip* sip,
                                  const Network::Address::Ip* dip, bool ingress, bool is_l7_lb);
 
-  IPAddressPair getIPAddressPairFrom(const Network::Address::InstanceConstSharedPtr source_address,
-                                     const IPAddressPair& addresses);
+  IpAddressPair getIpAddressPairFrom(const Network::Address::InstanceConstSharedPtr source_address,
+                                     const IpAddressPair& addresses);
 
-  const Network::Address::Ip* selectIPVersion(const Network::Address::IpVersion version,
-                                              const IPAddressPair& source_addresses);
+  const Network::Address::Ip* selectIpVersion(const Network::Address::IpVersion version,
+                                              const IpAddressPair& source_addresses);
 };
 
 using ConfigSharedPtr = std::shared_ptr<Config>;

--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -58,7 +58,7 @@ PACKED_STRUCT(struct ipv4_ct_tuple {
   __u8 flags;
 });
 
-struct ct_entry {
+struct CtEntry {
   __u64 rx_packets;
   __u64 rx_bytes;
   __u64 tx_packets;
@@ -82,10 +82,10 @@ struct ct_entry {
 };
 
 CtMap::CtMap4::CtMap4()
-    : Bpf(BPF_MAP_TYPE_HASH, sizeof(struct ipv4_ct_tuple), sizeof(struct ct_entry)) {}
+    : Bpf(BPF_MAP_TYPE_HASH, sizeof(struct ipv4_ct_tuple), sizeof(struct CtEntry)) {}
 
 CtMap::CtMap6::CtMap6()
-    : Bpf(BPF_MAP_TYPE_HASH, sizeof(struct ipv6_ct_tuple), sizeof(struct ct_entry)) {}
+    : Bpf(BPF_MAP_TYPE_HASH, sizeof(struct ipv6_ct_tuple), sizeof(struct CtEntry)) {}
 
 CtMap::CtMaps4::CtMaps4(const std::string& bpf_root, const std::string& map_name) : ok_(false) {
   // Open the IPv4 bpf maps from Cilium specific paths
@@ -190,7 +190,7 @@ uint32_t CtMap::lookupSrcIdentity(const std::string& map_name, const Network::Ad
 
   struct ipv4_ct_tuple key4 {};
   struct ipv6_ct_tuple key6 {};
-  struct ct_entry value {};
+  struct CtEntry value {};
 
   if (sip->version() == Network::Address::IpVersion::v4 &&
       dip->version() == Network::Address::IpVersion::v4) {

--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -1,10 +1,10 @@
 #include "conntrack.h"
 
-#include <arpa/inet.h>
 #include <netinet/in.h>
-#include <string.h>
 
+#include <cerrno> // IWYU pragma: keep
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <utility>

--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -30,12 +30,12 @@ namespace Cilium {
 // them to a separate include file we can include here instead of
 // copying them!
 
-typedef uint64_t __u64;
-typedef uint32_t __be32; // Beware of the byte order!
-typedef uint32_t __u32;
-typedef uint16_t __be16; // Beware of the byte order!
-typedef uint16_t __u16;
-typedef uint8_t __u8;
+using __u64 = uint64_t;
+using __be32 = uint32_t; // Beware of the byte order!
+using __u32 = uint32_t;
+using __be16 = uint16_t; // Beware of the byte order!
+using __u16 = uint16_t;
+using __u8 = uint8_t;
 
 #define TUPLE_F_OUT 0
 #define TUPLE_F_IN 1

--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -12,8 +12,8 @@
 #include "envoy/common/platform.h"
 #include "envoy/network/address.h"
 
+#include "source/common/common/lock_guard.h"
 #include "source/common/common/logger.h"
-#include "source/common/common/thread.h"
 #include "source/common/common/utility.h"
 
 #include "absl/container/flat_hash_map.h"
@@ -160,7 +160,7 @@ CtMap::openMap6(const std::string& map_name) {
 }
 
 void CtMap::closeMaps(const absl::flat_hash_set<std::string>& to_be_closed) {
-  std::lock_guard<Thread::MutexBasicLockable> guard(maps_mutex_);
+  Thread::LockGuard guard(maps_mutex_);
 
   for (const auto& name : to_be_closed) {
     auto ct4 = ct_maps4_.find(name);
@@ -224,7 +224,7 @@ uint32_t CtMap::lookupSrcIdentity(const std::string& map_name, const Network::Ad
 
   if (dip->version() == Network::Address::IpVersion::v4) {
     // Lock for the duration of the map lookup and conntrack lookup
-    std::lock_guard<Thread::MutexBasicLockable> guard(maps_mutex_);
+    Thread::LockGuard guard(maps_mutex_);
     auto it = ct_maps4_.find(map_name);
     if (it == ct_maps4_.end()) {
       it = openMap4(map_name);
@@ -242,7 +242,7 @@ uint32_t CtMap::lookupSrcIdentity(const std::string& map_name, const Network::Ad
     }
   } else {
     // Lock for the duration of the map lookup and conntrack lookup
-    std::lock_guard<Thread::MutexBasicLockable> guard(maps_mutex_);
+    Thread::LockGuard guard(maps_mutex_);
     auto it = ct_maps6_.find(map_name);
     if (it == ct_maps6_.end()) {
       it = openMap6(map_name);

--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -40,7 +40,7 @@ using __u8 = uint8_t;
 #define TUPLE_F_OUT 0
 #define TUPLE_F_IN 1
 
-PACKED_STRUCT(struct ipv6_ct_tuple {
+PACKED_STRUCT(struct IPv6CtTuple {
   __be32 saddr[4];
   __be32 daddr[4];
   __be16 dport;
@@ -49,7 +49,7 @@ PACKED_STRUCT(struct ipv6_ct_tuple {
   __u8 flags;
 });
 
-PACKED_STRUCT(struct ipv4_ct_tuple {
+PACKED_STRUCT(struct IPv4CtTuple {
   __be32 saddr;
   __be32 daddr;
   __be16 dport;
@@ -82,10 +82,10 @@ struct CtEntry {
 };
 
 CtMap::CtMap4::CtMap4()
-    : Bpf(BPF_MAP_TYPE_HASH, sizeof(struct ipv4_ct_tuple), sizeof(struct CtEntry)) {}
+    : Bpf(BPF_MAP_TYPE_HASH, sizeof(struct IPv4CtTuple), sizeof(struct CtEntry)) {}
 
 CtMap::CtMap6::CtMap6()
-    : Bpf(BPF_MAP_TYPE_HASH, sizeof(struct ipv6_ct_tuple), sizeof(struct CtEntry)) {}
+    : Bpf(BPF_MAP_TYPE_HASH, sizeof(struct IPv6CtTuple), sizeof(struct CtEntry)) {}
 
 CtMap::CtMaps4::CtMaps4(const std::string& bpf_root, const std::string& map_name) : ok_(false) {
   // Open the IPv4 bpf maps from Cilium specific paths
@@ -188,8 +188,8 @@ uint32_t CtMap::lookupSrcIdentity(const std::string& map_name, const Network::Ad
                                   const Network::Address::Ip* dip, bool ingress) {
   ENVOY_LOG(debug, "cilium.bpf_metadata: Using conntrack map {}", map_name);
 
-  struct ipv4_ct_tuple key4 {};
-  struct ipv6_ct_tuple key6 {};
+  struct IPv4CtTuple key4 {};
+  struct IPv6CtTuple key6 {};
   struct CtEntry value {};
 
   if (sip->version() == Network::Address::IpVersion::v4 &&

--- a/cilium/conntrack.h
+++ b/cilium/conntrack.h
@@ -79,7 +79,7 @@ private:
   std::string bpf_root_;
 };
 
-typedef std::shared_ptr<CtMap> CtMapSharedPtr;
+using CtMapSharedPtr = std::shared_ptr<CtMap>;
 
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/filter_state_cilium_policy.cc
+++ b/cilium/filter_state_cilium_policy.cc
@@ -1,8 +1,16 @@
 #include "cilium/filter_state_cilium_policy.h"
 
+#include <cstdint>
 #include <string>
 
+#include "envoy/http/header_map.h"
+#include "envoy/network/connection.h"
+
+#include "source/common/common/logger.h"
 #include "source/common/common/macros.h"
+
+#include "absl/strings/string_view.h"
+#include "cilium/accesslog.h"
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/filter_state_cilium_policy.cc
+++ b/cilium/filter_state_cilium_policy.cc
@@ -42,16 +42,16 @@ bool CiliumPolicyFilterState::enforceNetworkPolicy(const Network::Connection& co
     auto remote_id = ingress_ ? source_identity_ : destination_identity;
     auto port = ingress_ ? port_ : destination_port;
 
-    auto portPolicy = policy.findPortPolicy(ingress_, port);
+    auto port_policy = policy.findPortPolicy(ingress_, port);
 
-    if (!portPolicy.allowed(proxy_id_, remote_id, sni)) {
+    if (!port_policy.allowed(proxy_id_, remote_id, sni)) {
       ENVOY_CONN_LOG(debug, "Pod policy DENY on proxy_id: {} id: {} port: {} sni: \"{}\"", conn,
                      proxy_id_, remote_id, destination_port, sni);
       return false;
     }
 
     // populate l7proto_ if available
-    use_proxy_lib = portPolicy.useProxylib(proxy_id_, remote_id, l7_proto);
+    use_proxy_lib = port_policy.useProxylib(proxy_id_, remote_id, l7_proto);
   }
 
   // enforce Ingress policy 2nd, if any
@@ -61,8 +61,8 @@ bool CiliumPolicyFilterState::enforceNetworkPolicy(const Network::Connection& co
 
     // Enforce ingress policy for Ingress, on the original destination port
     if (ingress_source_identity_ != 0) {
-      auto ingressPortPolicy = policy.findPortPolicy(true, port_);
-      if (!ingressPortPolicy.allowed(proxy_id_, ingress_source_identity_, sni)) {
+      auto ingress_port_policy = policy.findPortPolicy(true, port_);
+      if (!ingress_port_policy.allowed(proxy_id_, ingress_source_identity_, sni)) {
         ENVOY_CONN_LOG(debug,
                        "Ingress network policy {} DROP for source identity and destination "
                        "reserved ingress identity: {} proxy_id: {} port: {} sni: \"{}\"",
@@ -73,8 +73,8 @@ bool CiliumPolicyFilterState::enforceNetworkPolicy(const Network::Connection& co
     }
 
     // Enforce egress policy for Ingress
-    auto egressPortPolicy = policy.findPortPolicy(false, destination_port);
-    if (!egressPortPolicy.allowed(proxy_id_, destination_identity, sni)) {
+    auto egress_port_policy = policy.findPortPolicy(false, destination_port);
+    if (!egress_port_policy.allowed(proxy_id_, destination_identity, sni)) {
       ENVOY_CONN_LOG(debug,
                      "Egress network policy {} DROP for reserved ingress identity and destination "
                      "identity: {} proxy_id: {} port: {} sni: \"{}\"",

--- a/cilium/filter_state_cilium_policy.cc
+++ b/cilium/filter_state_cilium_policy.cc
@@ -1,9 +1,5 @@
 #include "cilium/filter_state_cilium_policy.h"
 
-#include <asm-generic/socket.h>
-#include <netinet/in.h>
-
-#include <cerrno>
 #include <string>
 
 #include "source/common/common/macros.h"

--- a/cilium/filter_state_cilium_policy.h
+++ b/cilium/filter_state_cilium_policy.h
@@ -8,6 +8,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/http/header_map.h"
 #include "envoy/network/address.h"
+#include "envoy/network/connection.h"
 #include "envoy/stream_info/filter_state.h"
 
 #include "source/common/common/logger.h"
@@ -51,16 +52,18 @@ public:
 
   uint32_t resolvePolicyId(const Network::Address::Ip* ip) const {
     const auto resolver = policy_resolver_.lock();
-    if (resolver)
+    if (resolver) {
       return resolver->resolvePolicyId(ip);
+    }
     return Cilium::ID::WORLD; // default to WORLD policy ID if resolver is no longer available
   }
 
   const PolicyInstance& getPolicy() const {
     const auto resolver = policy_resolver_.lock();
-    if (resolver)
+    if (resolver) {
       return resolver->getPolicy(pod_ip_);
-    return NetworkPolicyMap::GetDenyAllPolicy();
+    }
+    return NetworkPolicyMap::getDenyAllPolicy();
   }
 
   bool enforceNetworkPolicy(const Network::Connection& conn, uint32_t destination_identity,

--- a/cilium/filter_state_cilium_policy.h
+++ b/cilium/filter_state_cilium_policy.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <asm-generic/socket.h>
-#include <netinet/in.h>
-
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/cilium/grpc_subscription.cc
+++ b/cilium/grpc_subscription.cc
@@ -16,6 +16,7 @@
 #include "envoy/config/subscription.h"
 #include "envoy/config/subscription_factory.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/grpc/async_client.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/stats/scope.h"
 #include "envoy/upstream/cluster_manager.h"
@@ -95,7 +96,7 @@ TypeUrlToServiceMap& typeUrlToServiceMap() {
 
 class NopConfigValidatorsImpl : public Envoy::Config::CustomConfigValidators {
 public:
-  NopConfigValidatorsImpl() {}
+  NopConfigValidatorsImpl() = default;
 
   void executeValidators(absl::string_view,
                          const std::vector<Envoy::Config::DecodedResourcePtr>&) override {}

--- a/cilium/grpc_subscription.h
+++ b/cilium/grpc_subscription.h
@@ -28,7 +28,7 @@ public:
   GrpcMuxImpl(Config::GrpcMuxContext& grpc_mux_context, bool skip_subsequent_node)
       : Config::GrpcMuxImpl(grpc_mux_context, skip_subsequent_node) {}
 
-  ~GrpcMuxImpl() override {}
+  ~GrpcMuxImpl() override = default;
 
   void onStreamEstablished() override {
     new_stream_ = true;

--- a/cilium/health_check_sink.cc
+++ b/cilium/health_check_sink.cc
@@ -33,9 +33,10 @@ HealthCheckEventPipeSink::HealthCheckEventPipeSink(const cilium::HealthCheckEven
   auto it = udss.find(path);
   if (it != udss.end()) {
     uds_client_ = it->second.lock();
-    if (!uds_client_)
+    if (!uds_client_) {
       // expired, remove
       udss.erase(path);
+    }
   }
   if (!uds_client_) {
     // Not found, allocate and store as a weak_ptr
@@ -52,7 +53,7 @@ void HealthCheckEventPipeSink::log(envoy::data::core::v3::HealthCheckEvent event
   }
   std::string msg;
   event.SerializeToString(&msg);
-  uds_client_->Log(msg);
+  uds_client_->log(msg);
 };
 
 Upstream::HealthCheckEventSinkPtr HealthCheckEventPipeSinkFactory::createHealthCheckEventSink(

--- a/cilium/health_check_sink.h
+++ b/cilium/health_check_sink.h
@@ -10,7 +10,7 @@
 #include "envoy/upstream/health_check_event_sink.h"
 
 #include "source/common/common/thread.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+#include "source/common/protobuf/protobuf.h"
 
 #include "absl/base/thread_annotations.h"
 #include "cilium/api/health_check_sink.pb.h"

--- a/cilium/host_map.cc
+++ b/cilium/host_map.cc
@@ -32,15 +32,15 @@ namespace Cilium {
 
 template <typename T>
 unsigned int checkPrefix(T addr, bool have_prefix, unsigned int plen, absl::string_view host) {
-  const unsigned int PLEN_MAX = sizeof(T) * 8;
+  const unsigned int plen_max = sizeof(T) * 8;
   if (!have_prefix) {
-    return PLEN_MAX;
+    return plen_max;
   }
-  if (plen > PLEN_MAX) {
+  if (plen > plen_max) {
     throw EnvoyException(fmt::format("NetworkPolicyHosts: Invalid prefix length in \'{}\'", host));
   }
   // Check for 1-bits after the prefix
-  if ((plen == 0 && addr) || (plen > 0 && addr & ntoh((T(1) << (PLEN_MAX - plen)) - 1))) {
+  if ((plen == 0 && addr) || (plen > 0 && addr & ntoh((T(1) << (plen_max - plen)) - 1))) {
     throw EnvoyException(fmt::format("NetworkPolicyHosts: Non-prefix bits set in \'{}\'", host));
   }
   return plen;

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -97,7 +97,7 @@ class PolicyHostMap : public Singleton::Instance,
 public:
   PolicyHostMap(Server::Configuration::CommonFactoryContext& context);
   PolicyHostMap(ThreadLocal::SlotAllocator& tls);
-  ~PolicyHostMap() {
+  ~PolicyHostMap() override {
     ENVOY_LOG(debug, "Cilium PolicyHostMap({}): PolicyHostMap is deleted NOW!", name_);
   }
 

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -27,7 +27,7 @@
 #include "source/common/common/macros.h"
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/utility.h"
 
 #include "absl/container/flat_hash_map.h"

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -62,8 +62,8 @@ template <> inline absl::uint128 hton(absl::uint128 addr) {
 }
 
 template <typename I> I masked(I addr, unsigned int plen) {
-  const unsigned int PLEN_MAX = sizeof(I) * 8;
-  return plen == 0 ? I(0) : addr & ~hton((I(1) << (PLEN_MAX - plen)) - 1);
+  const unsigned int plen_max = sizeof(I) * 8;
+  return plen == 0 ? I(0) : addr & ~hton((I(1) << (plen_max - plen)) - 1);
 };
 
 class PolicyHostDecoder : public Envoy::Config::OpaqueResourceDecoder {

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -187,7 +187,7 @@ public:
     std::vector<std::pair<unsigned int, absl::flat_hash_map<absl::uint128, uint64_t>>>
         ipv6_to_policy_;
   };
-  typedef std::shared_ptr<ThreadLocalHostMap> ThreadLocalHostMapSharedPtr;
+  using ThreadLocalHostMapSharedPtr = std::shared_ptr<ThreadLocalHostMap>;
 
   const ThreadLocalHostMap* getHostMap() const {
     return tls_->get().get() ? &tls_->getTyped<ThreadLocalHostMap>() : nullptr;

--- a/cilium/ipcache.cc
+++ b/cilium/ipcache.cc
@@ -29,11 +29,11 @@ namespace Cilium {
 // them to a separate include file we can include here instead of
 // copying them!
 
-typedef uint32_t __be32; // Beware of the byte order!
-typedef uint64_t __u64;
-typedef uint32_t __u32;
-typedef uint16_t __u16;
-typedef uint8_t __u8;
+using __be32 = uint32_t; // Beware of the byte order!
+using __u64 = uint64_t;
+using __u32 = uint32_t;
+using __u16 = uint16_t;
+using __u8 = uint8_t;
 
 PACKED_STRUCT(struct ipcache_key {
   struct bpf_lpm_trie_key lpm_key;

--- a/cilium/ipcache.cc
+++ b/cilium/ipcache.cc
@@ -1,8 +1,8 @@
 #include "ipcache.h"
 
-#include <arpa/inet.h>
 #include <netinet/in.h>
 
+#include <cerrno> // IWYU pragma: keep
 #include <cstdint>
 #include <cstring>
 #include <memory>

--- a/cilium/ipcache.h
+++ b/cilium/ipcache.h
@@ -15,13 +15,13 @@
 namespace Envoy {
 namespace Cilium {
 
-class IPCache : public Singleton::Instance, public Bpf {
+class IpCache : public Singleton::Instance, public Bpf {
 public:
-  static std::shared_ptr<IPCache> newIpCache(Server::Configuration::ServerFactoryContext& context,
+  static std::shared_ptr<IpCache> newIpCache(Server::Configuration::ServerFactoryContext& context,
                                              const std::string& path);
-  static std::shared_ptr<IPCache> getIpCache(Server::Configuration::ServerFactoryContext& context);
+  static std::shared_ptr<IpCache> getIpCache(Server::Configuration::ServerFactoryContext& context);
 
-  IPCache(const std::string& path);
+  IpCache(const std::string& path);
   void setPath(const std::string& path);
   bool open();
   bool openLocked();
@@ -33,7 +33,7 @@ private:
   std::string path_;
 };
 
-using IPCacheSharedPtr = std::shared_ptr<IPCache>;
+using IpCacheSharedPtr = std::shared_ptr<IpCache>;
 
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/ipcache.h
+++ b/cilium/ipcache.h
@@ -17,14 +17,14 @@ namespace Cilium {
 
 class IPCache : public Singleton::Instance, public Bpf {
 public:
-  static std::shared_ptr<IPCache> NewIPCache(Server::Configuration::ServerFactoryContext& context,
+  static std::shared_ptr<IPCache> newIpCache(Server::Configuration::ServerFactoryContext& context,
                                              const std::string& path);
-  static std::shared_ptr<IPCache> GetIPCache(Server::Configuration::ServerFactoryContext& context);
+  static std::shared_ptr<IPCache> getIpCache(Server::Configuration::ServerFactoryContext& context);
 
   IPCache(const std::string& path);
-  void SetPath(const std::string& path);
-  bool Open();
-  bool open_locked();
+  void setPath(const std::string& path);
+  bool open();
+  bool openLocked();
 
   uint32_t resolve(const Network::Address::Ip* ip);
 

--- a/cilium/ipcache.h
+++ b/cilium/ipcache.h
@@ -33,7 +33,7 @@ private:
   std::string path_;
 };
 
-typedef std::shared_ptr<IPCache> IPCacheSharedPtr;
+using IPCacheSharedPtr = std::shared_ptr<IPCache>;
 
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/l7policy.cc
+++ b/cilium/l7policy.cc
@@ -269,14 +269,14 @@ Http::FilterHeadersStatus AccessFilter::encodeHeaders(Http::ResponseHeaderMap& h
   if (!log_entry_->request_logged_) {
     // Default logging local errors as "forwarded".
     // The response log will contain the locally generated HTTP error code.
-    auto logType = ::cilium::EntryType::Request;
+    auto log_type = ::cilium::EntryType::Request;
 
     if (headers.Status()->value() == "403") {
       // Log as a denied request.
-      logType = ::cilium::EntryType::Denied;
+      log_type = ::cilium::EntryType::Denied;
       config_->stats_.access_denied_.inc();
     }
-    config_->log(*log_entry_, logType);
+    config_->log(*log_entry_, log_type);
   }
 
   // Log the response

--- a/cilium/l7policy.h
+++ b/cilium/l7policy.h
@@ -49,7 +49,7 @@ public:
   Config(const ::cilium::L7Policy& config, TimeSource& time_source, Stats::Scope& scope,
          bool is_upstream);
 
-  void Log(AccessLog::Entry&, ::cilium::EntryType);
+  void log(AccessLog::Entry&, ::cilium::EntryType);
 
   TimeSource& time_source_;
   FilterStats stats_;

--- a/cilium/l7policy.h
+++ b/cilium/l7policy.h
@@ -60,7 +60,7 @@ private:
   Cilium::AccessLogSharedPtr access_log_;
 };
 
-typedef std::shared_ptr<Config> ConfigSharedPtr;
+using ConfigSharedPtr = std::shared_ptr<Config>;
 
 // Each request gets their own instance of this filter, and
 // they can run parallel from multiple worker threads, all accessing

--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -1,7 +1,5 @@
 #include "cilium/network_filter.h"
 
-#include <dlfcn.h>
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -22,7 +20,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/network/upstream_server_name.h"
 #include "source/common/network/upstream_subject_alt_names.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/utility.h"
 
 #include "absl/status/statusor.h"

--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -122,19 +122,19 @@ Network::FilterStatus Instance::onNewConnection() {
   // Pass metadata from tls_inspector to the filterstate, if any & not already
   // set via upstream cluster config.
   if (!sni.empty()) {
-    auto filterState = conn.streamInfo().filterState();
+    auto filter_state = conn.streamInfo().filterState();
     auto have_sni =
-        filterState->hasData<Network::UpstreamServerName>(Network::UpstreamServerName::key());
-    auto have_san = filterState->hasData<Network::UpstreamSubjectAltNames>(
+        filter_state->hasData<Network::UpstreamServerName>(Network::UpstreamServerName::key());
+    auto have_san = filter_state->hasData<Network::UpstreamSubjectAltNames>(
         Network::UpstreamSubjectAltNames::key());
     if (!have_sni && !have_san) {
-      filterState->setData(Network::UpstreamServerName::key(),
-                           std::make_unique<Network::UpstreamServerName>(sni),
-                           StreamInfo::FilterState::StateType::Mutable);
-      filterState->setData(Network::UpstreamSubjectAltNames::key(),
-                           std::make_unique<Network::UpstreamSubjectAltNames>(
-                               std::vector<std::string>{std::string(sni)}),
-                           StreamInfo::FilterState::StateType::Mutable);
+      filter_state->setData(Network::UpstreamServerName::key(),
+                            std::make_unique<Network::UpstreamServerName>(sni),
+                            StreamInfo::FilterState::StateType::Mutable);
+      filter_state->setData(Network::UpstreamSubjectAltNames::key(),
+                            std::make_unique<Network::UpstreamSubjectAltNames>(
+                                std::vector<std::string>{std::string(sni)}),
+                            StreamInfo::FilterState::StateType::Mutable);
     }
   }
 
@@ -180,9 +180,9 @@ Network::FilterStatus Instance::onNewConnection() {
                                   stream_info.downstreamAddressProvider().remoteAddress(),
                                   destination_identity, dst_address, &config_->time_source_);
 
-    bool useProxyLib;
+    bool use_proxy_lib;
     if (!policy_fs->enforceNetworkPolicy(conn, destination_identity, destination_port_, sni,
-                                         useProxyLib, l7proto_, log_entry_)) {
+                                         use_proxy_lib, l7proto_, log_entry_)) {
       ENVOY_CONN_LOG(debug, "cilium.network: policy DENY on id: {} port: {} sni: \"{}\"", conn,
                      remote_id_, destination_port_, sni);
       config_->log(log_entry_, ::cilium::EntryType::Denied);
@@ -196,7 +196,7 @@ Network::FilterStatus Instance::onNewConnection() {
     ENVOY_LOG(debug, "cilium.network: policy ALLOW on id: {} port: {} sni: \"{}\"", remote_id_,
               destination_port_, sni);
 
-    if (useProxyLib) {
+    if (use_proxy_lib) {
       const std::string& policy_name = policy_fs->pod_ip_;
 
       // Initialize Go parser if requested

--- a/cilium/network_filter.h
+++ b/cilium/network_filter.h
@@ -33,7 +33,7 @@ public:
   Config(const ::cilium::NetworkFilter& config, Server::Configuration::FactoryContext& context);
   Config(const Json::Object& config, Server::Configuration::FactoryContext& context);
 
-  void Log(Cilium::AccessLog::Entry&, ::cilium::EntryType);
+  void log(Cilium::AccessLog::Entry&, ::cilium::EntryType);
 
   Cilium::GoFilterSharedPtr proxylib_;
   TimeSource& time_source_;

--- a/cilium/network_filter.h
+++ b/cilium/network_filter.h
@@ -42,7 +42,7 @@ private:
   Cilium::AccessLogSharedPtr access_log_;
 };
 
-typedef std::shared_ptr<Config> ConfigSharedPtr;
+using ConfigSharedPtr = std::shared_ptr<Config>;
 
 /**
  * Implementation of a Cilium network filter.

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <set>
 #include <string>
 #include <utility>
@@ -36,7 +37,7 @@
 #include "source/common/init/target_impl.h"
 #include "source/common/init/watcher_impl.h"
 #include "source/common/network/utility.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/utility.h"
 #include "source/extensions/config_subscription/grpc/grpc_subscription_impl.h"
 #include "source/server/transport_socket_config_impl.h"

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -57,7 +57,7 @@ namespace Cilium {
 
 uint64_t NetworkPolicyMap::instance_id_ = 0;
 
-IPAddressPair::IPAddressPair(const cilium::NetworkPolicy& proto) {
+IpAddressPair::IpAddressPair(const cilium::NetworkPolicy& proto) {
   for (const auto& ip_addr : proto.endpoint_ips()) {
     auto ip = Network::Utility::parseInternetAddressNoThrow(ip_addr);
     if (ip) {
@@ -637,7 +637,7 @@ public:
   uint32_t proxy_id_;
   absl::btree_set<uint32_t> remotes_;
 
-  std::vector<SNIPattern> allowed_snis_;          // All SNIs allowed if empty.
+  std::vector<SniPattern> allowed_snis_;          // All SNIs allowed if empty.
   std::vector<HttpNetworkPolicyRule> http_rules_; // Allowed if empty, but remote is checked first.
   std::string l7_proto_{};
   std::vector<L7NetworkPolicyRule> l7_allow_rules_;
@@ -1143,7 +1143,7 @@ public:
 
   uint32_t getEndpointID() const override { return endpoint_id_; }
 
-  const IPAddressPair& getEndpointIPs() const override { return endpoint_ips_; }
+  const IpAddressPair& getEndpointIPs() const override { return endpoint_ips_; }
 
   std::string string() const override {
     std::string res;
@@ -1161,7 +1161,7 @@ public:
   uint32_t endpoint_id_;
   uint64_t hash_;
   const cilium::NetworkPolicy policy_proto_;
-  const IPAddressPair endpoint_ips_;
+  const IpAddressPair endpoint_ips_;
 
 private:
   const NetworkPolicyMap& parent_;
@@ -1279,7 +1279,7 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
     ENVOY_LOG(info, "New NetworkPolicy stream");
 
     // Get ipcache singleton only if it was successfully created previously
-    IPCacheSharedPtr ipcache = IPCache::getIpCache(context_);
+    IpCacheSharedPtr ipcache = IpCache::getIpCache(context_);
     if (ipcache != nullptr) {
       ENVOY_LOG(info, "Reopening ipcache on new stream");
       ipcache->open();
@@ -1452,7 +1452,7 @@ public:
 
   uint32_t getEndpointID() const override { return 0; }
 
-  const IPAddressPair& getEndpointIPs() const override { return empty_ips; }
+  const IpAddressPair& getEndpointIPs() const override { return empty_ips; }
 
   std::string string() const override { return "AllowAllEgressPolicyInstanceImpl"; }
 
@@ -1461,11 +1461,11 @@ public:
 private:
   PolicyMap empty_map_;
   static const std::string empty_string;
-  static const IPAddressPair empty_ips;
+  static const IpAddressPair empty_ips;
   static const RulesList empty_rules_;
 };
 const std::string AllowAllEgressPolicyInstanceImpl::empty_string = "";
-const IPAddressPair AllowAllEgressPolicyInstanceImpl::empty_ips{};
+const IpAddressPair AllowAllEgressPolicyInstanceImpl::empty_ips{};
 const RulesList AllowAllEgressPolicyInstanceImpl::empty_rules_{};
 
 AllowAllEgressPolicyInstanceImpl NetworkPolicyMap::AllowAllEgressPolicy;
@@ -1498,7 +1498,7 @@ public:
 
   uint32_t getEndpointID() const override { return 0; }
 
-  const IPAddressPair& getEndpointIPs() const override { return empty_ips; }
+  const IpAddressPair& getEndpointIPs() const override { return empty_ips; }
 
   std::string string() const override { return "DenyAllPolicyInstanceImpl"; }
 
@@ -1507,11 +1507,11 @@ public:
 private:
   PolicyMap empty_map_;
   static const std::string empty_string;
-  static const IPAddressPair empty_ips;
+  static const IpAddressPair empty_ips;
   static const RulesList empty_rules;
 };
 const std::string DenyAllPolicyInstanceImpl::empty_string = "";
-const IPAddressPair DenyAllPolicyInstanceImpl::empty_ips{};
+const IpAddressPair DenyAllPolicyInstanceImpl::empty_ips{};
 const RulesList DenyAllPolicyInstanceImpl::empty_rules{};
 
 DenyAllPolicyInstanceImpl NetworkPolicyMap::DenyAllPolicy;

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -58,8 +58,8 @@ namespace Cilium {
 uint64_t NetworkPolicyMap::instance_id_ = 0;
 
 IPAddressPair::IPAddressPair(const cilium::NetworkPolicy& proto) {
-  for (const auto& ipAddr : proto.endpoint_ips()) {
-    auto ip = Network::Utility::parseInternetAddressNoThrow(ipAddr);
+  for (const auto& ip_addr : proto.endpoint_ips()) {
+    auto ip = Network::Utility::parseInternetAddressNoThrow(ip_addr);
     if (ip) {
       switch (ip->ip()->version()) {
       case Network::Address::IpVersion::v4:
@@ -110,8 +110,8 @@ public:
     }
 
     // Perform presence match if the value to match is empty
-    bool isPresentMatch = match_value->length() == 0;
-    if (isPresentMatch) {
+    bool is_present_match = match_value->length() == 0;
+    if (is_present_match) {
       matches = header_value.result().has_value();
     } else if (header_value.result().has_value()) {
       const absl::string_view val = header_value.result().value();
@@ -150,7 +150,7 @@ public:
         logMissing(log_entry, *match_value);
         return true;
       case cilium::HeaderMatch::DELETE_ON_MISMATCH:
-        if (isPresentMatch) {
+        if (is_present_match) {
           // presence match failed, nothing to do
           return true;
         }
@@ -1401,12 +1401,12 @@ ProtobufTypes::MessagePtr
 NetworkPolicyMap::dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_matcher) {
   ENVOY_LOG(debug, "Writing NetworkPolicies to NetworkPoliciesConfigDump");
 
-  std::vector<uint64_t> policyEndpointIds;
+  std::vector<uint64_t> policy_endpoint_ids;
   auto config_dump = std::make_unique<cilium::NetworkPoliciesConfigDump>();
   for (const auto& item : *load()) {
     // filter duplicates (policies are stored per endpoint ip)
-    if (std::find(policyEndpointIds.begin(), policyEndpointIds.end(),
-                  item.second->policy_proto_.endpoint_id()) != policyEndpointIds.end()) {
+    if (std::find(policy_endpoint_ids.begin(), policy_endpoint_ids.end(),
+                  item.second->policy_proto_.endpoint_id()) != policy_endpoint_ids.end()) {
       continue;
     }
 
@@ -1415,7 +1415,7 @@ NetworkPolicyMap::dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_m
     }
 
     config_dump->mutable_networkpolicies()->Add()->CopyFrom(item.second->policy_proto_);
-    policyEndpointIds.emplace_back(item.second->policy_proto_.endpoint_id());
+    policy_endpoint_ids.emplace_back(item.second->policy_proto_.endpoint_id());
   }
 
   return config_dump;

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -125,13 +125,13 @@ private:
   const PolicyMap::const_iterator port_rules_; // iterator to 'map_'
 };
 
-class IPAddressPair {
+class IpAddressPair {
 public:
-  IPAddressPair() = default;
-  IPAddressPair(Network::Address::InstanceConstSharedPtr& ipv4,
+  IpAddressPair() = default;
+  IpAddressPair(Network::Address::InstanceConstSharedPtr& ipv4,
                 Network::Address::InstanceConstSharedPtr& ipv6)
       : ipv4_(ipv4), ipv6_(ipv6){};
-  IPAddressPair(const cilium::NetworkPolicy& proto);
+  IpAddressPair(const cilium::NetworkPolicy& proto);
 
   Network::Address::InstanceConstSharedPtr ipv4_{};
   Network::Address::InstanceConstSharedPtr ipv6_{};
@@ -164,7 +164,7 @@ public:
 
   virtual uint32_t getEndpointID() const PURE;
 
-  virtual const IPAddressPair& getEndpointIPs() const PURE;
+  virtual const IpAddressPair& getEndpointIPs() const PURE;
 
   virtual std::string string() const PURE;
 
@@ -348,10 +348,10 @@ protected:
 };
 using NetworkPolicyMapSharedPtr = std::shared_ptr<const NetworkPolicyMap>;
 
-struct SNIPattern {
+struct SniPattern {
   std::string pattern;
 
-  explicit SNIPattern(const std::string& p) : pattern(absl::AsciiStrToLower(p)) {}
+  explicit SniPattern(const std::string& p) : pattern(absl::AsciiStrToLower(p)) {}
 
   bool matches(const absl::string_view sni) const {
     if (pattern.empty() || sni.empty()) {

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -59,7 +59,7 @@ namespace Cilium {
 // other given this comparison predicate).
 // On lookups we'll set both ends of the port range to the same port number, which will find the one
 // range that it overlaps with, if one exists.
-typedef std::pair<uint16_t, uint16_t> PortRange;
+using PortRange = std::pair<uint16_t, uint16_t>;
 struct PortRangeCompare {
   bool operator()(const PortRange& a, const PortRange& b) const {
     // return true if range 'a.first - a.second' is below range 'b.first - b.second'.
@@ -68,12 +68,12 @@ struct PortRangeCompare {
 };
 
 class PortNetworkPolicyRules;
-typedef std::list<PortNetworkPolicyRules> RulesList;
+using RulesList = std::list<PortNetworkPolicyRules>;
 
 // PolicyMap is keyed by port ranges, and contains a list of PortNetworkPolicyRules's applicable
 // to this range. A list is needed as rules may come from multiple sources (e.g., resulting from
 // use of named ports and numbered ports in Cilium Network Policy at the same time).
-typedef absl::btree_map<PortRange, RulesList, PortRangeCompare> PolicyMap;
+using PolicyMap = absl::btree_map<PortRange, RulesList, PortRangeCompare>;
 
 // PortPolicy holds a reference to a set of rules in a policy map that apply to the given port.
 // Methods then iterate through the set to determine if policy allows or denies. This is needed to

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -26,7 +26,7 @@
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
 #include "envoy/stats/scope.h"
-#include "envoy/stats/stats_macros.h"
+#include "envoy/stats/stats_macros.h" // IWYU pragma: keep
 
 #include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
@@ -34,7 +34,7 @@
 #include "source/common/common/thread.h"
 #include "source/common/init/target_impl.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/utility.h"
 #include "source/server/transport_socket_config_impl.h"
 

--- a/cilium/policy_id.h
+++ b/cilium/policy_id.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace Envoy {
 namespace Cilium {

--- a/cilium/privileged_service_client.cc
+++ b/cilium/privileged_service_client.cc
@@ -38,7 +38,7 @@ ProtocolClient::ProtocolClient()
                      (get_capabilities(CAP_PERMITTED) & ~(1UL << CAP_NET_BIND_SERVICE)) == 0,
                  "cilium-envoy running with privileges, exiting");
 
-  if (!check_privileged_service()) {
+  if (!checkPrivilegedService()) {
     // No Cilium privileged service detected
     close();
   }
@@ -90,7 +90,7 @@ out:
   return size;
 }
 
-bool ProtocolClient::check_privileged_service() {
+bool ProtocolClient::checkPrivilegedService() {
   // Dump the effective capabilities of the privileged service process
   DumpRequest req;
   Response resp;
@@ -105,8 +105,8 @@ bool ProtocolClient::check_privileged_service() {
   return true;
 }
 
-Envoy::Api::SysCallIntResult ProtocolClient::bpf_open(const char* path) {
-  if (!have_cilium_privileged_service()) {
+Envoy::Api::SysCallIntResult ProtocolClient::bpfOpen(const char* path) {
+  if (!haveCiliumPrivilegedService()) {
     return {-1, EPERM};
   }
 
@@ -123,9 +123,9 @@ Envoy::Api::SysCallIntResult ProtocolClient::bpf_open(const char* path) {
   return Envoy::Api::SysCallIntResult{resp.return_value_, resp.errno_};
 }
 
-Envoy::Api::SysCallIntResult ProtocolClient::bpf_lookup(int fd, const void* key, uint32_t key_size,
-                                                        void* value, uint32_t value_size) {
-  if (!have_cilium_privileged_service()) {
+Envoy::Api::SysCallIntResult ProtocolClient::bpfLookup(int fd, const void* key, uint32_t key_size,
+                                                       void* value, uint32_t value_size) {
+  if (!haveCiliumPrivilegedService()) {
     return {-1, EPERM};
   }
 
@@ -140,7 +140,7 @@ Envoy::Api::SysCallIntResult ProtocolClient::bpf_lookup(int fd, const void* key,
 
 Envoy::Api::SysCallIntResult ProtocolClient::setsockopt(int sockfd, int level, int optname,
                                                         const void* optval, socklen_t optlen) {
-  if (!have_cilium_privileged_service()) {
+  if (!haveCiliumPrivilegedService()) {
     return {-1, EPERM};
   }
 

--- a/cilium/privileged_service_client.h
+++ b/cilium/privileged_service_client.h
@@ -4,9 +4,14 @@
 #error "Linux platform file is part of non-Linux build."
 #endif
 
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <cstddef>
+#include <cstdint>
+
 #include "envoy/api/os_sys_calls_common.h"
 
-#include "source/common/common/assert.h"
 #include "source/common/singleton/threadsafe_singleton.h"
 
 #include "starter/privileged_service_protocol.h"

--- a/cilium/privileged_service_client.h
+++ b/cilium/privileged_service_client.h
@@ -39,13 +39,13 @@ public:
 
 protected:
   // Read-only bpf syscalls
-  Envoy::Api::SysCallIntResult bpf_open(const char* path);
-  Envoy::Api::SysCallIntResult bpf_lookup(int fd, const void* key, uint32_t key_size, void* value,
-                                          uint32_t value_size);
+  Envoy::Api::SysCallIntResult bpfOpen(const char* path);
+  Envoy::Api::SysCallIntResult bpfLookup(int fd, const void* key, uint32_t key_size, void* value,
+                                         uint32_t value_size);
 
 private:
-  bool check_privileged_service();
-  bool have_cilium_privileged_service() const { return is_open(); }
+  bool checkPrivilegedService();
+  bool haveCiliumPrivilegedService() const { return is_open(); }
 
   ssize_t transact(MessageHeader& req, size_t req_len, const void* data, size_t datalen, int* fd,
                    Response& resp, void* buf = nullptr, size_t bufsize = 0, bool assert = true);

--- a/cilium/proxylib.cc
+++ b/cilium/proxylib.cc
@@ -90,7 +90,7 @@ GoFilter::~GoFilter() {
   }
 }
 
-GoFilter::InstancePtr GoFilter::NewInstance(Network::Connection& conn, const std::string& go_proto,
+GoFilter::InstancePtr GoFilter::newInstance(Network::Connection& conn, const std::string& go_proto,
                                             bool ingress, uint32_t src_id, uint32_t dst_id,
                                             const std::string& src_addr,
                                             const std::string& dst_addr,
@@ -113,7 +113,7 @@ GoFilter::InstancePtr GoFilter::NewInstance(Network::Connection& conn, const std
   return parser;
 }
 
-FilterResult GoFilter::Instance::OnIO(bool reply, Buffer::Instance& data, bool end_stream) {
+FilterResult GoFilter::Instance::onIo(bool reply, Buffer::Instance& data, bool end_stream) {
   auto& dir = reply ? reply_ : orig_;
   int64_t data_len = data.length();
 
@@ -311,7 +311,7 @@ FilterResult GoFilter::Instance::OnIO(bool reply, Buffer::Instance& data, bool e
       return FILTER_PARSER_ERROR;
     }
 
-    inject_buf_exhausted = dir.inject_slice_.at_capacity();
+    inject_buf_exhausted = dir.inject_slice_.atCapacity();
 
     // Make space for more injected data
     dir.inject_slice_.reset();
@@ -327,7 +327,7 @@ FilterResult GoFilter::Instance::OnIO(bool reply, Buffer::Instance& data, bool e
   return res;
 }
 
-void GoFilter::Instance::Close() {
+void GoFilter::Instance::close() {
   (*parent_.go_close_)(connection_id_);
   connection_id_ = 0;
   conn_.close(Network::ConnectionCloseType::FlushWrite);

--- a/cilium/proxylib.h
+++ b/cilium/proxylib.h
@@ -89,7 +89,7 @@ template <typename T> struct ResetableSlice : GoSlice<T> {
 
     return len;
   }
-  bool at_capacity() {
+  bool atCapacity() {
     // Return true if all of the available space was used, not affected by
     // draining
     return (data_ + len_) >= (base_ + cap_);
@@ -137,19 +137,19 @@ public:
       }
     }
 
-    void Close();
+    void close();
 
-    FilterResult OnIO(bool reply, Buffer::Instance& data, bool end_stream);
+    FilterResult onIo(bool reply, Buffer::Instance& data, bool end_stream);
 
-    bool WantReplyInject() const { return reply_.WantToInject(); }
-    void SetOrigEndStream(bool end_stream) { orig_.closed_ = end_stream; }
-    void SetReplyEndStream(bool end_stream) { reply_.closed_ = end_stream; }
+    bool wantReplyInject() const { return reply_.wantToInject(); }
+    void setOrigEndStream(bool end_stream) { orig_.closed_ = end_stream; }
+    void setReplyEndStream(bool end_stream) { reply_.closed_ = end_stream; }
 
     struct Direction {
       Direction() : inject_slice_(inject_buf_, sizeof(inject_buf_)) {}
 
-      bool WantToInject() const { return !closed_ && inject_slice_.len() > 0; }
-      void Close() { closed_ = true; }
+      bool wantToInject() const { return !closed_ && inject_slice_.len() > 0; }
+      void close() { closed_ = true; }
 
       Buffer::OwnedImpl buffer_; // Buffered data in this direction
       int64_t need_bytes_{0};    // Number of additional data bytes needed before can parse again
@@ -168,7 +168,7 @@ public:
   };
   using InstancePtr = std::unique_ptr<Instance>;
 
-  InstancePtr NewInstance(Network::Connection& conn, const std::string& go_proto, bool ingress,
+  InstancePtr newInstance(Network::Connection& conn, const std::string& go_proto, bool ingress,
                           uint32_t src_id, uint32_t dst_id, const std::string& src_addr,
                           const std::string& dst_addr, const std::string& policy_name) const;
 

--- a/cilium/proxylib.h
+++ b/cilium/proxylib.h
@@ -108,19 +108,19 @@ struct GoStringPair {
   GoString value;
 };
 
-typedef GoSlice<GoStringPair> GoKeyValueSlice;
-typedef uint64_t (*GoOpenModuleCB)(GoKeyValueSlice, bool);
-typedef void (*GoCloseModuleCB)(uint64_t);
+using GoKeyValueSlice = GoSlice<GoStringPair>;
+using GoOpenModuleCB = uint64_t (*)(GoKeyValueSlice, bool);
+using GoCloseModuleCB = void (*)(uint64_t);
 
-typedef ResetableSlice<uint8_t> GoBufferSlice;
-typedef FilterResult (*GoOnNewConnectionCB)(uint64_t, GoString, uint64_t, bool, uint32_t, uint32_t,
-                                            GoString, GoString, GoString, GoBufferSlice*,
-                                            GoBufferSlice*);
+using GoBufferSlice = ResetableSlice<uint8_t>;
+using GoOnNewConnectionCB = FilterResult (*)(uint64_t, GoString, uint64_t, bool, uint32_t, uint32_t,
+                                             GoString, GoString, GoString, GoBufferSlice*,
+                                             GoBufferSlice*);
 
-typedef GoSlice<GoSlice<uint8_t>> GoDataSlices; // Scatter-gather buffer list as '[][]byte'
-typedef ResetableSlice<FilterOp> GoFilterOpSlice;
-typedef FilterResult (*GoOnDataCB)(uint64_t, bool, bool, GoDataSlices*, GoFilterOpSlice*);
-typedef void (*GoCloseCB)(uint64_t);
+using GoDataSlices = GoSlice<GoSlice<uint8_t>>; // Scatter-gather buffer list as '[][]byte'
+using GoFilterOpSlice = ResetableSlice<FilterOp>;
+using GoOnDataCB = FilterResult (*)(uint64_t, bool, bool, GoDataSlices*, GoFilterOpSlice*);
+using GoCloseCB = void (*)(uint64_t);
 
 class GoFilter : public Logger::Loggable<Logger::Id::filter> {
 public:
@@ -166,7 +166,7 @@ public:
     Direction reply_;
     uint64_t connection_id_ = 0;
   };
-  typedef std::unique_ptr<Instance> InstancePtr;
+  using InstancePtr = std::unique_ptr<Instance>;
 
   InstancePtr NewInstance(Network::Connection& conn, const std::string& go_proto, bool ingress,
                           uint32_t src_id, uint32_t dst_id, const std::string& src_addr,
@@ -181,7 +181,7 @@ private:
   uint64_t go_module_id_{0};
 };
 
-typedef std::shared_ptr<const GoFilter> GoFilterSharedPtr;
+using GoFilterSharedPtr = std::shared_ptr<const GoFilter>;
 
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/secret_watcher.cc
+++ b/cilium/secret_watcher.cc
@@ -47,8 +47,8 @@ secretProvider(Server::Configuration::TransportSocketFactoryContext& context,
 
 } // namespace
 
-getSDSConfigFunc getSDSConfig = &getCiliumSDSConfig;
-void setSDSConfigFunc(getSDSConfigFunc func) { getSDSConfig = func; }
+GetSdsConfigFunc getSDSConfig = &getCiliumSDSConfig;
+void setSDSConfigFunc(GetSdsConfigFunc func) { getSDSConfig = func; }
 void resetSDSConfigFunc() { getSDSConfig = &getCiliumSDSConfig; }
 
 SecretWatcher::SecretWatcher(const NetworkPolicyMap& parent, const std::string& sds_name)
@@ -98,26 +98,26 @@ namespace {
 
 void setCommonConfig(const cilium::TLSContext config,
                      envoy::extensions::transport_sockets::tls::v3::CommonTlsContext* tls_context) {
-  if (config.validation_context_sds_secret() != "") {
+  if (!config.validation_context_sds_secret().empty()) {
     auto sds_secret = tls_context->mutable_validation_context_sds_secret_config();
     sds_secret->set_name(config.validation_context_sds_secret());
     auto* config_source = sds_secret->mutable_sds_config();
     *config_source = getSDSConfig(config.validation_context_sds_secret());
-  } else if (config.trusted_ca() != "") {
+  } else if (!config.trusted_ca().empty()) {
     auto validation_context = tls_context->mutable_validation_context();
     auto trusted_ca = validation_context->mutable_trusted_ca();
     trusted_ca->set_inline_string(config.trusted_ca());
   }
-  if (config.tls_sds_secret() != "") {
+  if (!config.tls_sds_secret().empty()) {
     auto sds_secret = tls_context->add_tls_certificate_sds_secret_configs();
     sds_secret->set_name(config.tls_sds_secret());
     auto* config_source = sds_secret->mutable_sds_config();
     *config_source = getSDSConfig(config.tls_sds_secret());
-  } else if (config.certificate_chain() != "") {
+  } else if (!config.certificate_chain().empty()) {
     auto tls_certificate = tls_context->add_tls_certificates();
     auto certificate_chain = tls_certificate->mutable_certificate_chain();
     certificate_chain->set_inline_string(config.certificate_chain());
-    if (config.private_key() != "") {
+    if (!config.private_key().empty()) {
       auto private_key = tls_certificate->mutable_private_key();
       private_key->set_inline_string(config.private_key());
     } else {
@@ -138,14 +138,15 @@ DownstreamTLSContext::DownstreamTLSContext(const NetworkPolicyMap& parent,
                                            const cilium::TLSContext config)
     : TLSContext(parent, "server") {
   // Server config always needs the TLS certificate to present to the client
-  if (config.tls_sds_secret() == "" && config.certificate_chain() == "")
+  if (config.tls_sds_secret().empty() && config.certificate_chain().empty()) {
     throw EnvoyException("Downstream TLS Context: missing certificate chain");
+  }
 
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext context_config;
   auto tls_context = context_config.mutable_common_tls_context();
 
   // Check if client certificate is required
-  if (config.validation_context_sds_secret() != "" || config.trusted_ca() != "") {
+  if (!config.validation_context_sds_secret().empty() || !config.trusted_ca().empty()) {
     auto require_tls_certificate = context_config.mutable_require_client_certificate();
     require_tls_certificate->set_value(true);
   }
@@ -156,6 +157,7 @@ DownstreamTLSContext::DownstreamTLSContext(const NetworkPolicyMap& parent,
   }
   auto server_config_or_error = Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
       context_config, parent.transportFactoryContext(), false);
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   THROW_IF_NOT_OK(server_config_or_error.status());
   server_config_ = std::move(server_config_or_error.value());
 
@@ -163,6 +165,7 @@ DownstreamTLSContext::DownstreamTLSContext(const NetworkPolicyMap& parent,
     ENVOY_LOG(debug, "Server secret is updated.");
     auto ctx_or_error =
         manager_.createSslServerContext(scope_, *server_config_, server_names_, nullptr);
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     THROW_IF_NOT_OK(ctx_or_error.status());
     auto ctx = std::move(ctx_or_error.value());
     {
@@ -174,18 +177,20 @@ DownstreamTLSContext::DownstreamTLSContext(const NetworkPolicyMap& parent,
     return absl::OkStatus();
   };
   server_config_->setSecretUpdateCallback(create_server_context);
-  if (server_config_->isReady())
+  if (server_config_->isReady()) {
     static_cast<void>(create_server_context());
-  else
+  } else {
     parent.transportFactoryContext().initManager().add(init_target_);
+  }
 }
 
 UpstreamTLSContext::UpstreamTLSContext(const NetworkPolicyMap& parent, cilium::TLSContext config)
     : TLSContext(parent, "client") {
   // Client context always needs the trusted CA for server certificate validation
   // TODO: Default to system default trusted CAs?
-  if (config.validation_context_sds_secret() == "" && config.trusted_ca() == "")
+  if (config.validation_context_sds_secret().empty() && config.trusted_ca().empty()) {
     throw EnvoyException("Upstream TLS Context: missing trusted CA");
+  }
 
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext context_config;
   auto tls_context = context_config.mutable_common_tls_context();
@@ -199,12 +204,14 @@ UpstreamTLSContext::UpstreamTLSContext(const NetworkPolicyMap& parent, cilium::T
   }
   auto client_config_or_error = Extensions::TransportSockets::Tls::ClientContextConfigImpl::create(
       context_config, parent.transportFactoryContext());
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   THROW_IF_NOT_OK(client_config_or_error.status());
 
   client_config_ = std::move(client_config_or_error.value());
   auto create_client_context = [this]() {
     ENVOY_LOG(debug, "Client secret is updated.");
     auto ctx_or_error = manager_.createSslClientContext(scope_, *client_config_);
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     THROW_IF_NOT_OK(ctx_or_error.status());
     auto ctx = std::move(ctx_or_error.value());
     {
@@ -216,10 +223,11 @@ UpstreamTLSContext::UpstreamTLSContext(const NetworkPolicyMap& parent, cilium::T
     return absl::OkStatus();
   };
   client_config_->setSecretUpdateCallback(create_client_context);
-  if (client_config_->isReady())
+  if (client_config_->isReady()) {
     static_cast<void>(create_client_context());
-  else
+  } else {
     parent.transportFactoryContext().initManager().add(init_target_);
+  }
 }
 
 } // namespace Cilium

--- a/cilium/secret_watcher.h
+++ b/cilium/secret_watcher.h
@@ -26,7 +26,7 @@ namespace Envoy {
 namespace Cilium {
 
 // Facility for SDS config override for testing
-typedef envoy::config::core::v3::ConfigSource (*getSDSConfigFunc)(const std::string& name);
+using getSDSConfigFunc = envoy::config::core::v3::ConfigSource (*)(const std::string&);
 extern getSDSConfigFunc getSDSConfig;
 void setSDSConfigFunc(getSDSConfigFunc);
 void resetSDSConfigFunc();

--- a/cilium/secret_watcher.h
+++ b/cilium/secret_watcher.h
@@ -26,9 +26,9 @@ namespace Envoy {
 namespace Cilium {
 
 // Facility for SDS config override for testing
-using getSDSConfigFunc = envoy::config::core::v3::ConfigSource (*)(const std::string&);
-extern getSDSConfigFunc getSDSConfig;
-void setSDSConfigFunc(getSDSConfigFunc);
+using GetSdsConfigFunc = envoy::config::core::v3::ConfigSource (*)(const std::string&);
+extern GetSdsConfigFunc getSDSConfig;
+void setSDSConfigFunc(GetSdsConfigFunc);
 void resetSDSConfigFunc();
 
 class SecretWatcher : public Logger::Loggable<Logger::Id::config> {

--- a/cilium/socket_option_cilium_mark.cc
+++ b/cilium/socket_option_cilium_mark.cc
@@ -1,8 +1,5 @@
 #include "cilium/socket_option_cilium_mark.h"
 
-#include <asm-generic/socket.h>
-#include <netinet/in.h>
-
 #include <cerrno>
 #include <cstdint>
 

--- a/cilium/socket_option_ip_transparent.cc
+++ b/cilium/socket_option_ip_transparent.cc
@@ -32,8 +32,8 @@ bool IpTransparentSocketOption::setOption(
 
   auto& cilium_calls = PrivilegedService::Singleton::get();
 
-  auto ipVersion = socket.ipVersion();
-  if (!ipVersion.has_value()) {
+  auto ip_version = socket.ipVersion();
+  if (!ip_version.has_value()) {
     ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
     return false;
   }
@@ -44,7 +44,7 @@ bool IpTransparentSocketOption::setOption(
   auto ip_socket_level = SOL_IP;
   auto ip_transparent_socket_option = IP_TRANSPARENT;
   auto ip_transparent_socket_option_name = "IP_TRANSPARENT";
-  if (*ipVersion == Network::Address::IpVersion::v6) {
+  if (*ip_version == Network::Address::IpVersion::v6) {
     ip_socket_level = SOL_IPV6;
     ip_transparent_socket_option = IPV6_TRANSPARENT;
     ip_transparent_socket_option_name = "IPV6_TRANSPARENT";

--- a/cilium/socket_option_source_address.cc
+++ b/cilium/socket_option_source_address.cc
@@ -1,15 +1,19 @@
 #include "cilium/socket_option_source_address.h"
 
+#include <sys/socket.h>
+
 #include <cstdint>
 #include <utility>
 #include <vector>
 
+#include "envoy/api/os_sys_calls_common.h"
 #include "envoy/config/core/v3/socket_option.pb.h"
 #include "envoy/network/address.h"
 #include "envoy/network/socket.h"
 
 #include "source/common/common/hex.h"
 #include "source/common/common/logger.h"
+#include "source/common/common/utility.h"
 
 #include "absl/numeric/int128.h"
 

--- a/cilium/socket_option_source_address.cc
+++ b/cilium/socket_option_source_address.cc
@@ -47,8 +47,8 @@ bool SourceAddressSocketOption::setOption(
     return true;
   }
 
-  auto ipVersion = socket.ipVersion();
-  if (!ipVersion.has_value()) {
+  auto ip_version = socket.ipVersion();
+  if (!ip_version.has_value()) {
     ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
     return false;
   }
@@ -57,7 +57,7 @@ bool SourceAddressSocketOption::setOption(
   if (!source_address && (ipv4_source_address_ || ipv6_source_address_)) {
     // Select source address based on the socket address family
     source_address = ipv6_source_address_;
-    if (*ipVersion == Network::Address::IpVersion::v4) {
+    if (*ip_version == Network::Address::IpVersion::v4) {
       source_address = ipv4_source_address_;
     }
   }

--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -44,7 +44,7 @@ class SslSocketWrapper : public Network::TransportSocket, Logger::Loggable<Logge
 public:
   SslSocketWrapper(Extensions::TransportSockets::Tls::InitialState state,
                    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options)
-      : state_(state), transport_socket_options_(transport_socket_options), callbacks_() {}
+      : state_(state), transport_socket_options_(transport_socket_options) {}
 
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override {
@@ -211,7 +211,7 @@ private:
   Extensions::TransportSockets::Tls::InitialState state_;
   const Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   Network::TransportSocketPtr socket_{nullptr};
-  Network::TransportSocketCallbacks* callbacks_;
+  Network::TransportSocketCallbacks* callbacks_{};
 };
 
 class ClientSslSocketFactory : public Network::CommonUpstreamTransportSocketFactory {

--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -158,7 +158,7 @@ public:
       } else {
         policy.tlsWrapperMissingPolicyInc();
 
-        std::string ipStr("<none>");
+        std::string ip_str("<none>");
         if (policy_fs->ingress_) {
           Network::Address::InstanceConstSharedPtr src_address =
               is_client ? callbacks_->connection().connectionInfoProvider().localAddress()
@@ -166,12 +166,12 @@ public:
           if (src_address) {
             const auto sip = src_address->ip();
             if (sip) {
-              ipStr = sip->addressAsString();
+              ip_str = sip->addressAsString();
             }
           }
         } else {
           if (dip) {
-            ipStr = dip->addressAsString();
+            ip_str = dip->addressAsString();
           }
         }
         ENVOY_CONN_LOG(
@@ -179,7 +179,7 @@ public:
             "cilium.tls_wrapper: Could not get {} TLS context for pod {} on {} IP {} (id {}) port "
             "{} sni \"{}\" and raw socket is not allowed",
             conn, is_client ? "client" : "server", policy_fs->pod_ip_,
-            policy_fs->ingress_ ? "source" : "destination", ipStr, remote_id, destination_port,
+            policy_fs->ingress_ ? "source" : "destination", ip_str, remote_id, destination_port,
             sni);
       }
     } else {

--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -87,7 +87,7 @@ public:
     // configuration.
     // Cilium socket option is only created if the (initial) policy for the local pod exists.
     // If the policy requires TLS then a TLS socket is used, but if the policy does not require
-    // TLS a raw socket is used instead,
+    // TLS a raw socket is used instead.
     auto& conn = callbacks_->connection();
 
     ENVOY_CONN_LOG(trace, "retrieving policy filter state", conn);

--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -21,7 +21,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/network/raw_buffer_socket.h"
 #include "source/common/network/transport_socket_options_impl.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/tls/ssl_socket.h"
 
 #include "absl/status/statusor.h"

--- a/cilium/tls_wrapper.h
+++ b/cilium/tls_wrapper.h
@@ -8,7 +8,7 @@
 #include "envoy/server/transport_socket_config.h"
 #include "envoy/stats/stats_macros.h" // IWYU pragma: keep
 
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+#include "source/common/protobuf/protobuf.h"
 
 #include "absl/status/statusor.h"
 

--- a/cilium/uds_client.cc
+++ b/cilium/uds_client.cc
@@ -43,15 +43,16 @@ UDSClient::~UDSClient() {
   fd_mutex_.unlock();
 }
 
-void UDSClient::Log(const std::string& msg) {
+void UDSClient::log(const std::string& msg) {
   {
     int tries = 2;
     ssize_t length = msg.length();
 
     Thread::LockGuard guard(fd_mutex_);
     while (tries-- > 0) {
-      if (!try_connect())
+      if (!tryConnect()) {
         continue; // retry
+      }
 
       ssize_t sent = ::send(fd_, msg.data(), length, MSG_DONTWAIT | MSG_EOR | MSG_NOSIGNAL);
       if (sent == -1) {
@@ -74,7 +75,7 @@ void UDSClient::Log(const std::string& msg) {
   fd_mutex_.unlock();
 }
 
-bool UDSClient::try_connect() {
+bool UDSClient::tryConnect() {
   if (fd_ != -1) {
     if (errno_ == 0) {
       return true;

--- a/cilium/uds_client.cc
+++ b/cilium/uds_client.cc
@@ -1,12 +1,11 @@
 #include "cilium/uds_client.h"
 
-#include <errno.h>
 #include <fmt/format.h>
-#include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <memory>
 #include <string>
 

--- a/cilium/uds_client.h
+++ b/cilium/uds_client.h
@@ -21,13 +21,13 @@ public:
   UDSClient(const std::string& path, TimeSource& time_source);
   ~UDSClient();
 
-  void Log(const std::string& msg);
+  void log(const std::string& msg);
 
   const std::string& asString() const { return addr_->asString(); }
   absl::string_view asStringView() const { return addr_->asStringView(); }
 
 private:
-  bool try_connect() ABSL_EXCLUSIVE_LOCKS_REQUIRED(fd_mutex_);
+  bool tryConnect() ABSL_EXCLUSIVE_LOCKS_REQUIRED(fd_mutex_);
 
   Thread::MutexBasicLockable fd_mutex_;
   std::shared_ptr<Network::Address::PipeInstance> addr_;

--- a/cilium/websocket.cc
+++ b/cilium/websocket.cc
@@ -1,7 +1,5 @@
 #include "cilium/websocket.h"
 
-#include <http_parser.h>
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -18,7 +16,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/http/headers.h"
 #include "source/common/network/utility.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/utility.h"
 #include "source/common/stream_info/bool_accessor_impl.h"
 #include "source/common/tcp_proxy/tcp_proxy.h"

--- a/cilium/websocket.cc
+++ b/cilium/websocket.cc
@@ -168,7 +168,7 @@ Network::FilterStatus Instance::onNewConnection() {
     destination_identity = 0;
   }
   // Initialize the log entry
-  log_entry_.InitFromConnection(pod_ip, proxy_id, is_ingress, identity,
+  log_entry_.initFromConnection(pod_ip, proxy_id, is_ingress, identity,
                                 callbacks_->connection().connectionInfoProvider().remoteAddress(),
                                 destination_identity, dst_address, &config_->time_source_);
 
@@ -258,7 +258,7 @@ void Instance::onHandshakeRequest(const Http::RequestHeaderMap& headers) {
   }
 
   // Initialize the log entry
-  log_entry_.UpdateFromRequest(destination_identity, orig_dst_address, headers);
+  log_entry_.updateFromRequest(destination_identity, orig_dst_address, headers);
 }
 
 } // namespace WebSocket

--- a/cilium/websocket.h
+++ b/cilium/websocket.h
@@ -38,24 +38,24 @@ public:
   // WebSocket::CodecCallbacks
   const ConfigSharedPtr& config() override { return config_; }
   void onHandshakeCreated(const Http::RequestHeaderMap& headers) override {
-    log_entry_.UpdateFromRequest(0, nullptr, headers);
+    log_entry_.updateFromRequest(0, nullptr, headers);
   }
-  void onHandshakeSent() override { config_->Log(log_entry_, ::cilium::EntryType::Request); }
+  void onHandshakeSent() override { config_->log(log_entry_, ::cilium::EntryType::Request); }
   void onHandshakeRequest(const Http::RequestHeaderMap& headers) override;
   void onHandshakeResponse(const Http::ResponseHeaderMap& headers) override {
-    log_entry_.UpdateFromResponse(headers, config_->time_source_);
-    config_->Log(log_entry_, ::cilium::EntryType::Response);
+    log_entry_.updateFromResponse(headers, config_->time_source_);
+    config_->log(log_entry_, ::cilium::EntryType::Response);
   }
   void onHandshakeResponseSent(const Http::ResponseHeaderMap& headers) override {
     bool accepted = headers.Status() && headers.getStatusValue() == "101";
     if (accepted) {
-      config_->Log(log_entry_, ::cilium::EntryType::Request);
+      config_->log(log_entry_, ::cilium::EntryType::Request);
     } else {
-      config_->Log(log_entry_, ::cilium::EntryType::Denied);
+      config_->log(log_entry_, ::cilium::EntryType::Denied);
       config_->stats_.access_denied_.inc();
     }
-    log_entry_.UpdateFromResponse(headers, config_->time_source_);
-    config_->Log(log_entry_, ::cilium::EntryType::Response);
+    log_entry_.updateFromResponse(headers, config_->time_source_);
+    config_->log(log_entry_, ::cilium::EntryType::Response);
   }
 
   void injectEncoded(Buffer::Instance& data, bool end_stream) override;

--- a/cilium/websocket_codec.cc
+++ b/cilium/websocket_codec.cc
@@ -102,7 +102,7 @@ public:
     return message_complete_;
   }
 
-  bool versionIsHttp1_1() {
+  bool versionIsHttp11() {
     ENVOY_LOG(trace, "websocket: http_parser got version major: {} minor: {}", parser_.http_major,
               parser_.http_minor);
     return parser_.http_major == 1 && parser_.http_minor == 1;
@@ -557,7 +557,7 @@ void Codec::decode(Buffer::Instance& data, bool end_stream) {
       const Http::ResponseHeaderMap& headers = parser.headers();
       parent_->onHandshakeResponse(headers);
 
-      if (!parser.versionIsHttp1_1()) {
+      if (!parser.versionIsHttp11()) {
         config->stats_.handshake_invalid_http_version_.inc();
         return closeOnError(handshake_buffer_, "unsupported HTTP protocol");
       }
@@ -603,7 +603,7 @@ void Codec::decode(Buffer::Instance& data, bool end_stream) {
       const Http::RequestHeaderMap& headers = parser.headers();
       parent_->onHandshakeRequest(headers);
 
-      if (!parser.versionIsHttp1_1()) {
+      if (!parser.versionIsHttp11()) {
         config->stats_.handshake_invalid_http_version_.inc();
         return closeOnError(handshake_buffer_, "unsupported HTTP protocol");
       }

--- a/cilium/websocket_codec.h
+++ b/cilium/websocket_codec.h
@@ -127,7 +127,7 @@ private:
   Buffer::OwnedImpl handshake_buffer_{};
   bool accepted_{false};
 };
-typedef std::unique_ptr<Codec> CodecPtr;
+using CodecPtr = std::unique_ptr<Codec>;
 
 } // namespace WebSocket
 } // namespace Cilium

--- a/cilium/websocket_config.cc
+++ b/cilium/websocket_config.cc
@@ -1,11 +1,9 @@
 #include "cilium/websocket_config.h"
 
-#include <http_parser.h>
 #include <openssl/digest.h>
 #include <openssl/sha.h>
 
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -21,7 +19,6 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/base64.h"
 #include "source/common/http/request_id_extension_impl.h"
-#include "source/common/protobuf/protobuf.h" // IWYU pragma: keep
 #include "source/common/protobuf/utility.h"
 
 #include "absl/strings/ascii.h"

--- a/cilium/websocket_config.cc
+++ b/cilium/websocket_config.cc
@@ -72,7 +72,7 @@ Config::Config(Server::Configuration::FactoryContext& context, bool client,
   }
 
   if (!access_log_path.empty()) {
-    access_log_ = AccessLog::Open(access_log_path, time_source_);
+    access_log_ = AccessLog::open(access_log_path, time_source_);
   }
 
   const uint64_t timeout = DurationUtil::durationToMilliseconds(handshake_timeout);
@@ -107,8 +107,8 @@ Config::Config(const ::cilium::WebSocketClient& config,
   }
   if (key_.empty()) {
     uint64_t random[2]; // 16 bytes
-    for (size_t i = 0; i < sizeof(random) / sizeof(random[0]); i++) {
-      random[i] = random_.random();
+    for (unsigned long& i : random) {
+      i = random_.random();
     }
     key_ = Base64::encode(reinterpret_cast<char*>(random), sizeof(random));
   }
@@ -128,9 +128,9 @@ std::string Config::keyResponse(absl::string_view key) {
   return Base64::encode(reinterpret_cast<char*>(sha1.data()), sha1.size());
 }
 
-void Config::Log(AccessLog::Entry& entry, ::cilium::EntryType type) {
+void Config::log(AccessLog::Entry& entry, ::cilium::EntryType type) {
   if (access_log_) {
-    access_log_->Log(entry, type);
+    access_log_->log(entry, type);
   }
 }
 

--- a/cilium/websocket_config.h
+++ b/cilium/websocket_config.h
@@ -68,7 +68,7 @@ public:
 
   static std::string keyResponse(absl::string_view key);
 
-  void Log(Cilium::AccessLog::Entry&, ::cilium::EntryType);
+  void log(Cilium::AccessLog::Entry&, ::cilium::EntryType);
 
   TimeSource& time_source_;
   Event::Dispatcher& dispatcher_;

--- a/cilium/websocket_config.h
+++ b/cilium/websocket_config.h
@@ -92,7 +92,7 @@ private:
   Cilium::AccessLogSharedPtr access_log_;
 };
 
-typedef std::shared_ptr<Config> ConfigSharedPtr;
+using ConfigSharedPtr = std::shared_ptr<Config>;
 
 } // namespace WebSocket
 } // namespace Cilium

--- a/tests/accesslog_server.cc
+++ b/tests/accesslog_server.cc
@@ -18,7 +18,7 @@ namespace Envoy {
 AccessLogServer::AccessLogServer(const std::string path)
     : UDSServer(path, std::bind(&AccessLogServer::msgCallback, this, std::placeholders::_1)) {}
 
-AccessLogServer::~AccessLogServer() {}
+AccessLogServer::~AccessLogServer() = default;
 
 void AccessLogServer::clear() {
   absl::MutexLock lock(&mutex_);

--- a/tests/accesslog_server.cc
+++ b/tests/accesslog_server.cc
@@ -1,7 +1,5 @@
 #include "tests/accesslog_server.h"
 
-#include <unistd.h>
-
 #include <chrono>
 #include <functional>
 #include <string>

--- a/tests/accesslog_server.h
+++ b/tests/accesslog_server.h
@@ -27,24 +27,27 @@ public:
   template <typename P>
   bool expectRequestTo(P&& pred, std::chrono::milliseconds timeout = TestUtility::DefaultTimeout) {
     auto maybe_entry = waitForMessage(::cilium::EntryType::Request, timeout);
-    if (maybe_entry.has_value())
+    if (maybe_entry.has_value()) {
       return pred(maybe_entry.value());
+    }
     return false;
   }
 
   template <typename P>
   bool expectResponseTo(P&& pred, std::chrono::milliseconds timeout = TestUtility::DefaultTimeout) {
     auto maybe_entry = waitForMessage(::cilium::EntryType::Response, timeout);
-    if (maybe_entry.has_value())
+    if (maybe_entry.has_value()) {
       return pred(maybe_entry.value());
+    }
     return false;
   }
 
   template <typename P>
   bool expectDeniedTo(P&& pred, std::chrono::milliseconds timeout = TestUtility::DefaultTimeout) {
     auto maybe_entry = waitForMessage(::cilium::EntryType::Denied, timeout);
-    if (maybe_entry.has_value())
+    if (maybe_entry.has_value()) {
       return pred(maybe_entry.value());
+    }
     return false;
   }
 

--- a/tests/accesslog_test.cc
+++ b/tests/accesslog_test.cc
@@ -38,7 +38,7 @@ TEST_F(CiliumTest, AccessLog) {
 
   AccessLog::Entry log;
 
-  log.InitFromRequest("1.2.3.4", 42, true, 1, source_address, 173, destination_address,
+  log.initFromRequest("1.2.3.4", 42, true, 1, source_address, 173, destination_address,
                       connection.stream_info_, headers);
 
   EXPECT_EQ(log.entry_.is_ingress(), true);
@@ -67,7 +67,7 @@ TEST_F(CiliumTest, AccessLog) {
   Http::TestResponseHeaderMapImpl response_headers{{"my-response-header", "response"}};
 
   NiceMock<Event::SimulatedTimeSystem> time_source;
-  log.UpdateFromResponse(response_headers, time_source);
+  log.updateFromResponse(response_headers, time_source);
 
   // Unmodified
   EXPECT_EQ(log.entry_.has_http(), true);

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -80,8 +80,8 @@ createPolicyMap(const std::string& config,
                 Server::Configuration::FactoryContext& context) {
   return context.serverFactoryContext().singletonManager().getTyped<const Cilium::NetworkPolicyMap>(
       "cilium_network_policy_singleton", [&config, &secret_configs, &context] {
-        if (secret_configs.size() > 0) {
-          for (auto sds_pair : secret_configs) {
+        if (!secret_configs.empty()) {
+          for (const auto& sds_pair : secret_configs) {
             auto& name = sds_pair.first;
             auto& sds_config = sds_pair.second;
             std::string sds_path = TestEnvironment::writeStringToFileForTest(
@@ -190,9 +190,9 @@ TestConfig::extractSocketMetadata(Network::ConnectionSocket& socket) {
   policy.useProxylib(is_ingress_, proxy_id_, is_ingress_ ? source_identity : destination_identity,
                      port, l7proto);
 
-  return absl::optional(Cilium::BpfMetadata::SocketMetadata(
+  return {Cilium::BpfMetadata::SocketMetadata(
       0, 0, source_identity, is_ingress_, is_l7lb_, port, std::move(pod_ip), "", nullptr, nullptr,
-      nullptr, original_dst_address, shared_from_this(), 0, std::move(l7proto), ""));
+      nullptr, original_dst_address, shared_from_this(), 0, std::move(l7proto), "")};
 }
 
 } // namespace BpfMetadata

--- a/tests/bpf_metadata.h
+++ b/tests/bpf_metadata.h
@@ -36,7 +36,7 @@ class TestConfig : public Config {
 public:
   TestConfig(const ::cilium::TestBpfMetadata& config,
              Server::Configuration::ListenerFactoryContext& context);
-  ~TestConfig();
+  ~TestConfig() override;
 
   absl::optional<Cilium::BpfMetadata::SocketMetadata>
   extractSocketMetadata(Network::ConnectionSocket& socket) override;

--- a/tests/cilium_http_integration.cc
+++ b/tests/cilium_http_integration.cc
@@ -7,7 +7,7 @@
 #include <memory>
 #include <string>
 
-#include "envoy/http/codec.h"
+#include "envoy/http/codec.h" // IWYU pragma: keep
 #include "envoy/network/address.h"
 
 #include "source/common/common/base_logger.h"

--- a/tests/cilium_http_integration.cc
+++ b/tests/cilium_http_integration.cc
@@ -33,7 +33,7 @@ CiliumHttpIntegrationTest::CiliumHttpIntegrationTest(const std::string& config)
 #endif
 }
 
-CiliumHttpIntegrationTest::~CiliumHttpIntegrationTest() {}
+CiliumHttpIntegrationTest::~CiliumHttpIntegrationTest() = default;
 
 void CiliumHttpIntegrationTest::createEnvoy() {
   // fake upstreams have been created by now, use the port from the 1st upstream

--- a/tests/cilium_http_integration.cc
+++ b/tests/cilium_http_integration.cc
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include "envoy/http/codec.h"
 #include "envoy/network/address.h"
 
 #include "source/common/common/base_logger.h"

--- a/tests/cilium_http_integration.h
+++ b/tests/cilium_http_integration.h
@@ -26,7 +26,7 @@ class CiliumHttpIntegrationTest : public HttpIntegrationTest,
                                   public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   CiliumHttpIntegrationTest(const std::string& config);
-  ~CiliumHttpIntegrationTest();
+  ~CiliumHttpIntegrationTest() override;
 
   void createEnvoy() override;
 
@@ -63,8 +63,9 @@ public:
   getHeader(const Protobuf::RepeatedPtrField<::cilium::KeyValue>& headers,
             const std::string& name) {
     for (const auto& entry : headers) {
-      if (Http::LowerCaseString(entry.key()) == Http::LowerCaseString(name))
+      if (Http::LowerCaseString(entry.key()) == Http::LowerCaseString(name)) {
         return entry.value();
+      }
     }
     return absl::nullopt;
   }
@@ -73,8 +74,9 @@ public:
                         const std::string& name, const std::string& value = "") {
     for (const auto& entry : headers) {
       if (Http::LowerCaseString(entry.key()) == Http::LowerCaseString(name) &&
-          (value == "" || entry.value() == value))
+          (value.empty() || entry.value() == value)) {
         return true;
+      }
     }
     return false;
   }

--- a/tests/cilium_http_integration_test.cc
+++ b/tests/cilium_http_integration_test.cc
@@ -316,7 +316,7 @@ public:
     }
   }
 
-  void Denied(Http::TestRequestHeaderMapImpl&& headers) {
+  void denied(Http::TestRequestHeaderMapImpl&& headers) {
     initialize();
     codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response = codec_client_->makeHeaderOnlyRequest(headers);
@@ -345,7 +345,7 @@ public:
     cleanupUpstreamAndDownstream();
   }
 
-  void Accepted(Http::TestRequestHeaderMapImpl&& headers) {
+  void accepted(Http::TestRequestHeaderMapImpl&& headers) {
     initialize();
     codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response = sendRequestAndWaitForResponse(headers, 0, default_response_headers_, 0);
@@ -390,7 +390,7 @@ public:
 
   std::string testPolicyFmt() override { return "version_info: \"0\""; }
 
-  void InvalidHostMap(const std::string& config, const char* exmsg) {
+  void invalidHostMap(const std::string& config, const char* exmsg) {
     std::string path = TestEnvironment::writeStringToFileForTest("host_map_fail.yaml", config);
     envoy::service::discovery::v3::DiscoveryResponse message;
     ThreadLocal::InstanceImpl tls;
@@ -468,7 +468,7 @@ resources:
 
 TEST_P(HostMapTest, HostMapInvalidNonCIDRBits) {
   if (GetParam() == Network::Address::IpVersion::v4) {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -476,7 +476,7 @@ resources:
 )EOF",
                    "NetworkPolicyHosts: Non-prefix bits set in '127.0.0.1/31'");
   } else {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -488,7 +488,7 @@ resources:
 
 TEST_P(HostMapTest, HostMapInvalidPrefixLengths) {
   if (GetParam() == Network::Address::IpVersion::v4) {
-    InvalidHostMap(
+    invalidHostMap(
         R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
@@ -497,7 +497,7 @@ resources:
 )EOF",
         "NetworkPolicyHosts: Invalid prefix length in '127.0.0.1/33'");
   } else {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -509,7 +509,7 @@ resources:
 
 TEST_P(HostMapTest, HostMapInvalidPrefixLengths2) {
   if (GetParam() == Network::Address::IpVersion::v4) {
-    InvalidHostMap(
+    invalidHostMap(
         R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
@@ -518,7 +518,7 @@ resources:
 )EOF",
         "NetworkPolicyHosts: Invalid prefix length in '127.0.0.1/32a'");
   } else {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -530,7 +530,7 @@ resources:
 
 TEST_P(HostMapTest, HostMapInvalidPrefixLengths3) {
   if (GetParam() == Network::Address::IpVersion::v4) {
-    InvalidHostMap(
+    invalidHostMap(
         R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
@@ -539,7 +539,7 @@ resources:
 )EOF",
         "NetworkPolicyHosts: Invalid prefix length in '127.0.0.1/ 32'");
   } else {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -551,7 +551,7 @@ resources:
 
 TEST_P(HostMapTest, HostMapDuplicateEntry) {
   if (GetParam() == Network::Address::IpVersion::v4) {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -560,7 +560,7 @@ resources:
                    "NetworkPolicyHosts: Duplicate host entry '127.0.0.1' for "
                    "policy 11, already mapped to 11");
   } else {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -573,7 +573,7 @@ resources:
 
 TEST_P(HostMapTest, HostMapDuplicateEntry2) {
   if (GetParam() == Network::Address::IpVersion::v4) {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -585,7 +585,7 @@ resources:
                    "NetworkPolicyHosts: Duplicate host entry '127.0.0.1' for "
                    "policy 12, already mapped to 11");
   } else {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -601,7 +601,7 @@ resources:
 
 TEST_P(HostMapTest, HostMapInvalidAddress) {
   if (GetParam() == Network::Address::IpVersion::v4) {
-    InvalidHostMap(
+    invalidHostMap(
         R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
@@ -610,7 +610,7 @@ resources:
 )EOF",
         "NetworkPolicyHosts: Invalid host entry '255.256.0.0' for policy 11");
   } else {
-    InvalidHostMap(
+    invalidHostMap(
         R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
@@ -623,7 +623,7 @@ resources:
 
 TEST_P(HostMapTest, HostMapInvalidAddress2) {
   if (GetParam() == Network::Address::IpVersion::v4) {
-    InvalidHostMap(
+    invalidHostMap(
         R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
@@ -632,7 +632,7 @@ resources:
 )EOF",
         "NetworkPolicyHosts: Invalid host entry '255.255.0.0 ' for policy 11");
   } else {
-    InvalidHostMap(
+    invalidHostMap(
         R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
@@ -645,7 +645,7 @@ resources:
 
 TEST_P(HostMapTest, HostMapInvalidDefaults) {
   if (GetParam() == Network::Address::IpVersion::v4) {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -653,7 +653,7 @@ resources:
 )EOF",
                    "NetworkPolicyHosts: Non-prefix bits set in '128.0.0.0/0'");
   } else {
-    InvalidHostMap(R"EOF(version_info: "0"
+    invalidHostMap(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicyHosts
   policy: 11
@@ -664,7 +664,7 @@ resources:
 }
 
 TEST_P(CiliumIntegrationTest, DeniedPathPrefix) {
-  Denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -674,7 +674,7 @@ TEST_P(CiliumIntegrationTest, DeniedPathPrefix) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedPathPrefix) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "host"},
             {"bearer-token", "d4ef0f5011f163ac"}});
@@ -689,7 +689,7 @@ TEST_P(CiliumIntegrationTest, AllowedPathPrefix) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedPathPrefixWrongHeader) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "host"},
             {"bearer-token", "wrong-value"},
@@ -711,7 +711,7 @@ TEST_P(CiliumIntegrationTest, AllowedPathPrefixWrongHeader) {
 
 TEST_P(CiliumIntegrationTest, MultipleRequests) {
   // 1st request
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "host"},
             {"bearer-token", "d4ef0f5011f163ac"}});
@@ -725,7 +725,7 @@ TEST_P(CiliumIntegrationTest, MultipleRequests) {
   }));
 
   // 2nd request
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "host"},
             {"bearer-token", "wrong-value"},
@@ -746,7 +746,7 @@ TEST_P(CiliumIntegrationTest, MultipleRequests) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedPathRegex) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/public"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/public"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -756,7 +756,7 @@ TEST_P(CiliumIntegrationTest, AllowedPathRegex) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedPathRegexDeleteHeader) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/maybe/public"},
             {":authority", "host"},
             {"User-Agent", "test"}});
@@ -771,7 +771,7 @@ TEST_P(CiliumIntegrationTest, AllowedPathRegexDeleteHeader) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedHostRegexDeleteHeader) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/maybe/private"},
             {":authority", "hostREGEXname"},
             {"header42", "test"}});
@@ -787,7 +787,7 @@ TEST_P(CiliumIntegrationTest, AllowedHostRegexDeleteHeader) {
 }
 
 TEST_P(CiliumIntegrationTest, DeniedPath) {
-  Denied({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -797,7 +797,7 @@ TEST_P(CiliumIntegrationTest, DeniedPath) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedHostString) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "allowedHOST"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "allowedHOST"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -810,7 +810,7 @@ TEST_P(CiliumIntegrationTest, AllowedHostString) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedReplaced) {
-  Accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "allowedHOST"}});
+  accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "allowedHOST"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -825,7 +825,7 @@ TEST_P(CiliumIntegrationTest, AllowedReplaced) {
 }
 
 TEST_P(CiliumIntegrationTest, Denied42) {
-  Denied({{":method", "GET"},
+  denied({{":method", "GET"},
           {":path", "/allowed"},
           {":authority", "host"},
           {"header42", "anything"}});
@@ -843,7 +843,7 @@ TEST_P(CiliumIntegrationTest, Denied42) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedReplacedAndDeleted) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "allowedHOST"},
             {"header42", "anything"}});
@@ -862,7 +862,7 @@ TEST_P(CiliumIntegrationTest, AllowedReplacedAndDeleted) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedHostRegex) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "hostREGEXname"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "hostREGEXname"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -872,7 +872,7 @@ TEST_P(CiliumIntegrationTest, AllowedHostRegex) {
 }
 
 TEST_P(CiliumIntegrationTest, DeniedMethod) {
-  Denied({{":method", "POST"}, {":path", "/maybe/private"}, {":authority", "host"}});
+  denied({{":method", "POST"}, {":path", "/maybe/private"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -882,7 +882,7 @@ TEST_P(CiliumIntegrationTest, DeniedMethod) {
 }
 
 TEST_P(CiliumIntegrationTest, AcceptedMethod) {
-  Accepted({{":method", "PUT"}, {":path", "/public/opinions"}, {":authority", "host"}});
+  accepted({{":method", "PUT"}, {":path", "/public/opinions"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -892,7 +892,7 @@ TEST_P(CiliumIntegrationTest, AcceptedMethod) {
 }
 
 TEST_P(CiliumIntegrationTest, L3DeniedPath) {
-  Denied({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -903,9 +903,9 @@ TEST_P(CiliumIntegrationTest, L3DeniedPath) {
 
 class CiliumIntegrationPortTest : public CiliumIntegrationTest {
 public:
-  CiliumIntegrationPortTest() : CiliumIntegrationTest() {}
+  CiliumIntegrationPortTest() = default;
 
-  std::string testPolicyFmt() {
+  std::string testPolicyFmt() override {
     return TestEnvironment::substitute(R"EOF(version_info: "0"
 resources:
 - "@type": type.googleapis.com/cilium.NetworkPolicy
@@ -949,18 +949,18 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, CiliumIntegrationPortTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(CiliumIntegrationPortTest, DuplicatePortAllowedPath) {
-  Accepted({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationPortTest, DuplicatePortAllowedPath2) {
-  Accepted({{":method", "GET"}, {":path", "/also-2-allowed"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/also-2-allowed"}, {":authority", "host"}});
 }
 
 class CiliumIntegrationPortRangeTest : public CiliumIntegrationTest {
 public:
-  CiliumIntegrationPortRangeTest() : CiliumIntegrationTest() {}
+  CiliumIntegrationPortRangeTest() = default;
 
-  std::string testPolicyFmt() {
+  std::string testPolicyFmt() override {
     return TestEnvironment::substitute(BASIC_POLICY_fmt + R"EOF(  - end_port: {0}
     rules:
     - remote_policies: [ 2 ]
@@ -1017,39 +1017,39 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, CiliumIntegrationEgressTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(CiliumIntegrationEgressTest, DeniedPathPrefix) {
-  Denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AllowedPathPrefix) {
-  Accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AllowedPathRegex) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/public"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/public"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, DeniedPath) {
-  Denied({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AllowedHostString) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "allowedHOST"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "allowedHOST"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AllowedHostRegex) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "hostREGEXname"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "hostREGEXname"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, DeniedMethod) {
-  Denied({{":method", "POST"}, {":path", "/maybe/private"}, {":authority", "host"}});
+  denied({{":method", "POST"}, {":path", "/maybe/private"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AcceptedMethod) {
-  Accepted({{":method", "PUT"}, {":path", "/public/opinions"}, {":authority", "host"}});
+  accepted({{":method", "PUT"}, {":path", "/public/opinions"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, L3DeniedPath) {
-  Denied({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
 }
 
 const std::string L34_POLICY_fmt = R"EOF(version_info: "0"
@@ -1067,20 +1067,22 @@ resources:
 
 class CiliumIntegrationEgressL34Test : public CiliumIntegrationEgressTest {
 public:
-  CiliumIntegrationEgressL34Test() {}
+  CiliumIntegrationEgressL34Test() = default;
 
-  std::string testPolicyFmt() { return TestEnvironment::substitute(L34_POLICY_fmt, GetParam()); }
+  std::string testPolicyFmt() override {
+    return TestEnvironment::substitute(L34_POLICY_fmt, GetParam());
+  }
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, CiliumIntegrationEgressL34Test,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(CiliumIntegrationEgressL34Test, DeniedPathPrefix) {
-  Denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressL34Test, DeniedPathPrefix2) {
-  Denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 }
 
 const std::string HEADER_ACTION_MISSING_SDS_POLICY_fmt = R"EOF(version_info: "1"
@@ -1132,7 +1134,7 @@ resources:
 
 class SDSIntegrationTest : public CiliumIntegrationTest {
 public:
-  SDSIntegrationTest() : CiliumIntegrationTest() {
+  SDSIntegrationTest() {
     // switch back to SDS secrets so that we can test with a missing secret.
     // File based secret fails if the file does not exist, while SDS should allow for secret to be
     // created in future.
@@ -1169,7 +1171,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, SDSIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(SDSIntegrationTest, TestDeniedL3) {
-  Denied({{":method", "GET"}, {":path", "/only42"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/only42"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -1186,7 +1188,7 @@ TEST_P(SDSIntegrationTest, TestDeniedL3) {
 }
 
 TEST_P(SDSIntegrationTest, TestDeniedL3SpoofedXFF) {
-  Denied({{":method", "GET"},
+  denied({{":method", "GET"},
           {":path", "/only42"},
           {":authority", "host"},
           {"x-forwarded-for", "192.168.1.1"}});
@@ -1207,7 +1209,7 @@ TEST_P(SDSIntegrationTest, TestDeniedL3SpoofedXFF) {
 }
 
 TEST_P(SDSIntegrationTest, TestMissingSDSSecretOnUpdate) {
-  Accepted({{":method", "GET"}, {":path", "/allowed2"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/allowed2"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -1235,7 +1237,7 @@ TEST_P(SDSIntegrationTest, TestMissingSDSSecretOnUpdate) {
   absl::SleepFor(absl::Milliseconds(100));
 
   // 2nd round, on updated policy
-  Denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -1258,7 +1260,7 @@ TEST_P(SDSIntegrationTest, TestMissingSDSSecretOnUpdate) {
   // Reduce flakiness by allowing some time for the policy to be updated before the following test
   absl::SleepFor(absl::Milliseconds(100));
 
-  Denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {

--- a/tests/cilium_http_upstream_integration_test.cc
+++ b/tests/cilium_http_upstream_integration_test.cc
@@ -353,7 +353,7 @@ resources:
     }
   }
 
-  void Denied(Http::TestRequestHeaderMapImpl&& headers) {
+  void denied(Http::TestRequestHeaderMapImpl&& headers) {
     initialize();
     codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response = codec_client_->makeHeaderOnlyRequest(headers);
@@ -382,7 +382,7 @@ resources:
     cleanupUpstreamAndDownstream();
   }
 
-  void Accepted(Http::TestRequestHeaderMapImpl&& headers) {
+  void accepted(Http::TestRequestHeaderMapImpl&& headers) {
     initialize();
     codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response = sendRequestAndWaitForResponse(headers, 0, default_response_headers_, 0);
@@ -419,7 +419,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, CiliumIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(CiliumIntegrationTest, DeniedPathPrefix) {
-  Denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -429,7 +429,7 @@ TEST_P(CiliumIntegrationTest, DeniedPathPrefix) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedPathPrefix) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "host"},
             {"bearer-token", "d4ef0f5011f163ac"}});
@@ -444,7 +444,7 @@ TEST_P(CiliumIntegrationTest, AllowedPathPrefix) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedPathPrefixWrongHeader) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "host"},
             {"bearer-token", "wrong-value"},
@@ -466,7 +466,7 @@ TEST_P(CiliumIntegrationTest, AllowedPathPrefixWrongHeader) {
 
 TEST_P(CiliumIntegrationTest, MultipleRequests) {
   // 1st request
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "host"},
             {"bearer-token", "d4ef0f5011f163ac"}});
@@ -480,7 +480,7 @@ TEST_P(CiliumIntegrationTest, MultipleRequests) {
   }));
 
   // 2nd request
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "host"},
             {"bearer-token", "wrong-value"},
@@ -501,7 +501,7 @@ TEST_P(CiliumIntegrationTest, MultipleRequests) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedPathRegex) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/public"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/public"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -511,7 +511,7 @@ TEST_P(CiliumIntegrationTest, AllowedPathRegex) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedPathRegexDeleteHeader) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/maybe/public"},
             {":authority", "host"},
             {"User-Agent", "test"}});
@@ -526,7 +526,7 @@ TEST_P(CiliumIntegrationTest, AllowedPathRegexDeleteHeader) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedHostRegexDeleteHeader) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/maybe/private"},
             {":authority", "hostREGEXname"},
             {"header42", "test"}});
@@ -542,7 +542,7 @@ TEST_P(CiliumIntegrationTest, AllowedHostRegexDeleteHeader) {
 }
 
 TEST_P(CiliumIntegrationTest, DeniedPath) {
-  Denied({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -552,7 +552,7 @@ TEST_P(CiliumIntegrationTest, DeniedPath) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedHostString) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "allowedHOST"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "allowedHOST"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -565,7 +565,7 @@ TEST_P(CiliumIntegrationTest, AllowedHostString) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedReplaced) {
-  Accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "allowedHOST"}});
+  accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "allowedHOST"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -580,7 +580,7 @@ TEST_P(CiliumIntegrationTest, AllowedReplaced) {
 }
 
 TEST_P(CiliumIntegrationTest, Denied42) {
-  Denied({{":method", "GET"},
+  denied({{":method", "GET"},
           {":path", "/allowed"},
           {":authority", "host"},
           {"header42", "anything"}});
@@ -598,7 +598,7 @@ TEST_P(CiliumIntegrationTest, Denied42) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedReplacedAndDeleted) {
-  Accepted({{":method", "GET"},
+  accepted({{":method", "GET"},
             {":path", "/allowed"},
             {":authority", "allowedHOST"},
             {"header42", "anything"}});
@@ -617,7 +617,7 @@ TEST_P(CiliumIntegrationTest, AllowedReplacedAndDeleted) {
 }
 
 TEST_P(CiliumIntegrationTest, AllowedHostRegex) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "hostREGEXname"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "hostREGEXname"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -627,7 +627,7 @@ TEST_P(CiliumIntegrationTest, AllowedHostRegex) {
 }
 
 TEST_P(CiliumIntegrationTest, DeniedMethod) {
-  Denied({{":method", "POST"}, {":path", "/maybe/private"}, {":authority", "host"}});
+  denied({{":method", "POST"}, {":path", "/maybe/private"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -637,7 +637,7 @@ TEST_P(CiliumIntegrationTest, DeniedMethod) {
 }
 
 TEST_P(CiliumIntegrationTest, AcceptedMethod) {
-  Accepted({{":method", "PUT"}, {":path", "/public/opinions"}, {":authority", "host"}});
+  accepted({{":method", "PUT"}, {":path", "/public/opinions"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -647,7 +647,7 @@ TEST_P(CiliumIntegrationTest, AcceptedMethod) {
 }
 
 TEST_P(CiliumIntegrationTest, L3DeniedPath) {
-  Denied({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -678,39 +678,39 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, CiliumIntegrationEgressTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(CiliumIntegrationEgressTest, DeniedPathPrefix) {
-  Denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AllowedPathPrefix) {
-  Accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AllowedPathRegex) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/public"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/public"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, DeniedPath) {
-  Denied({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AllowedHostString) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "allowedHOST"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "allowedHOST"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AllowedHostRegex) {
-  Accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "hostREGEXname"}});
+  accepted({{":method", "GET"}, {":path", "/maybe/private"}, {":authority", "hostREGEXname"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, DeniedMethod) {
-  Denied({{":method", "POST"}, {":path", "/maybe/private"}, {":authority", "host"}});
+  denied({{":method", "POST"}, {":path", "/maybe/private"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, AcceptedMethod) {
-  Accepted({{":method", "PUT"}, {":path", "/public/opinions"}, {":authority", "host"}});
+  accepted({{":method", "PUT"}, {":path", "/public/opinions"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressTest, L3DeniedPath) {
-  Denied({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/only-2-allowed"}, {":authority", "host"}});
 }
 
 const std::string L34_POLICY_fmt = R"EOF(version_info: "0"
@@ -728,20 +728,22 @@ resources:
 
 class CiliumIntegrationEgressL34Test : public CiliumIntegrationEgressTest {
 public:
-  CiliumIntegrationEgressL34Test() {}
+  CiliumIntegrationEgressL34Test() = default;
 
-  std::string testPolicyFmt() { return TestEnvironment::substitute(L34_POLICY_fmt, GetParam()); }
+  std::string testPolicyFmt() override {
+    return TestEnvironment::substitute(L34_POLICY_fmt, GetParam());
+  }
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, CiliumIntegrationEgressL34Test,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(CiliumIntegrationEgressL34Test, DeniedPathPrefix) {
-  Denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/prefix"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumIntegrationEgressL34Test, DeniedPathPrefix2) {
-  Denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 }
 
 const std::string HEADER_ACTION_MISSING_SDS_POLICY_fmt = R"EOF(version_info: "1"
@@ -793,7 +795,7 @@ resources:
 
 class SDSIntegrationTest : public CiliumIntegrationTest {
 public:
-  SDSIntegrationTest() : CiliumIntegrationTest() {
+  SDSIntegrationTest() {
     // switch back to SDS secrets so that we can test with a missing secret.
     // File based secret fails if the file does not exist, while SDS should allow for secret to be
     // created in future.
@@ -830,7 +832,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, SDSIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 TEST_P(SDSIntegrationTest, TestDeniedL3) {
-  Denied({{":method", "GET"}, {":path", "/only42"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/only42"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -845,7 +847,7 @@ TEST_P(SDSIntegrationTest, TestDeniedL3) {
 }
 
 TEST_P(SDSIntegrationTest, TestDeniedL3SpoofedXFF) {
-  Denied({{":method", "GET"},
+  denied({{":method", "GET"},
           {":path", "/only42"},
           {":authority", "host"},
           {"x-forwarded-for", "192.168.1.1"}});
@@ -863,7 +865,7 @@ TEST_P(SDSIntegrationTest, TestDeniedL3SpoofedXFF) {
 }
 
 TEST_P(SDSIntegrationTest, TestMissingSDSSecretOnUpdate) {
-  Accepted({{":method", "GET"}, {":path", "/allowed2"}, {":authority", "host"}});
+  accepted({{":method", "GET"}, {":path", "/allowed2"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogRequestTo([](const ::cilium::LogEntry& entry) {
@@ -891,7 +893,7 @@ TEST_P(SDSIntegrationTest, TestMissingSDSSecretOnUpdate) {
   absl::SleepFor(absl::Milliseconds(100));
 
   // 2nd round, on updated policy
-  Denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {
@@ -911,7 +913,7 @@ TEST_P(SDSIntegrationTest, TestMissingSDSSecretOnUpdate) {
   // Reduce flakiness by allowing some time for the policy to be updated before the following test
   absl::SleepFor(absl::Milliseconds(100));
 
-  Denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}});
 
   // Validate that missing headers are access logged correctly
   EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry& entry) {

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -1895,7 +1895,7 @@ resources:
 
 TEST_F(CiliumNetworkPolicyTest, SNIPatternMatching) {
   // Test empty pattern
-  SNIPattern empty("");
+  SniPattern empty("");
   EXPECT_FALSE(empty.matches("example.com"));
   EXPECT_FALSE(empty.matches("EXAMPLE.COM"));
   EXPECT_FALSE(empty.matches("www.example.com"));
@@ -1903,7 +1903,7 @@ TEST_F(CiliumNetworkPolicyTest, SNIPatternMatching) {
   EXPECT_FALSE(empty.matches(""));
 
   // Test exact matches
-  SNIPattern exact("example.com");
+  SniPattern exact("example.com");
   EXPECT_TRUE(exact.matches("example.com"));
   EXPECT_TRUE(exact.matches("EXAMPLE.COM"));
   EXPECT_FALSE(exact.matches("www.example.com"));
@@ -1911,7 +1911,7 @@ TEST_F(CiliumNetworkPolicyTest, SNIPatternMatching) {
   EXPECT_FALSE(exact.matches(""));
 
   // Test wildcard matches
-  SNIPattern wild("*.example.com");
+  SniPattern wild("*.example.com");
   EXPECT_TRUE(wild.matches("foo.example.com"));
   EXPECT_TRUE(wild.matches("bar.example.com"));
   EXPECT_TRUE(wild.matches("FOO.EXAMPLE.COM"));
@@ -1921,7 +1921,7 @@ TEST_F(CiliumNetworkPolicyTest, SNIPatternMatching) {
   EXPECT_FALSE(wild.matches(""));
 
   // Test subdomain wildcard matches
-  SNIPattern subwild("*.sub.example.com");
+  SniPattern subwild("*.sub.example.com");
   EXPECT_TRUE(subwild.matches("foo.sub.example.com"));
   EXPECT_TRUE(subwild.matches("bar.sub.example.com"));
   EXPECT_FALSE(subwild.matches("sub.example.com"));
@@ -1929,7 +1929,7 @@ TEST_F(CiliumNetworkPolicyTest, SNIPatternMatching) {
   EXPECT_FALSE(subwild.matches("foo.bar.sub.example.com"));
 
   // Test subdomain double wildcard matches
-  SNIPattern double_wildcard("**.sub.example.com");
+  SniPattern double_wildcard("**.sub.example.com");
   EXPECT_TRUE(double_wildcard.matches("foo.sub.example.com"));
   EXPECT_TRUE(double_wildcard.matches("bar.sub.example.com"));
   EXPECT_FALSE(double_wildcard.matches("sub.example.com"));
@@ -1937,7 +1937,7 @@ TEST_F(CiliumNetworkPolicyTest, SNIPatternMatching) {
   EXPECT_TRUE(double_wildcard.matches("foo.bar.sub.example.com"));
 
   // Test with unsupported wildcard label
-  SNIPattern wildcard_label("*example.com");
+  SniPattern wildcard_label("*example.com");
   EXPECT_FALSE(wildcard_label.matches("foo.example.com"));
   EXPECT_FALSE(wildcard_label.matches("bar.example.com"));
   EXPECT_FALSE(wildcard_label.matches("FOO.EXAMPLE.COM"));

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -81,7 +81,7 @@ protected:
     NetworkPolicyDecoder network_policy_decoder;
     const auto decoded_resources_or_error = Config::DecodedResourcesWrapper::create(
         network_policy_decoder, message.resources(), message.version_info());
-    THROW_IF_NOT_OK(decoded_resources_or_error.status());
+    THROW_IF_NOT_OK_REF(decoded_resources_or_error.status());
     const auto decoded_resources = std::move(decoded_resources_or_error.value().get());
 
     EXPECT_TRUE(

--- a/tests/cilium_tls_http_integration_test.cc
+++ b/tests/cilium_tls_http_integration_test.cc
@@ -9,7 +9,7 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
-#include "envoy/http/codec.h"
+#include "envoy/http/codec.h" // IWYU pragma: keep
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/transport_socket.h"

--- a/tests/cilium_tls_http_integration_test.cc
+++ b/tests/cilium_tls_http_integration_test.cc
@@ -9,6 +9,7 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
+#include "envoy/http/codec.h"
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/transport_socket.h"

--- a/tests/cilium_tls_http_integration_test.cc
+++ b/tests/cilium_tls_http_integration_test.cc
@@ -240,12 +240,12 @@ public:
     Network::Address::InstanceConstSharedPtr address =
         Ssl::getSslAddress(version_, lookupPort("http"));
     context_ = createClientSslTransportSocketFactory(context_manager_, *api_);
-    Network::ClientConnectionPtr ssl_client_ = dispatcher_->createClientConnection(
+    Network::ClientConnectionPtr ssl_client = dispatcher_->createClientConnection(
         address, Network::Address::InstanceConstSharedPtr(),
         context_->createTransportSocket(nullptr, nullptr), nullptr, nullptr);
 
-    ssl_client_->enableHalfClose(true);
-    codec_client_ = makeHttpConnection(std::move(ssl_client_));
+    ssl_client->enableHalfClose(true);
+    codec_client_ = makeHttpConnection(std::move(ssl_client));
   }
 
   void createUpstreams() override {

--- a/tests/cilium_tls_integration.cc
+++ b/tests/cilium_tls_integration.cc
@@ -40,11 +40,13 @@ createClientSslTransportSocketFactory(Ssl::ContextManager& context_manager, Api:
   ON_CALL(mock_factory_ctx.server_context_, api()).WillByDefault(testing::ReturnRef(api));
   auto cfg_or_error = Extensions::TransportSockets::Tls::ClientContextConfigImpl::create(
       tls_context, mock_factory_ctx);
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   THROW_IF_NOT_OK(cfg_or_error.status());
   auto cfg = std::move(cfg_or_error.value());
   static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
   auto factory_or_error = Extensions::TransportSockets::Tls::ClientSslSocketFactory::create(
       std::move(cfg), context_manager, *client_stats_store->rootScope());
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   THROW_IF_NOT_OK(factory_or_error.status());
   return std::move(factory_or_error.value());
 }

--- a/tests/cilium_tls_tcp_integration_test.cc
+++ b/tests/cilium_tls_tcp_integration_test.cc
@@ -119,7 +119,7 @@ public:
   void initialize() override {
     CiliumTcpIntegrationTest::initialize();
 
-    payload_reader_.reset(new WaitForPayloadReader(*dispatcher_));
+    payload_reader_ = std::make_shared<WaitForPayloadReader>(*dispatcher_);
   }
 
   void createUpstreams() override {
@@ -147,6 +147,7 @@ public:
 
     auto cfg_or_error = Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
         tls_context, factory_context_, false);
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     THROW_IF_NOT_OK(cfg_or_error.status());
     auto cfg = std::move(cfg_or_error.value());
 
@@ -154,6 +155,7 @@ public:
     auto server_or_error = Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
         std::move(cfg), context_manager_, *upstream_stats_store->rootScope(),
         std::vector<std::string>{});
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     THROW_IF_NOT_OK(server_or_error.status());
     return std::move(server_or_error.value());
   }

--- a/tests/cilium_tls_tcp_integration_test.cc
+++ b/tests/cilium_tls_tcp_integration_test.cc
@@ -18,7 +18,7 @@
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
-#include "envoy/http/codec.h"
+#include "envoy/http/codec.h" // IWYU pragma: keep
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/transport_socket.h"

--- a/tests/cilium_tls_tcp_integration_test.cc
+++ b/tests/cilium_tls_tcp_integration_test.cc
@@ -18,6 +18,7 @@
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
+#include "envoy/http/codec.h"
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/transport_socket.h"

--- a/tests/cilium_websocket_decap_integration_test.cc
+++ b/tests/cilium_websocket_decap_integration_test.cc
@@ -156,14 +156,14 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
   response->waitForHeaders();
   EXPECT_EQ("101", response->headers().getStatusValue());
 
-  auto clientConn = codec_client_->connection();
+  auto client_conn = codec_client_->connection();
 
   // Create websocket framed data & write it on the client connection
   Buffer::OwnedImpl buf{"\x82\x5"
                         "hello"};
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   std::string data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(5, &data));
@@ -187,9 +187,9 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
           "hello21"
           "\x82\x3"
           "foo");
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(seen_data_len + 16, &data));
   ASSERT_EQ(data.substr(seen_data_len), "hello2hello21foo");
@@ -211,9 +211,9 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
                             "len16",
                             9};
   buf.add(frame16);
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(seen_data_len + 5, &data));
   ASSERT_EQ(data.substr(seen_data_len), "len16");
@@ -238,9 +238,9 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
                             "len64",
                             15};
   buf.add(frame64);
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(seen_data_len + 5, &data));
   ASSERT_EQ(data.substr(seen_data_len), "len64");
@@ -259,9 +259,9 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
           "hello"
           "\x82\xe"
           "gap ");
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(seen_data_len + 9, &data));
   ASSERT_EQ(data.substr(seen_data_len), "hellogap ");
@@ -273,9 +273,9 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
   buf.add("in between"
           "\x82\x3"
           "foo");
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(seen_data_len + 13, &data));
   ASSERT_EQ(data.substr(seen_data_len), "in betweenfoo");
@@ -298,9 +298,9 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
   buf.add("\x82\x8e");
   buf.add(mask, 4);
   buf.add(masked.data(), masked.length());
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(seen_data_len + 14, &data));
   ASSERT_EQ(data.substr(seen_data_len), msg);
@@ -326,15 +326,15 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
   // Write frame header
   buf.add("\x82\x8d");
   buf.add(mask2, 4);
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   // Write 5 first bytes
   buf.add(masked2.data(), 5);
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(seen_data_len + 5, &data));
   ASSERT_EQ(data.substr(seen_data_len), absl::string_view(msg2.data(), 5));
@@ -342,9 +342,9 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
 
   // Write remaining bytes
   buf.add(masked2.data() + 5, masked2.length() - 5);
-  clientConn->write(buf, false);
+  client_conn->write(buf, false);
   // Run the dispatcher so that the write event is handled
-  clientConn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+  client_conn->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(seen_data_len + 13 - 5, &data));
   ASSERT_EQ(data.substr(seen_data_len), msg2.data() + 5);

--- a/tests/cilium_websocket_decap_integration_test.cc
+++ b/tests/cilium_websocket_decap_integration_test.cc
@@ -115,7 +115,7 @@ resources:
                                        GetParam());
   }
 
-  void Denied(Http::TestRequestHeaderMapImpl&& headers) {
+  void denied(Http::TestRequestHeaderMapImpl&& headers) {
     codec_client_ = makeHttpConnection(lookupPort("http"));
     auto response = codec_client_->makeHeaderOnlyRequest(headers);
     ASSERT_TRUE(response->waitForEndStream());
@@ -131,7 +131,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, CiliumWebSocketIntegrationTest,
 
 TEST_P(CiliumWebSocketIntegrationTest, DeniedNonWebSocket) {
   initialize();
-  Denied({{":method", "GET"}, {":path", "/"}, {":authority", "host"}});
+  denied({{":method", "GET"}, {":path", "/"}, {":authority", "host"}});
 }
 
 TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
@@ -348,7 +348,7 @@ TEST_P(CiliumWebSocketIntegrationTest, AcceptedWebSocket) {
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(seen_data_len + 13 - 5, &data));
   ASSERT_EQ(data.substr(seen_data_len), msg2.data() + 5);
-  seen_data_len = data.length();
+  // seen_data_len = data.length(); // not used after, no need to update
 
   ASSERT_TRUE(fake_upstream_connection->write(msg2));
 

--- a/tests/cilium_websocket_encap_integration_test.cc
+++ b/tests/cilium_websocket_encap_integration_test.cc
@@ -158,7 +158,7 @@ static const char EXPECTED_HANDSHAKE_FMT[] =
 
 namespace {
 
-size_t normalize_x_request_id(std::string& headers) {
+size_t normalizeXRequestId(std::string& headers) {
   auto idx = headers.find(X_REQUEST_ID_HEADER HEADER_SEPARATOR);
   if (idx != std::string::npos) {
     idx += sizeof(X_REQUEST_ID_HEADER HEADER_SEPARATOR) - 1; // w/o the \0 in the end
@@ -189,7 +189,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketHandshakeNonHTTPResponse) 
 
   ASSERT_TRUE(fake_upstream_connection->waitForData(expected_handshake.length(),
                                                     &received_handshake, std::chrono::seconds(10)));
-  ASSERT_EQ(normalize_x_request_id(received_handshake), sizeof(X_REQUEST_ID_VALUE) - 1);
+  ASSERT_EQ(normalizeXRequestId(received_handshake), sizeof(X_REQUEST_ID_VALUE) - 1);
   ASSERT_EQ(received_handshake, expected_handshake);
   ASSERT_TRUE(fake_upstream_connection->write("\x82\x5"
                                               "world"));
@@ -217,7 +217,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketHandshakeInvalidResponse) 
       fmt::format(fmt::runtime(EXPECTED_HANDSHAKE_FMT), original_dst_address->asString());
   std::string received_data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(expected_handshake.length(), &received_data));
-  ASSERT_EQ(normalize_x_request_id(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
+  ASSERT_EQ(normalizeXRequestId(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
   ASSERT_EQ(received_data, expected_handshake);
 
   // Handshake response with invalid hash value
@@ -244,7 +244,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketHandshakeSuccess) {
       fmt::format(fmt::runtime(EXPECTED_HANDSHAKE_FMT), original_dst_address->asString());
   std::string received_data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(expected_handshake.length(), &received_data));
-  ASSERT_EQ(normalize_x_request_id(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
+  ASSERT_EQ(normalizeXRequestId(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
   ASSERT_EQ(received_data, expected_handshake);
 
   // Handshake response with the correct hash value
@@ -283,7 +283,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketHandshakeNoData) {
       fmt::format(fmt::runtime(EXPECTED_HANDSHAKE_FMT), original_dst_address->asString());
   std::string received_data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(expected_handshake.length(), &received_data));
-  ASSERT_EQ(normalize_x_request_id(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
+  ASSERT_EQ(normalizeXRequestId(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
   ASSERT_EQ(received_data, expected_handshake);
 
   // Handshake response with the correct hash value
@@ -314,7 +314,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketDownstreamDisconnect) {
       fmt::format(fmt::runtime(EXPECTED_HANDSHAKE_FMT), original_dst_address->asString());
   std::string received_data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(expected_handshake.length(), &received_data));
-  ASSERT_EQ(normalize_x_request_id(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
+  ASSERT_EQ(normalizeXRequestId(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
   ASSERT_EQ(received_data, expected_handshake);
 
   // Handshake response with the correct hash value
@@ -368,7 +368,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketLargeWrite) {
       fmt::format(fmt::runtime(EXPECTED_HANDSHAKE_FMT), original_dst_address->asString());
   std::string received_data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(expected_handshake.length(), &received_data));
-  ASSERT_EQ(normalize_x_request_id(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
+  ASSERT_EQ(normalizeXRequestId(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
   ASSERT_EQ(received_data, expected_handshake);
 
   // Handshake response with the correct hash value
@@ -430,7 +430,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketDownstreamFlush) {
       fmt::format(fmt::runtime(EXPECTED_HANDSHAKE_FMT), original_dst_address->asString());
   std::string received_data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(expected_handshake.length(), &received_data));
-  ASSERT_EQ(normalize_x_request_id(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
+  ASSERT_EQ(normalizeXRequestId(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
   ASSERT_EQ(received_data, expected_handshake);
 
   // Handshake response with the correct hash value
@@ -485,7 +485,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketUpstreamFlush) {
       fmt::format(fmt::runtime(EXPECTED_HANDSHAKE_FMT), original_dst_address->asString());
   std::string received_data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(expected_handshake.length(), &received_data));
-  ASSERT_EQ(normalize_x_request_id(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
+  ASSERT_EQ(normalizeXRequestId(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
   ASSERT_EQ(received_data, expected_handshake);
 
   // Handshake response with the correct hash value
@@ -532,7 +532,7 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketUpstreamFlushEnvoyExit) {
       fmt::format(fmt::runtime(EXPECTED_HANDSHAKE_FMT), original_dst_address->asString());
   std::string received_data;
   ASSERT_TRUE(fake_upstream_connection->waitForData(expected_handshake.length(), &received_data));
-  ASSERT_EQ(normalize_x_request_id(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
+  ASSERT_EQ(normalizeXRequestId(received_data), sizeof(X_REQUEST_ID_VALUE) - 1);
   ASSERT_EQ(received_data, expected_handshake);
 
   // Handshake response with the correct hash value

--- a/tests/health_check_sink_server.cc
+++ b/tests/health_check_sink_server.cc
@@ -20,7 +20,7 @@ HealthCheckSinkServer::HealthCheckSinkServer(const std::string path)
     : UDSServer(path, std::bind(&HealthCheckSinkServer::msgCallback, this, std::placeholders::_1)) {
 }
 
-HealthCheckSinkServer::~HealthCheckSinkServer() {}
+HealthCheckSinkServer::~HealthCheckSinkServer() = default;
 
 void HealthCheckSinkServer::clear() {
   absl::MutexLock lock(&mutex_);

--- a/tests/health_check_sink_server.cc
+++ b/tests/health_check_sink_server.cc
@@ -1,10 +1,5 @@
 #include "tests/health_check_sink_server.h"
 
-#include <stdlib.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
-
 #include <chrono>
 #include <functional>
 #include <string>

--- a/tests/health_check_sink_server.h
+++ b/tests/health_check_sink_server.h
@@ -28,8 +28,9 @@ public:
   template <typename P>
   bool expectEventTo(P&& pred, std::chrono::milliseconds timeout = TestUtility::DefaultTimeout) {
     auto maybe_event = waitForEvent(timeout);
-    if (maybe_event.has_value())
+    if (maybe_event.has_value()) {
       return pred(maybe_event.value());
+    }
     return false;
   }
 

--- a/tests/health_check_sink_test.cc
+++ b/tests/health_check_sink_test.cc
@@ -54,7 +54,7 @@ TEST(HealthCheckEventPipeSink, logTest) {
 
   // Set up server
   std::string normal_path("test_path");
-  HealthCheckSinkServer eventSink(normal_path);
+  HealthCheckSinkServer event_sink(normal_path);
 
   // Set up client factory
   auto factory =
@@ -92,7 +92,7 @@ TEST(HealthCheckEventPipeSink, logTest) {
 
   pipe_sink->log(eject_event);
   EXPECT_TRUE(
-      eventSink.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
+      event_sink.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
         return Protobuf::util::MessageDifferencer::Equals(observed_event, eject_event);
       }));
 
@@ -119,7 +119,7 @@ TEST(HealthCheckEventPipeSink, logTest) {
 
   pipe_sink2->log(add_event);
   EXPECT_TRUE(
-      eventSink.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
+      event_sink.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
         return Protobuf::util::MessageDifferencer::Equals(observed_event, add_event);
       }));
 
@@ -127,7 +127,7 @@ TEST(HealthCheckEventPipeSink, logTest) {
   // Set up server
 #define ABSTRACT_PATH "@another\0test_path"
   std::string abstract_name(ABSTRACT_PATH, sizeof(ABSTRACT_PATH) - 1);
-  HealthCheckSinkServer eventSink3(abstract_name);
+  HealthCheckSinkServer event_sink3(abstract_name);
 
   // Set up 3rd client on a different socket
   cilium::HealthCheckEventPipeSink config3;
@@ -138,7 +138,7 @@ TEST(HealthCheckEventPipeSink, logTest) {
 
   pipe_sink3->log(eject_event);
   EXPECT_TRUE(
-      eventSink3.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
+      event_sink3.expectEventTo([&](const envoy::data::core::v3::HealthCheckEvent& observed_event) {
         return Protobuf::util::MessageDifferencer::Equals(observed_event, eject_event);
       }));
 }

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -21,12 +21,14 @@
 
 #include "source/common/common/base_logger.h"
 #include "source/common/common/logger.h"
+#include "source/common/common/statusor.h"
 #include "source/common/init/watcher_impl.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/network/socket_impl.h"
 #include "source/common/stats/isolated_store_impl.h"
 
 #include "test/mocks/filesystem/mocks.h"
+#include "test/mocks/network/connection.h"
 #include "test/mocks/network/io_handle.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/listener_factory_context.h"

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -82,8 +82,8 @@ protected:
         }));
     ON_CALL(context_.init_manager_, initialize(_))
         .WillByDefault(Invoke([this](const Init::Watcher& watcher) {
-          for (auto& handle_ : target_handles_) {
-            handle_->initialize(watcher);
+          for (auto& handle : target_handles_) {
+            handle->initialize(watcher);
           }
         }));
 
@@ -349,17 +349,17 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedMetadata) {
   EXPECT_EQ("10.1.1.42", policy_fs->ingress_policy_name_);
   EXPECT_EQ(12345678, policy_fs->ingress_source_identity_);
 
-  AccessLog::Entry logEntry;
-  logEntry.entry_.set_policy_name("pod");
+  AccessLog::Entry log_entry;
+  log_entry.entry_.set_policy_name("pod");
 
   // Expect policy accepts security ID 12345678 on ingress on port 80
-  bool useProxyLib;
-  std::string l7Proto;
+  bool use_proxy_lib;
+  std::string l7_proto;
   EXPECT_TRUE(
-      policy_fs->enforceNetworkPolicy(conn_, 12345678, 80, "", useProxyLib, l7Proto, logEntry));
-  EXPECT_FALSE(useProxyLib);
-  EXPECT_EQ("", l7Proto);
-  EXPECT_NE("pod", logEntry.entry_.policy_name());
+      policy_fs->enforceNetworkPolicy(conn_, 12345678, 80, "", use_proxy_lib, l7_proto, log_entry));
+  EXPECT_FALSE(use_proxy_lib);
+  EXPECT_EQ("", l7_proto);
+  EXPECT_NE("pod", log_entry.entry_.policy_name());
 
   auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption(-1);
   EXPECT_NE(nullptr, source_addresses_socket_option);
@@ -419,33 +419,35 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbPodAndIngressEnforcedMetadata) {
   EXPECT_EQ("10.1.1.42", policy_fs->ingress_policy_name_);
   EXPECT_EQ(9999, policy_fs->ingress_source_identity_);
 
-  AccessLog::Entry logEntry;
-  logEntry.entry_.set_policy_name("pod");
+  AccessLog::Entry log_entry;
+  log_entry.entry_.set_policy_name("pod");
 
   // Expect pod policy denies security ID 12345678 on port 80 (only 222 allowed)
-  bool useProxyLib;
-  std::string l7Proto;
+  bool use_proxy_lib;
+  std::string l7_proto;
   EXPECT_FALSE(
-      policy_fs->enforceNetworkPolicy(conn_, 12345678, 80, "", useProxyLib, l7Proto, logEntry));
-  EXPECT_FALSE(useProxyLib);
-  EXPECT_EQ("", l7Proto);
-  EXPECT_EQ("pod", logEntry.entry_.policy_name());
+      policy_fs->enforceNetworkPolicy(conn_, 12345678, 80, "", use_proxy_lib, l7_proto, log_entry));
+  EXPECT_FALSE(use_proxy_lib);
+  EXPECT_EQ("", l7_proto);
+  EXPECT_EQ("pod", log_entry.entry_.policy_name());
 
   // Expect pod policy allows egress to security ID 222 on port 80
   // Ingress policy allows ingress from 9999 (pod's security ID)
   // Ingress policy allows 222 egress
-  EXPECT_TRUE(policy_fs->enforceNetworkPolicy(conn_, 222, 80, "", useProxyLib, l7Proto, logEntry));
-  EXPECT_FALSE(useProxyLib);
-  EXPECT_EQ("", l7Proto);
-  EXPECT_NE("pod", logEntry.entry_.policy_name());
+  EXPECT_TRUE(
+      policy_fs->enforceNetworkPolicy(conn_, 222, 80, "", use_proxy_lib, l7_proto, log_entry));
+  EXPECT_FALSE(use_proxy_lib);
+  EXPECT_EQ("", l7_proto);
+  EXPECT_NE("pod", log_entry.entry_.policy_name());
 
   // Expect pod policy allows egress to security ID 333 on port 80
   // Ingress policy allows ingress from 9999
   // Ingress policy denies 333 egress
-  EXPECT_FALSE(policy_fs->enforceNetworkPolicy(conn_, 333, 80, "", useProxyLib, l7Proto, logEntry));
-  EXPECT_FALSE(useProxyLib);
-  EXPECT_EQ("", l7Proto);
-  EXPECT_NE("pod", logEntry.entry_.policy_name());
+  EXPECT_FALSE(
+      policy_fs->enforceNetworkPolicy(conn_, 333, 80, "", use_proxy_lib, l7_proto, log_entry));
+  EXPECT_FALSE(use_proxy_lib);
+  EXPECT_EQ("", l7_proto);
+  EXPECT_NE("pod", log_entry.entry_.policy_name());
 
   auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption(-1);
   EXPECT_NE(nullptr, source_addresses_socket_option);
@@ -488,16 +490,17 @@ TEST_F(MetadataConfigTest, NorthSouthL7LbIngressEnforcedCIDRMetadata) {
   EXPECT_EQ("10.1.1.42", policy_fs->ingress_policy_name_);
   EXPECT_EQ(2, policy_fs->ingress_source_identity_);
 
-  AccessLog::Entry logEntry;
-  logEntry.entry_.set_policy_name("pod");
+  AccessLog::Entry log_entry;
+  log_entry.entry_.set_policy_name("pod");
 
   // Expect policy does not accept security ID 2 on port 80
-  bool useProxyLib;
-  std::string l7Proto;
-  EXPECT_FALSE(policy_fs->enforceNetworkPolicy(conn_, 2, 80, "", useProxyLib, l7Proto, logEntry));
-  EXPECT_FALSE(useProxyLib);
-  EXPECT_EQ("", l7Proto);
-  EXPECT_NE("pod", logEntry.entry_.policy_name());
+  bool use_proxy_lib;
+  std::string l7_proto;
+  EXPECT_FALSE(
+      policy_fs->enforceNetworkPolicy(conn_, 2, 80, "", use_proxy_lib, l7_proto, log_entry));
+  EXPECT_FALSE(use_proxy_lib);
+  EXPECT_EQ("", l7_proto);
+  EXPECT_NE("pod", log_entry.entry_.policy_name());
 
   auto source_addresses_socket_option = socket_metadata->buildSourceAddressSocketOption(-1);
   EXPECT_NE(nullptr, source_addresses_socket_option);

--- a/tests/uds_server.cc
+++ b/tests/uds_server.cc
@@ -1,10 +1,10 @@
 #include "tests/uds_server.h"
 
-#include <errno.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <functional>
 #include <memory>
 #include <string>

--- a/tests/uds_server.h
+++ b/tests/uds_server.h
@@ -18,7 +18,7 @@ public:
   ~UDSServer();
 
 private:
-  void Close();
+  void close();
   void threadRoutine();
 
   std::function<void(const std::string&)> msg_cb_;


### PR DESCRIPTION
Add new clang-tidy make targets `tidy` and `tidy-fix`. Rename existing clang-format targets from `check` and `fix` to `format` and `format-fix`, respectively.

Add a new GH workflow to run clang-tidy on changed files.
Bazel build options are passed into `gen_compilation_database.py` so that the analysis cache is not invalidated between `make tidy` and `make tests` targets, for example.

`.clang-tidy` is copied from upstream Envoy, with addition of `misc-include-cleaner` `IgnoreHeaders` options adapted from `.clangd`. Additionally, linting of local variables to `lower_case` is added, which found out a few places where the "member variable suffix" `_` was used on a local variable, in addition to some `camelCase` local variables that are now changed to `lower_case`.

By default `make tidy` will tidy up all sources in `tests` and `cilium` directories, which takes a long time. Defining the variable `TIDY_SOURCES` can be used to specify a subset, e.g.,:
```
$ TIDY_SOURCES=cilium/network_policy.cc make tidy
```
Please note that `make tidy-fix` is prone to producing duplicated includes and non-compiling code, so all edits made with it must be manually inspected.

For the tidy targets to work, the host must have the package `clang-tidy-17` installed.

