### PR TITLE
bpf_metadata: align logging for restoration

### DIFF
--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -90,9 +90,11 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
 
     // Restoration of the original destination address lets the OriginalDstCluster know the
     // destination address that can be used.
-    ENVOY_LOG(trace, "cilium.bpf_metadata: restoreLocalAddress ({} -> {})",
+    ENVOY_LOG(trace, "Restoring local address (original destination) on socket {} ({} -> {})",
+              socket.ioHandle().fdDoNotUse(),
               socket.connectionInfoProvider().localAddress()->asString(),
               original_dest_address_->asString());
+
     socket.connectionInfoProvider().restoreLocalAddress(original_dest_address_);
   }
 

--- a/cilium/socket_option_source_address.h
+++ b/cilium/socket_option_source_address.h
@@ -82,11 +82,16 @@ public:
       return true;
     }
 
-    // Note: we don't expect this to change the behaviour of the socket. We expect it to be copied
-    // into the upstream connection later.
+    // Note: Restoration of the original source address happens on the socket of the upstream
+    // connection.
+    ENVOY_LOG(trace, "Restoring local address (original source) on socket: {} ({} -> {})",
+              socket.ioHandle().fdDoNotUse(),
+              socket.connectionInfoProvider().localAddress()
+                  ? socket.connectionInfoProvider().localAddress()->asString()
+                  : "n/a",
+              source_address->asString());
+
     socket.connectionInfoProvider().setLocalAddress(std::move(source_address));
-    ENVOY_LOG(trace, "Successfully restored local address on socket: {}",
-              socket.ioHandle().fdDoNotUse());
 
     return true;
   }


### PR DESCRIPTION
This commit aligns the logging for restoration of the local address for downstream & upstream socket by always logging the socket and the old & new local address.