### PR TITLE
envoy: skip upstream handling on shadows

### DIFF
--- a/cilium/l7policy.cc
+++ b/cilium/l7policy.cc
@@ -265,6 +265,10 @@ void AccessFilter::onStreamComplete() {
 }
 
 Http::FilterHeadersStatus AccessFilter::encodeHeaders(Http::ResponseHeaderMap& headers, bool) {
+  // Skip enforcement or logging on shadows
+  if (callbacks_->streamInfo().isShadow()) {
+    return Http::FilterHeadersStatus::Continue;
+  }
 
   ENVOY_CONN_LOG(debug, "cilium.l7policy: {} encodeHeaders()", callbacks_->connection().ref(),
                  config_->is_upstream_ ? "upstream" : "downstream");

--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -143,6 +143,11 @@ Network::FilterStatus Instance::onNewConnection() {
   callbacks_->addUpstreamCallback([this, policy_fs,
                                    sni](Upstream::HostDescriptionConstSharedPtr host,
                                         StreamInfo::StreamInfo& stream_info) -> bool {
+    // Skip enforcement or logging on shadows
+    if (stream_info.isShadow()) {
+      return true;
+    }
+
     auto& conn = callbacks_->connection();
     ENVOY_CONN_LOG(trace, "cilium.network: in upstream callback", conn);
 


### PR DESCRIPTION
PR https://github.com/cilium/proxy/pull/1140 introduced a regression where
logging fails on shadow upstream connections (Detected in Gateway API tests in cilium/cilium).

Therefore this PR is checking for shadowing connections and skips
enforcement & logging on them.