### PR TITLE
bpf_metadata: extract proxylib appprotocol logic

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -522,8 +522,8 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
     mark = ((is_ingress_) ? 0x0A00 : 0x0B00) | cluster_id | identity_id;
   }
   return absl::optional(Cilium::BpfMetadata::SocketMetadata(
-      mark, ingress_source_identity, source_identity, is_ingress_, is_l7lb_, dip->port(),
-      std::move(pod_ip), std::move(src_address), std::move(source_addresses.ipv4_),
+      mark, ingress_source_identity, source_identity, destination_identity, is_ingress_, is_l7lb_,
+      dip->port(), std::move(pod_ip), std::move(src_address), std::move(source_addresses.ipv4_),
       std::move(source_addresses.ipv6_), weak_from_this(), proxy_id_, sni));
 }
 

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -32,15 +32,17 @@ namespace BpfMetadata {
 
 struct SocketMetadata {
   SocketMetadata(uint32_t mark, uint32_t ingress_source_identity, uint32_t source_identity,
-                 bool ingress, bool l7lb, uint16_t port, std::string&& pod_ip,
+                 uint32_t destination_identity, bool ingress, bool l7lb, uint16_t port,
+                 std::string&& pod_ip,
                  Network::Address::InstanceConstSharedPtr original_source_address,
                  Network::Address::InstanceConstSharedPtr source_address_ipv4,
                  Network::Address::InstanceConstSharedPtr source_address_ipv6,
                  const std::weak_ptr<PolicyResolver>& policy_resolver, uint32_t proxy_id,
                  absl::string_view sni)
       : ingress_source_identity_(ingress_source_identity), source_identity_(source_identity),
-        ingress_(ingress), is_l7lb_(l7lb), port_(port), pod_ip_(std::move(pod_ip)),
-        proxy_id_(proxy_id), sni_(sni), policy_resolver_(policy_resolver), mark_(mark),
+        destination_identity_(destination_identity), ingress_(ingress), is_l7lb_(l7lb), port_(port),
+        pod_ip_(std::move(pod_ip)), proxy_id_(proxy_id), sni_(sni),
+        policy_resolver_(policy_resolver), mark_(mark),
         original_source_address_(std::move(original_source_address)),
         source_address_ipv4_(std::move(source_address_ipv4)),
         source_address_ipv6_(std::move(source_address_ipv6)) {}
@@ -62,6 +64,7 @@ struct SocketMetadata {
 
   uint32_t ingress_source_identity_;
   uint32_t source_identity_;
+  uint32_t destination_identity_;
   bool ingress_;
   bool is_l7lb_;
   uint16_t port_;

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -201,7 +201,7 @@ TestConfig::extractSocketMetadata(Network::ConnectionSocket& socket) {
   }
 
   return absl::optional(Cilium::BpfMetadata::SocketMetadata(
-      0, 0, source_identity, is_ingress_, is_l7lb_, port, std::move(pod_ip), nullptr, nullptr,
+      0, 0, source_identity, 0, is_ingress_, is_l7lb_, port, std::move(pod_ip), nullptr, nullptr,
       nullptr, shared_from_this(), 0, ""));
 }
 


### PR DESCRIPTION
Currently, the function `extractSocketMetadata` does not only extract relevant information from the socket and enriches it with data retrieved from BPF maps. It also has some side-effects: namely setting the proxylib protocol as application protocol on the network socket.

Therefore, this commit extracts this logic from the function `extractSocketMetadata` and moves it into a dedicated function on the `SocketMetadata` struct that then is called from the BPF  metadata listener filter in the `onAccept` function.

This way, we can keep the function `extractSocketMetadata` free of side-effects and bundle the logic that changes the socket in the BPF metadata listener filter (`onAccept`).

Note: `socket.connectionInfoProvider().restoreLocalAddress(dst_address)` - the last modifying action in `extractSocketMetadata`) will be cleaned up in a follow up PR.

As discussed over [here](https://github.com/cilium/proxy/pull/1107#discussion_r1909271347)