### PR TITLE
bpf_metadata: extract setting requested proxylib app protocol

### DIFF
--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -202,7 +202,7 @@ TestConfig::extractSocketMetadata(Network::ConnectionSocket& socket) {
 
   return absl::optional(Cilium::BpfMetadata::SocketMetadata(
       0, 0, source_identity, is_ingress_, is_l7lb_, port, std::move(pod_ip), nullptr, nullptr,
-      nullptr, shared_from_this(), 0, ""));
+      nullptr, shared_from_this(), 0, "", ""));
 }
 
 } // namespace BpfMetadata


### PR DESCRIPTION
Currently, the function `extractSocketMetadata` does not only extract relevant information from the socket and enriches it with data retrieved from BPF maps. It also has some side-effects: namely setting the proxylib protocol as application protocol on the network socket.

Therefore, this commit splits this logic from the function `extractSocketMetadata` and moves the part that is setting the proxylib l7 protocol as requested app protocol on the network socket into a dedicated function on the SocketMetadata struct that then is called from the BPF metadata listener filter in the onAccept function.

The part that is evaluating the ProxyLib L7 proto is still kept in the function `extractSocketMetadata`.

This way, we can keep the function extractSocketMetadata free of side-effects and bundle the logic that changes the socket in the BPF metadata listener filter (onAccept).

Note: socket.connectionInfoProvider().restoreLocalAddress(dst_address) - the last modifying action in extractSocketMetadata) will be cleaned up in a follow up commit.