### PR TITLE
Remove the SO_LINGER option

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -568,15 +568,6 @@ Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {
   Network::Socket::appendOptions(socket_options,
                                  Network::SocketOptionFactory::buildReusePortOptions());
 
-  // linger (SO_LINGER)
-  struct linger linger;
-  linger.l_onoff = 1;
-  linger.l_linger = 10;
-  absl::string_view linger_bstr{reinterpret_cast<const char*>(&linger), sizeof(struct linger)};
-  socket_options->push_back(std::make_shared<Envoy::Network::SocketOptionImpl>(
-      envoy::config::core::v3::SocketOption::STATE_LISTENING,
-      ENVOY_MAKE_SOCKET_OPTION_NAME(SOL_SOCKET, SO_LINGER), linger_bstr));
-
   // keep alive (SO_KEEPALIVE, TCP_KEEPINTVL, TCP_KEEPIDLE)
   Network::Socket::appendOptions(
       socket_options,


### PR DESCRIPTION
SO_LINGER option makes the close() system call block if there is any unfinished business on the socket, even if the socket is set to the non-blocking mode. Any blocking is at odds with Envoy's threading model, and we have seen non-zero Envoy watchdog mege miss metrics corroborated by Envoy trace logs indicating that a close system call was blocking for 10 seconds, exactly the time we had set for the SO_LINGER option.

Fix this by removing the setting of the linger option.

Due to the different code structure v1.31 version is in a separate PR: https://github.com/cilium/proxy/pull/1128