### PR TITLE
bpf_metadata: extract restoreLocalAddress

### DIFF
--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -83,6 +83,11 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
       return;
     }
 
+    if (*original_dest_address_ == *socket.connectionInfoProvider().localAddress()) {
+      // Only set the local address if it really changed, and mark it as address being restored.
+      return;
+    }
+
     // Restoration of the original destination address lets the OriginalDstCluster know the
     // destination address that can be used.
     ENVOY_LOG(trace, "cilium.bpf_metadata: restoreLocalAddress ({} -> {})",

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -159,11 +159,6 @@ TestConfig::~TestConfig() {
 
 absl::optional<Cilium::BpfMetadata::SocketMetadata>
 TestConfig::extractSocketMetadata(Network::ConnectionSocket& socket) {
-  // fake setting the local address. It remains the same as required by the test
-  // infra, but it will be marked as restored as required by the original_dst
-  // cluster.
-  socket.connectionInfoProvider().restoreLocalAddress(original_dst_address);
-
   // TLS filter chain matches this, make namespace part of this (e.g.,
   // "default")?
   socket.setDetectedTransportProtocol("cilium:default");
@@ -197,7 +192,7 @@ TestConfig::extractSocketMetadata(Network::ConnectionSocket& socket) {
 
   return absl::optional(Cilium::BpfMetadata::SocketMetadata(
       0, 0, source_identity, is_ingress_, is_l7lb_, port, std::move(pod_ip), nullptr, nullptr,
-      nullptr, shared_from_this(), 0, std::move(l7proto), ""));
+      nullptr, original_dst_address, shared_from_this(), 0, std::move(l7proto), ""));
 }
 
 } // namespace BpfMetadata

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -1,5 +1,6 @@
 #include <gmock/gmock-actions.h>
 #include <gmock/gmock-spec-builders.h>
+#include <gtest/gtest.h>
 #include <spdlog/common.h>
 
 #include <cstdint>
@@ -514,6 +515,23 @@ TEST_F(MetadataConfigTest, ProxyLibConfigured) {
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(protos));
 
   socket_metadata->configureProxyLibApplicationProtocol(socket_);
+}
+
+TEST_F(MetadataConfigTest, RestoreLocalAddress) {
+  ::cilium::BpfMetadata config{};
+
+  EXPECT_NO_THROW(initialize(config));
+
+  auto socket_metadata = config_->extractSocketMetadata(socket_);
+  EXPECT_TRUE(socket_metadata);
+
+  EXPECT_NE(socket_.connectionInfoProvider().localAddress(), original_dst_address);
+  EXPECT_FALSE(socket_.connectionInfoProvider().localAddressRestored());
+
+  socket_metadata->configureOriginalDstAddress(socket_);
+
+  EXPECT_EQ(socket_.connectionInfoProvider().localAddress(), original_dst_address);
+  EXPECT_TRUE(socket_.connectionInfoProvider().localAddressRestored());
 }
 
 } // namespace


### PR DESCRIPTION
Currently, `extractSocketMetadata` also restores the local address for the use by the `OriginalDestCluster`.

To keep the function free of side-effects, the logic that restores the local address gets extracted into a function within the `SocketMetadata` that gets called from the BPF metadata listener after extracting the BPF metadata from the socket.