### PR TITLE
socket_options: introduce C files

### DIFF
--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -65,12 +65,22 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "socket_option_lib",
+    srcs = [
+        "socket_option_cilium_mark.cc",
+        "socket_option_ip_transparent.cc",
+        "socket_option_source_address.cc",
+    ],
     hdrs = [
         "socket_option_cilium_mark.h",
         "socket_option_ip_transparent.h",
         "socket_option_source_address.h",
     ],
     repository = "@envoy",
+    deps = [
+        "privileged_service_client_lib",
+        "@envoy//source/common/common:hex_lib",
+        "@envoy//source/common/network:address_lib",
+    ],
 )
 
 envoy_cc_library(

--- a/cilium/socket_option_cilium_mark.cc
+++ b/cilium/socket_option_cilium_mark.cc
@@ -1,0 +1,9 @@
+#include "cilium/socket_option_cilium_mark.h"
+
+namespace Envoy {
+namespace Cilium {
+
+// empty
+
+} // namespace Cilium
+} // namespace Envoy

--- a/cilium/socket_option_cilium_mark.cc
+++ b/cilium/socket_option_cilium_mark.cc
@@ -1,9 +1,62 @@
 #include "cilium/socket_option_cilium_mark.h"
 
+#include <asm-generic/socket.h>
+#include <netinet/in.h>
+
+#include <cerrno>
+#include <cstdint>
+
+#include "envoy/config/core/v3/socket_option.pb.h"
+#include "envoy/network/socket.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/common/utility.h"
+
+#include "cilium/privileged_service_client.h"
+
 namespace Envoy {
 namespace Cilium {
 
-// empty
+CiliumMarkSocketOption::CiliumMarkSocketOption(uint32_t mark) : mark_(mark) {
+  ENVOY_LOG(debug,
+            "Cilium CiliumMarkSocketOption(): mark: {:x} (magic mark: {:x}, cluster: {}, ID: {})",
+            mark_, mark & 0xff00, mark & 0xff, mark >> 16);
+}
+
+bool CiliumMarkSocketOption::setOption(
+    Network::Socket& socket, envoy::config::core::v3::SocketOption::SocketState state) const {
+  // Only set the option once per socket
+  if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
+    ENVOY_LOG(trace, "Skipping setting socket ({}) option SO_MARK, state != STATE_PREBIND",
+              socket.ioHandle().fdDoNotUse());
+    return true;
+  }
+
+  auto& cilium_calls = PrivilegedService::Singleton::get();
+  auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_SOCKET, SO_MARK, &mark_,
+                                        sizeof(mark_));
+  if (status.return_value_ < 0) {
+    if (status.errno_ == EPERM) {
+      // Do not assert out in this case so that we can run tests without
+      // CAP_NET_ADMIN.
+      ENVOY_LOG(critical,
+                "Failed to set socket option SO_MARK to {}, capability "
+                "CAP_NET_ADMIN needed: {}",
+                mark_, Envoy::errorDetails(status.errno_));
+    } else {
+      ENVOY_LOG(critical, "Socket option failure. Failed to set SO_MARK to {}: {}", mark_,
+                Envoy::errorDetails(status.errno_));
+      return false;
+    }
+  }
+
+  ENVOY_LOG(trace,
+            "Set socket ({}) option SO_MARK to {:x} (magic mark: {:x}, id: "
+            "{}, cluster: {})",
+            socket.ioHandle().fdDoNotUse(), mark_, mark_ & 0xff00, mark_ >> 16, mark_ & 0xff);
+
+  return true;
+}
 
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/socket_option_cilium_mark.h
+++ b/cilium/socket_option_cilium_mark.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <asm-generic/socket.h>
-#include <netinet/in.h>
-
-#include <cerrno>
 #include <cstdint>
 #include <vector>
 
@@ -11,10 +7,8 @@
 #include "envoy/network/socket.h"
 
 #include "source/common/common/logger.h"
-#include "source/common/common/utility.h"
 
 #include "absl/types/optional.h"
-#include "cilium/privileged_service_client.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -26,12 +20,7 @@ namespace Cilium {
 class CiliumMarkSocketOption : public Network::Socket::Option,
                                public Logger::Loggable<Logger::Id::filter> {
 public:
-  CiliumMarkSocketOption(uint32_t mark) : mark_(mark) {
-    ENVOY_LOG(debug,
-              "Cilium CiliumMarkSocketOption(): mark: {:x} (magic mark: {:x}, cluster: {}, ID: {})",
-              mark_, mark & 0xff00, mark & 0xff, mark >> 16);
-  }
-
+  CiliumMarkSocketOption(uint32_t mark);
   absl::optional<Network::Socket::Option::Details>
   getOptionDetails(const Network::Socket&,
                    envoy::config::core::v3::SocketOption::SocketState) const override {
@@ -39,39 +28,7 @@ public:
   }
 
   bool setOption(Network::Socket& socket,
-                 envoy::config::core::v3::SocketOption::SocketState state) const override {
-    // Only set the option once per socket
-    if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
-      ENVOY_LOG(trace, "Skipping setting socket ({}) option SO_MARK, state != STATE_PREBIND",
-                socket.ioHandle().fdDoNotUse());
-      return true;
-    }
-
-    auto& cilium_calls = PrivilegedService::Singleton::get();
-    auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), SOL_SOCKET, SO_MARK,
-                                          &mark_, sizeof(mark_));
-    if (status.return_value_ < 0) {
-      if (status.errno_ == EPERM) {
-        // Do not assert out in this case so that we can run tests without
-        // CAP_NET_ADMIN.
-        ENVOY_LOG(critical,
-                  "Failed to set socket option SO_MARK to {}, capability "
-                  "CAP_NET_ADMIN needed: {}",
-                  mark_, Envoy::errorDetails(status.errno_));
-      } else {
-        ENVOY_LOG(critical, "Socket option failure. Failed to set SO_MARK to {}: {}", mark_,
-                  Envoy::errorDetails(status.errno_));
-        return false;
-      }
-    }
-
-    ENVOY_LOG(trace,
-              "Set socket ({}) option SO_MARK to {:x} (magic mark: {:x}, id: "
-              "{}, cluster: {})",
-              socket.ioHandle().fdDoNotUse(), mark_, mark_ & 0xff00, mark_ >> 16, mark_ & 0xff);
-
-    return true;
-  }
+                 envoy::config::core::v3::SocketOption::SocketState state) const override;
 
   void hashKey([[maybe_unused]] std::vector<uint8_t>& key) const override {}
 

--- a/cilium/socket_option_ip_transparent.cc
+++ b/cilium/socket_option_ip_transparent.cc
@@ -1,9 +1,77 @@
 #include "cilium/socket_option_ip_transparent.h"
 
+#include <netinet/in.h>
+
+#include <cerrno>
+#include <cstdint>
+
+#include "envoy/config/core/v3/socket_option.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/network/socket.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/common/utility.h"
+
+#include "cilium/privileged_service_client.h"
+
 namespace Envoy {
 namespace Cilium {
 
-// empty
+IpTransparentSocketOption::IpTransparentSocketOption() {
+  ENVOY_LOG(debug, "Cilium IpTransparentSocketOption()");
+}
+
+bool IpTransparentSocketOption::setOption(
+    Network::Socket& socket, envoy::config::core::v3::SocketOption::SocketState state) const {
+  // Only set the option once per socket
+  if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
+    ENVOY_LOG(trace, "Skipping setting socket ({}) option IP_TRANSPARENT, state != STATE_PREBIND",
+              socket.ioHandle().fdDoNotUse());
+    return true;
+  }
+
+  auto& cilium_calls = PrivilegedService::Singleton::get();
+
+  auto ipVersion = socket.ipVersion();
+  if (!ipVersion.has_value()) {
+    ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
+    return false;
+  }
+
+  uint32_t one = 1;
+
+  // Set ip transparent option based on the socket address family
+  auto ip_socket_level = SOL_IP;
+  auto ip_transparent_socket_option = IP_TRANSPARENT;
+  auto ip_transparent_socket_option_name = "IP_TRANSPARENT";
+  if (*ipVersion == Network::Address::IpVersion::v6) {
+    ip_socket_level = SOL_IPV6;
+    ip_transparent_socket_option = IPV6_TRANSPARENT;
+    ip_transparent_socket_option_name = "IPV6_TRANSPARENT";
+  }
+
+  auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), ip_socket_level,
+                                        ip_transparent_socket_option, &one, sizeof(one));
+  if (status.return_value_ < 0) {
+    if (status.errno_ == EPERM) {
+      // Do not assert out in this case so that we can run tests without
+      // CAP_NET_ADMIN.
+      ENVOY_LOG(critical,
+                "Failed to set socket option {}, capability "
+                "CAP_NET_ADMIN needed: {}",
+                ip_transparent_socket_option_name, Envoy::errorDetails(status.errno_));
+    } else {
+      ENVOY_LOG(critical, "Socket option failure. Failed to set {}: {}",
+                ip_transparent_socket_option_name, Envoy::errorDetails(status.errno_));
+      return false;
+    }
+  }
+
+  ENVOY_LOG(trace, "Successfully set socket option {} on socket: {}",
+            ip_transparent_socket_option_name, socket.ioHandle().fdDoNotUse());
+
+  return true;
+}
 
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/socket_option_ip_transparent.cc
+++ b/cilium/socket_option_ip_transparent.cc
@@ -1,0 +1,9 @@
+#include "cilium/socket_option_ip_transparent.h"
+
+namespace Envoy {
+namespace Cilium {
+
+// empty
+
+} // namespace Cilium
+} // namespace Envoy

--- a/cilium/socket_option_ip_transparent.h
+++ b/cilium/socket_option_ip_transparent.h
@@ -1,21 +1,14 @@
 #pragma once
 
-#include <asm-generic/socket.h>
-#include <netinet/in.h>
-
-#include <cerrno>
 #include <cstdint>
 #include <vector>
 
 #include "envoy/config/core/v3/socket_option.pb.h"
-#include "envoy/network/address.h"
 #include "envoy/network/socket.h"
 
 #include "source/common/common/logger.h"
-#include "source/common/common/utility.h"
 
 #include "absl/types/optional.h"
-#include "cilium/privileged_service_client.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -26,7 +19,7 @@ namespace Cilium {
 class IpTransparentSocketOption : public Network::Socket::Option,
                                   public Logger::Loggable<Logger::Id::filter> {
 public:
-  IpTransparentSocketOption() { ENVOY_LOG(debug, "Cilium IpTransparentSocketOption()"); }
+  IpTransparentSocketOption();
 
   absl::optional<Network::Socket::Option::Details>
   getOptionDetails(const Network::Socket&,
@@ -35,56 +28,7 @@ public:
   }
 
   bool setOption(Network::Socket& socket,
-                 envoy::config::core::v3::SocketOption::SocketState state) const override {
-    // Only set the option once per socket
-    if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
-      ENVOY_LOG(trace, "Skipping setting socket ({}) option IP_TRANSPARENT, state != STATE_PREBIND",
-                socket.ioHandle().fdDoNotUse());
-      return true;
-    }
-
-    auto& cilium_calls = PrivilegedService::Singleton::get();
-
-    auto ipVersion = socket.ipVersion();
-    if (!ipVersion.has_value()) {
-      ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
-      return false;
-    }
-
-    uint32_t one = 1;
-
-    // Set ip transparent option based on the socket address family
-    auto ip_socket_level = SOL_IP;
-    auto ip_transparent_socket_option = IP_TRANSPARENT;
-    auto ip_transparent_socket_option_name = "IP_TRANSPARENT";
-    if (*ipVersion == Network::Address::IpVersion::v6) {
-      ip_socket_level = SOL_IPV6;
-      ip_transparent_socket_option = IPV6_TRANSPARENT;
-      ip_transparent_socket_option_name = "IPV6_TRANSPARENT";
-    }
-
-    auto status = cilium_calls.setsockopt(socket.ioHandle().fdDoNotUse(), ip_socket_level,
-                                          ip_transparent_socket_option, &one, sizeof(one));
-    if (status.return_value_ < 0) {
-      if (status.errno_ == EPERM) {
-        // Do not assert out in this case so that we can run tests without
-        // CAP_NET_ADMIN.
-        ENVOY_LOG(critical,
-                  "Failed to set socket option {}, capability "
-                  "CAP_NET_ADMIN needed: {}",
-                  ip_transparent_socket_option_name, Envoy::errorDetails(status.errno_));
-      } else {
-        ENVOY_LOG(critical, "Socket option failure. Failed to set {}: {}",
-                  ip_transparent_socket_option_name, Envoy::errorDetails(status.errno_));
-        return false;
-      }
-    }
-
-    ENVOY_LOG(trace, "Successfully set socket option {} on socket: {}",
-              ip_transparent_socket_option_name, socket.ioHandle().fdDoNotUse());
-
-    return true;
-  }
+                 envoy::config::core::v3::SocketOption::SocketState state) const override;
 
   void hashKey([[maybe_unused]] std::vector<uint8_t>& key) const override {}
 

--- a/cilium/socket_option_source_address.cc
+++ b/cilium/socket_option_source_address.cc
@@ -1,9 +1,118 @@
 #include "cilium/socket_option_source_address.h"
 
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "envoy/config/core/v3/socket_option.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/network/socket.h"
+
+#include "source/common/common/hex.h"
+#include "source/common/common/logger.h"
+
+#include "absl/numeric/int128.h"
+
 namespace Envoy {
 namespace Cilium {
 
-// empty
+SourceAddressSocketOption::SourceAddressSocketOption(
+    uint32_t source_identity, Network::Address::InstanceConstSharedPtr original_source_address,
+    Network::Address::InstanceConstSharedPtr ipv4_source_address,
+    Network::Address::InstanceConstSharedPtr ipv6_source_address)
+    : source_identity_(source_identity),
+      original_source_address_(std::move(original_source_address)),
+      ipv4_source_address_(std::move(ipv4_source_address)),
+      ipv6_source_address_(std::move(ipv6_source_address)) {
+  ENVOY_LOG(debug,
+            "Cilium SourceAddressSocketOption(): source_identity: {}, source_addresses: {}/{}/{}",
+            source_identity, original_source_address_ ? original_source_address_->asString() : "",
+            ipv4_source_address_ ? ipv4_source_address_->asString() : "",
+            ipv6_source_address_ ? ipv6_source_address_->asString() : "");
+}
+
+bool SourceAddressSocketOption::setOption(
+    Network::Socket& socket, envoy::config::core::v3::SocketOption::SocketState state) const {
+  // Only set the option once per socket
+  if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
+    ENVOY_LOG(trace, "Skipping setting socket ({}) source address, state != STATE_PREBIND",
+              socket.ioHandle().fdDoNotUse());
+    return true;
+  }
+
+  auto ipVersion = socket.ipVersion();
+  if (!ipVersion.has_value()) {
+    ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
+    return false;
+  }
+
+  Network::Address::InstanceConstSharedPtr source_address = original_source_address_;
+  if (!source_address && (ipv4_source_address_ || ipv6_source_address_)) {
+    // Select source address based on the socket address family
+    source_address = ipv6_source_address_;
+    if (*ipVersion == Network::Address::IpVersion::v4) {
+      source_address = ipv4_source_address_;
+    }
+  }
+
+  if (!source_address) {
+    ENVOY_LOG(trace, "Skipping restore of local address on socket: {} - no source address",
+              socket.ioHandle().fdDoNotUse());
+    return true;
+  }
+
+  // Note: Restoration of the original source address happens on the socket of the upstream
+  // connection.
+  ENVOY_LOG(trace, "Restoring local address (original source) on socket: {} ({} -> {})",
+            socket.ioHandle().fdDoNotUse(),
+            socket.connectionInfoProvider().localAddress()
+                ? socket.connectionInfoProvider().localAddress()->asString()
+                : "n/a",
+            source_address->asString());
+
+  socket.connectionInfoProvider().setLocalAddress(std::move(source_address));
+
+  return true;
+}
+
+template <typename T> void addressIntoVector(std::vector<uint8_t>& vec, const T& address) {
+  const uint8_t* byte_array = reinterpret_cast<const uint8_t*>(&address);
+  vec.insert(vec.end(), byte_array, byte_array + sizeof(T));
+}
+
+void SourceAddressSocketOption::hashKey(std::vector<uint8_t>& key) const {
+  // Source address is more specific than policy ID. If using an original
+  // source address, we do not need to also add the source security ID to the
+  // hash key. Note that since the identity is 3 bytes it will not collide
+  // with neither an IPv4 nor IPv6 address.
+  if (original_source_address_) {
+    const auto& ip = original_source_address_->ip();
+    uint16_t port = ip->port();
+    if (ip->version() == Network::Address::IpVersion::v4) {
+      uint32_t raw_address = ip->ipv4()->address();
+      addressIntoVector(key, raw_address);
+    } else if (ip->version() == Network::Address::IpVersion::v6) {
+      absl::uint128 raw_address = ip->ipv6()->address();
+      addressIntoVector(key, raw_address);
+    }
+    // Add source port to the hash key if defined
+    if (port != 0) {
+      ENVOY_LOG(trace, "hashKey port: {:x}", port);
+      key.emplace_back(uint8_t(port >> 8));
+      key.emplace_back(uint8_t(port));
+    }
+    ENVOY_LOG(trace, "hashKey after with original source address: {}, original_source_address: {}",
+              Hex::encode(key), original_source_address_->asString());
+  } else {
+    // Add the source identity to the hash key. This will separate upstream
+    // connection pools per security ID.
+    key.emplace_back(uint8_t(source_identity_ >> 16));
+    key.emplace_back(uint8_t(source_identity_ >> 8));
+    key.emplace_back(uint8_t(source_identity_));
+    ENVOY_LOG(trace, "hashKey with source identity: {}, source_identity: {}", Hex::encode(key),
+              source_identity_);
+  }
+}
 
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/socket_option_source_address.cc
+++ b/cilium/socket_option_source_address.cc
@@ -1,0 +1,9 @@
+#include "cilium/socket_option_source_address.h"
+
+namespace Envoy {
+namespace Cilium {
+
+// empty
+
+} // namespace Cilium
+} // namespace Envoy

--- a/cilium/socket_option_source_address.h
+++ b/cilium/socket_option_source_address.h
@@ -1,22 +1,14 @@
 #pragma once
 
-#include <asm-generic/socket.h>
-#include <netinet/in.h>
-
-#include <cerrno>
 #include <cstdint>
-#include <string>
-#include <utility>
 #include <vector>
 
 #include "envoy/config/core/v3/socket_option.pb.h"
 #include "envoy/network/address.h"
 #include "envoy/network/socket.h"
 
-#include "source/common/common/hex.h"
 #include "source/common/common/logger.h"
 
-#include "absl/numeric/int128.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -34,17 +26,7 @@ public:
       uint32_t source_identity,
       Network::Address::InstanceConstSharedPtr original_source_address = nullptr,
       Network::Address::InstanceConstSharedPtr ipv4_source_address = nullptr,
-      Network::Address::InstanceConstSharedPtr ipv6_source_address = nullptr)
-      : source_identity_(source_identity),
-        original_source_address_(std::move(original_source_address)),
-        ipv4_source_address_(std::move(ipv4_source_address)),
-        ipv6_source_address_(std::move(ipv6_source_address)) {
-    ENVOY_LOG(debug,
-              "Cilium SourceAddressSocketOption(): source_identity: {}, source_addresses: {}/{}/{}",
-              source_identity, original_source_address_ ? original_source_address_->asString() : "",
-              ipv4_source_address_ ? ipv4_source_address_->asString() : "",
-              ipv6_source_address_ ? ipv6_source_address_->asString() : "");
-  }
+      Network::Address::InstanceConstSharedPtr ipv6_source_address = nullptr);
 
   absl::optional<Network::Socket::Option::Details>
   getOptionDetails(const Network::Socket&,
@@ -53,88 +35,9 @@ public:
   }
 
   bool setOption(Network::Socket& socket,
-                 envoy::config::core::v3::SocketOption::SocketState state) const override {
-    // Only set the option once per socket
-    if (state != envoy::config::core::v3::SocketOption::STATE_PREBIND) {
-      ENVOY_LOG(trace, "Skipping setting socket ({}) source address, state != STATE_PREBIND",
-                socket.ioHandle().fdDoNotUse());
-      return true;
-    }
+                 envoy::config::core::v3::SocketOption::SocketState state) const override;
 
-    auto ipVersion = socket.ipVersion();
-    if (!ipVersion.has_value()) {
-      ENVOY_LOG(critical, "Socket address family is not available, can not choose source address");
-      return false;
-    }
-
-    Network::Address::InstanceConstSharedPtr source_address = original_source_address_;
-    if (!source_address && (ipv4_source_address_ || ipv6_source_address_)) {
-      // Select source address based on the socket address family
-      source_address = ipv6_source_address_;
-      if (*ipVersion == Network::Address::IpVersion::v4) {
-        source_address = ipv4_source_address_;
-      }
-    }
-
-    if (!source_address) {
-      ENVOY_LOG(trace, "Skipping restore of local address on socket: {} - no source address",
-                socket.ioHandle().fdDoNotUse());
-      return true;
-    }
-
-    // Note: Restoration of the original source address happens on the socket of the upstream
-    // connection.
-    ENVOY_LOG(trace, "Restoring local address (original source) on socket: {} ({} -> {})",
-              socket.ioHandle().fdDoNotUse(),
-              socket.connectionInfoProvider().localAddress()
-                  ? socket.connectionInfoProvider().localAddress()->asString()
-                  : "n/a",
-              source_address->asString());
-
-    socket.connectionInfoProvider().setLocalAddress(std::move(source_address));
-
-    return true;
-  }
-
-  template <typename T> void addressIntoVector(std::vector<uint8_t>& vec, const T& address) const {
-    const uint8_t* byte_array = reinterpret_cast<const uint8_t*>(&address);
-    vec.insert(vec.end(), byte_array, byte_array + sizeof(T));
-  }
-
-  void hashKey(std::vector<uint8_t>& key) const override {
-    // Source address is more specific than policy ID. If using an original
-    // source address, we do not need to also add the source security ID to the
-    // hash key. Note that since the identity is 3 bytes it will not collide
-    // with neither an IPv4 nor IPv6 address.
-    if (original_source_address_) {
-      const auto& ip = original_source_address_->ip();
-      uint16_t port = ip->port();
-      if (ip->version() == Network::Address::IpVersion::v4) {
-        uint32_t raw_address = ip->ipv4()->address();
-        addressIntoVector(key, raw_address);
-      } else if (ip->version() == Network::Address::IpVersion::v6) {
-        absl::uint128 raw_address = ip->ipv6()->address();
-        addressIntoVector(key, raw_address);
-      }
-      // Add source port to the hash key if defined
-      if (port != 0) {
-        ENVOY_LOG(trace, "hashKey port: {:x}", port);
-        key.emplace_back(uint8_t(port >> 8));
-        key.emplace_back(uint8_t(port));
-      }
-      ENVOY_LOG(trace,
-                "hashKey after with original source address: {}, original_source_address: {}",
-                Hex::encode(key), original_source_address_->asString());
-    } else {
-      // Add the source identity to the hash key. This will separate upstream
-      // connection pools per security ID.
-      key.emplace_back(uint8_t(source_identity_ >> 16));
-      key.emplace_back(uint8_t(source_identity_ >> 8));
-      key.emplace_back(uint8_t(source_identity_));
-      ENVOY_LOG(trace, "hashKey with source identity: {}, source_identity: {}", Hex::encode(key),
-                source_identity_);
-    }
-  }
+  void hashKey(std::vector<uint8_t>& key) const override;
 
   bool isSupported() const override { return true; }
 


### PR DESCRIPTION
```
socket_options: introduce C files

Currently, the socket options are completely defined in C++
header files. As a result, the bazel BUILD file misses some
dependencies that also result to clangd not working properly
for these files.

This commit prepares the split into C & Header files by introducing
the "empty" *.cc files and fixing the dependencies in the BUILD file.

In the next commit, the logic will be moved.
```

```
socket_options: move logic to C files

This commit moves the implementation of the socket options
into the *.cc files.
```