### PR TITLE
Remove the SO_LINGER option

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -529,19 +529,11 @@ Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {
     }
   }
 
-  // Set socket options for linger and keepalive (5 minutes).
-  struct ::linger lin {
-    true, 10
-  };
+  // Set socket option for keepalive (5 minutes).
   int keepalive = true;
   int secs = 5 * 60; // Five minutes
 
-  auto status = socket.setSocketOption(SOL_SOCKET, SO_LINGER, &lin, sizeof(lin));
-  if (status.return_value_ < 0) {
-    ENVOY_LOG(critical, "Socket option failure. Failed to set SO_LINGER: {}",
-              Envoy::errorDetails(status.errno_));
-  }
-  status = socket.setSocketOption(SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
+  auto status = socket.setSocketOption(SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
   if (status.return_value_ < 0) {
     ENVOY_LOG(critical, "Socket option failure. Failed to set SO_KEEPALIVE: {}",
               Envoy::errorDetails(status.errno_));


### PR DESCRIPTION
SO_LINGER option makes the close() system call block if there is any unfinished business on the socket, even if the socket is set to the non-blocking mode. Any blocking is at odds with Envoy's threading model, and we have seen non-zero Envoy watchdog mege miss metrics corroborated by Envoy trace logs indicating that a close system call was blocking for 10 seconds, exactly the time we had set for the SO_LINGER option.

Fix this by removing the setting of the linger option.