### PR TITLE
bpf_metadata: cleanp proxylib in test bpfmetadata config

### DIFF
--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -192,17 +192,12 @@ TestConfig::extractSocketMetadata(Network::ConnectionSocket& socket) {
   // Set metadata for policy based listener filter chain matching
   // Note: tls_inspector may overwrite this value, if it executes after us!
   std::string l7proto;
-  if (policy.useProxylib(is_ingress_, port, is_ingress_ ? source_identity : destination_identity,
-                         l7proto)) {
-    std::vector<absl::string_view> protocols;
-    protocols.emplace_back(l7proto);
-    socket.setRequestedApplicationProtocols(protocols);
-    ENVOY_LOG_MISC(info, "setRequestedApplicationProtocols({})", l7proto);
-  }
+  policy.useProxylib(is_ingress_, port, is_ingress_ ? source_identity : destination_identity,
+                     l7proto);
 
   return absl::optional(Cilium::BpfMetadata::SocketMetadata(
       0, 0, source_identity, is_ingress_, is_l7lb_, port, std::move(pod_ip), nullptr, nullptr,
-      nullptr, shared_from_this(), 0, "", ""));
+      nullptr, shared_from_this(), 0, std::move(l7proto), ""));
 }
 
 } // namespace BpfMetadata


### PR DESCRIPTION
The logic that sets the proxylib l7 proto as requested application protocol on the network socket has been extracted from the function `extractSocketMetadata`.

But, the test bpfmetadata config still contains this functionality.

Therefore, this commit removes setting the requested application protocol on the network socket in the test bpfmetadata config. Tests that rely on this functionality should do this explicitly in the setup by calling the function `configureProxyLibApplicationProtocol` on the `SocketMetadata` struct.

Related to: https://github.com/cilium/proxy/pull/1129