### PR TITLE
bpf_metadata: fix setting proxylib l7 protocol

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -538,6 +538,8 @@ Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {
       socket_options->push_back(socket_metadata->buildCiliumMarkSocketOption());
     }
 
+    socket_metadata->configureProxyLibApplicationProtocol(socket);
+
     // Make Cilium Policy data available to filters and upstream connection (Cilium TLS Wrapper) as
     // filter state.
     cb.filterState().setData(


### PR DESCRIPTION
The refactoring of PR #1129 completely missed calling the newly introduced function `configureProxyLibApplicationProtocol` in the BPF metadata listener filter.

This commit fixes this.

Looks like the test coverage for the ProxyLib integration in the unit & connectivity tests is quite low - at least the ones that are executed. Probably worth to improve.