### PR TITLE
bpf_metadata: don't restore local address for L7LB

### DIFF
--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -88,11 +88,18 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
       return;
     }
 
+    if (is_l7lb_) {
+      // Don't restore local address (original destination address) in case
+      // of L7LB (these cases don't use original dest discovery type)
+      return;
+    }
+
     // Restoration of the original destination address lets the OriginalDstCluster know the
     // destination address that can be used.
     ENVOY_LOG(trace, "cilium.bpf_metadata: restoreLocalAddress ({} -> {})",
               socket.connectionInfoProvider().localAddress()->asString(),
               original_dest_address_->asString());
+
     socket.connectionInfoProvider().restoreLocalAddress(original_dest_address_);
   }
 


### PR DESCRIPTION
Currently, the local address always gets restored.

But this functionality is only used to restore the original destination address that then is used by the original destination discovery service.

But this is only used in the E/W ingress/egress cases for Cilium policy enforcement, but not for the L7 loadbalancing cases (N/S & E/W). In these cases, the related  log message is confusing.

Therefore, this commit changes the logic to prevent  restoration in case of L7 LB.

Example

```
[2025-01-24 08:43:18.782][35][trace][filter] [./cilium/bpf_metadata.h:95] cilium.bpf_metadata: restoreLocalAddress (127.0.0.1:16898 -> 172.19.255.1:80)
```

In case of N/S L7 LB where we see an unnecessary restoration (`127.0.0.1:16898` (Ingress listener with dynamic port) -> `172.19.255.1:80` (Node IP where the Ingress call was sent to). This doesn't make sense and is confusing.