### PR TITLE
policy: Use source pod's egress policy if available

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -371,7 +371,7 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
     return absl::nullopt;
   }
 
-  std::string pod_ip, other_ip;
+  std::string pod_ip, other_ip, ingress_policy_name;
   if (is_ingress_) {
     pod_ip = dip->addressAsString();
     other_ip = sip->addressAsString();
@@ -446,30 +446,27 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
       return absl::nullopt;
     }
 
-    auto& ingress_ip_str = ingress_ip->addressAsString();
+    // Enforce pod policy only for local pods.
+    if (policy->getEndpointID() == 0) {
+      pod_ip = ""; // source is not a local pod
+    }
 
-    auto new_source_identity = resolvePolicyId(ingress_ip);
-    if (new_source_identity == Cilium::ID::WORLD) {
+    // Enforce Ingress policy?
+    if (enforce_policy_on_l7lb_) {
+      ingress_source_identity = source_identity;
+      ingress_policy_name = ingress_ip->addressAsString();
+    }
+
+    // Resolve source identity for the Ingress address
+    source_identity = resolvePolicyId(ingress_ip);
+    if (source_identity == Cilium::ID::WORLD) {
       // No security ID available for the configured source IP
       ENVOY_LOG(warn,
                 "cilium.bpf_metadata (north/south L7 LB): Unknown local Ingress IP source address "
                 "configured: {}",
-                ingress_ip_str);
+                ingress_ip->addressAsString());
       return absl::nullopt;
     }
-
-    // Enforce ingress policy on the incoming Ingress traffic?
-    if (enforce_policy_on_l7lb_)
-      ingress_source_identity = source_identity;
-
-    source_identity = new_source_identity;
-
-    // AllowAllEgressPolicy will be returned if no explicit Ingress policy exists
-    policy = &getPolicy(ingress_ip_str);
-
-    // Set Ingress source IP as pod_ip (In case of egress (how N/S L7 LB is implemented), the pod_ip
-    // is the source IP)
-    pod_ip = ingress_ip_str;
 
     // Original source address is never used for north/south LB
     src_address = nullptr;
@@ -511,9 +508,9 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
   }
   return absl::optional(Cilium::BpfMetadata::SocketMetadata(
       mark, ingress_source_identity, source_identity, is_ingress_, is_l7lb_, dip->port(),
-      std::move(pod_ip), std::move(src_address), std::move(source_addresses.ipv4_),
-      std::move(source_addresses.ipv6_), std::move(dst_address), weak_from_this(), proxy_id_,
-      std::move(proxylib_l7proto), sni));
+      std::move(pod_ip), std::move(ingress_policy_name), std::move(src_address),
+      std::move(source_addresses.ipv4_), std::move(source_addresses.ipv6_), std::move(dst_address),
+      weak_from_this(), proxy_id_, std::move(proxylib_l7proto), sni));
 }
 
 Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -33,6 +33,7 @@ namespace BpfMetadata {
 struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
   SocketMetadata(uint32_t mark, uint32_t ingress_source_identity, uint32_t source_identity,
                  bool ingress, bool l7lb, uint16_t port, std::string&& pod_ip,
+                 std::string&& ingress_policy_name,
                  Network::Address::InstanceConstSharedPtr original_source_address,
                  Network::Address::InstanceConstSharedPtr source_address_ipv4,
                  Network::Address::InstanceConstSharedPtr source_address_ipv6,
@@ -41,7 +42,8 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
                  std::string&& proxylib_l7_proto, absl::string_view sni)
       : ingress_source_identity_(ingress_source_identity), source_identity_(source_identity),
         ingress_(ingress), is_l7lb_(l7lb), port_(port), pod_ip_(std::move(pod_ip)),
-        proxy_id_(proxy_id), proxylib_l7_proto_(std::move(proxylib_l7_proto)), sni_(sni),
+        ingress_policy_name_(std::move(ingress_policy_name)), proxy_id_(proxy_id),
+        proxylib_l7_proto_(std::move(proxylib_l7_proto)), sni_(sni),
         policy_resolver_(policy_resolver), mark_(mark),
         original_source_address_(std::move(original_source_address)),
         source_address_ipv4_(std::move(source_address_ipv4)),
@@ -51,7 +53,7 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
   std::shared_ptr<Envoy::Cilium::CiliumPolicyFilterState> buildCiliumPolicyFilterState() {
     return std::make_shared<Envoy::Cilium::CiliumPolicyFilterState>(
         ingress_source_identity_, source_identity_, ingress_, is_l7lb_, port_, std::move(pod_ip_),
-        policy_resolver_, proxy_id_, sni_);
+        std::move(ingress_policy_name_), policy_resolver_, proxy_id_, sni_);
   };
 
   std::shared_ptr<Envoy::Cilium::CiliumMarkSocketOption> buildCiliumMarkSocketOption() {
@@ -103,7 +105,8 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
   bool ingress_;
   bool is_l7lb_;
   uint16_t port_;
-  std::string pod_ip_;
+  std::string pod_ip_;              // pod policy to enforce, if any
+  std::string ingress_policy_name_; // Ingress policy to enforce, if any
   uint32_t proxy_id_;
   std::string proxylib_l7_proto_;
   std::string sni_;

--- a/cilium/filter_state_cilium_policy.cc
+++ b/cilium/filter_state_cilium_policy.cc
@@ -11,8 +11,129 @@
 namespace Envoy {
 namespace Cilium {
 
-const std::string& Envoy::Cilium::CiliumPolicyFilterState::key() {
+const std::string& CiliumPolicyFilterState::key() {
   CONSTRUCT_ON_FIRST_USE(std::string, "cilium.policy");
+}
+
+bool CiliumPolicyFilterState::enforceNetworkPolicy(const Network::Connection& conn,
+                                                   uint32_t destination_identity,
+                                                   uint16_t destination_port,
+                                                   const absl::string_view sni,
+                                                   /* OUT */ bool& use_proxy_lib,
+                                                   /* OUT */ std::string& l7_proto,
+                                                   /* INOUT */ AccessLog::Entry& log_entry) const {
+  const auto resolver = policy_resolver_.lock();
+  use_proxy_lib = false;
+  l7_proto = "";
+
+  if (!resolver) {
+    // No policy resolver
+    ENVOY_CONN_LOG(debug, "No policy resolver", conn);
+    return false;
+  }
+
+  // enforce pod policy first, if any
+  if (pod_ip_.length() > 0) {
+    const auto& policy = resolver->getPolicy(pod_ip_);
+    auto remote_id = ingress_ ? source_identity_ : destination_identity;
+    auto port = ingress_ ? port_ : destination_port;
+
+    auto portPolicy = policy.findPortPolicy(ingress_, port);
+
+    if (!portPolicy.allowed(remote_id, sni)) {
+      ENVOY_CONN_LOG(debug, "Pod policy DENY on id: {} port: {} sni: \"{}\"", conn, remote_id,
+                     destination_port, sni);
+      return false;
+    }
+
+    // populate l7proto_ if available
+    use_proxy_lib = portPolicy.useProxylib(remote_id, l7_proto);
+  }
+
+  // enforce Ingress policy 2nd, if any
+  if (ingress_policy_name_.length() > 0) {
+    log_entry.entry_.set_policy_name(ingress_policy_name_);
+    const auto& policy = resolver->getPolicy(ingress_policy_name_);
+
+    // Enforce ingress policy for Ingress, on the original destination port
+    if (ingress_source_identity_ != 0) {
+      auto ingressPortPolicy = policy.findPortPolicy(true, port_);
+      if (!ingressPortPolicy.allowed(ingress_source_identity_, sni)) {
+        ENVOY_CONN_LOG(debug,
+                       "Ingress network policy DROP for source identity: {} port: {} sni: \"{}\"",
+                       conn, ingress_source_identity_, destination_port, sni);
+        return false;
+      }
+    }
+
+    // Enforce egress policy for Ingress
+    auto egressPortPolicy = policy.findPortPolicy(false, destination_port);
+    if (!egressPortPolicy.allowed(destination_identity, sni)) {
+      ENVOY_CONN_LOG(debug,
+                     "Egress network policy DROP for destination identity: {} port: {} sni: \"{}\"",
+                     conn, destination_identity, destination_port, sni);
+      return false;
+    }
+  }
+
+  // Connection allowed by policy
+  return true;
+}
+
+bool CiliumPolicyFilterState::enforceHTTPPolicy(const Network::Connection& conn, bool is_downstream,
+                                                uint32_t destination_identity,
+                                                uint16_t destination_port,
+                                                /* INOUT */ Http::RequestHeaderMap& headers,
+                                                /* INOUT */ AccessLog::Entry& log_entry) const {
+  const auto resolver = policy_resolver_.lock();
+
+  if (!resolver) {
+    // No policy resolver
+    ENVOY_CONN_LOG(debug, "No policy resolver", conn);
+    return false;
+  }
+
+  // enforce pod policy first, if any.
+  // - ingress enforcement in downstream
+  // - egress enforcement in upstream
+  // - unless !L7LB, where both are done on downstream filter (only)
+  // =>
+  // - is_l7lb_: ingress_ == is_downstream
+  // - !is_l7lb_: is_downstream
+  if (pod_ip_.length() > 0 && (is_l7lb_ ? is_downstream == ingress_ : is_downstream)) {
+    const auto& policy = resolver->getPolicy(pod_ip_);
+    auto remote_id = ingress_ ? source_identity_ : destination_identity;
+    auto port = ingress_ ? port_ : destination_port;
+    if (!policy.allowed(ingress_, remote_id, port, headers, log_entry)) {
+      ENVOY_CONN_LOG(debug, "Pod HTTP policy DENY on id: {} port: {}", conn, remote_id, port);
+      return false;
+    }
+  }
+
+  // enforce Ingress policy 2nd, if any, always on the upstream
+  if (!is_downstream && ingress_policy_name_.length() > 0) {
+    log_entry.entry_.set_policy_name(ingress_policy_name_);
+    const auto& policy = resolver->getPolicy(ingress_policy_name_);
+
+    // Enforce ingress policy for Ingress, on the original destination port
+    if (ingress_source_identity_ != 0) {
+      if (!policy.allowed(true, ingress_source_identity_, port_, headers, log_entry)) {
+        ENVOY_CONN_LOG(debug, "Ingress HTTP policy DROP for source identity: {} port: {}", conn,
+                       ingress_source_identity_, port_);
+        return false;
+      }
+    }
+
+    // Enforce egress policy for Ingress
+    if (!policy.allowed(false, destination_identity, destination_port, headers, log_entry)) {
+      ENVOY_CONN_LOG(debug, "Egress HTTP policy DROP for destination identity: {} port: {}", conn,
+                     destination_identity, destination_port);
+      return false;
+    }
+  }
+
+  // Connection allowed by policy
+  return true;
 }
 
 } // namespace Cilium

--- a/cilium/filter_state_cilium_policy.h
+++ b/cilium/filter_state_cilium_policy.h
@@ -3,19 +3,20 @@
 #include <asm-generic/socket.h>
 #include <netinet/in.h>
 
-#include <cerrno>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include "envoy/common/pure.h"
+#include "envoy/http/header_map.h"
 #include "envoy/network/address.h"
 #include "envoy/stream_info/filter_state.h"
 
 #include "source/common/common/logger.h"
 
 #include "absl/strings/string_view.h"
+#include "cilium/accesslog.h"
 #include "cilium/network_policy.h"
 #include "cilium/policy_id.h"
 
@@ -37,15 +38,18 @@ class CiliumPolicyFilterState : public StreamInfo::FilterState::Object,
 public:
   CiliumPolicyFilterState(uint32_t ingress_source_identity, uint32_t source_identity, bool ingress,
                           bool l7lb, uint16_t port, std::string&& pod_ip,
+                          std::string&& ingress_policy_name,
                           const std::weak_ptr<PolicyResolver>& policy_resolver, uint32_t proxy_id,
                           absl::string_view sni)
       : ingress_source_identity_(ingress_source_identity), source_identity_(source_identity),
         ingress_(ingress), is_l7lb_(l7lb), port_(port), pod_ip_(std::move(pod_ip)),
-        proxy_id_(proxy_id), sni_(sni), policy_resolver_(policy_resolver) {
-    ENVOY_LOG(debug,
-              "Cilium CiliumPolicyFilterState(): source_identity: {}, "
-              "ingress: {}, port: {}, pod_ip: {}, proxy_id: {}, sni: \"{}\"",
-              source_identity_, ingress_, port_, pod_ip_, proxy_id_, sni_);
+        ingress_policy_name_(std::move(ingress_policy_name)), proxy_id_(proxy_id), sni_(sni),
+        policy_resolver_(policy_resolver) {
+    ENVOY_LOG(
+        debug,
+        "Cilium CiliumPolicyFilterState(): source_identity: {}, "
+        "ingress: {}, port: {}, pod_ip: {}, ingress_policy_name: {}, proxy_id: {}, sni: \"{}\"",
+        source_identity_, ingress_, port_, pod_ip_, ingress_policy_name_, proxy_id_, sni_);
   }
 
   uint32_t resolvePolicyId(const Network::Address::Ip* ip) const {
@@ -62,6 +66,17 @@ public:
     return NetworkPolicyMap::GetDenyAllPolicy();
   }
 
+  bool enforceNetworkPolicy(const Network::Connection& conn, uint32_t destination_identity,
+                            uint16_t destination_port, const absl::string_view sni,
+                            /* OUT */ bool& use_proxy_lib,
+                            /* OUT */ std::string& l7_proto,
+                            /* INOUT */ AccessLog::Entry& log_entry) const;
+
+  bool enforceHTTPPolicy(const Network::Connection& conn, bool is_downstream,
+                         uint32_t destination_identity, uint16_t destination_port,
+                         /* INOUT */ Http::RequestHeaderMap& headers,
+                         /* INOUT */ AccessLog::Entry& log_entry) const;
+
   // policyUseUpstreamDestinationAddress returns 'true' if policy enforcement should be done on the
   // basis of the upstream destination address.
   bool policyUseUpstreamDestinationAddress() const { return is_l7lb_; }
@@ -75,6 +90,7 @@ public:
   bool is_l7lb_;
   uint16_t port_;
   std::string pod_ip_;
+  std::string ingress_policy_name_;
   uint32_t proxy_id_;
   std::string sni_;
 

--- a/cilium/l7policy.cc
+++ b/cilium/l7policy.cc
@@ -192,63 +192,46 @@ Http::FilterHeadersStatus AccessFilter::decodeHeaders(Http::RequestHeaderMap& he
     return Http::FilterHeadersStatus::StopIteration;
   }
 
-  uint32_t destination_port = dip->port();
-  uint32_t destination_identity = policy_fs->resolvePolicyId(dip);
-
-  // Policy may have changed since the connection was established, get fresh policy
-  const auto& policy = policy_fs->getPolicy();
-
   if (log_entry_ == nullptr) {
     sendLocalError("cilium.l7policy: No log entry");
     return Http::FilterHeadersStatus::StopIteration;
   }
 
-  bool denied = false;
-  // Enforce Ingress policy only in the downstream filter
+  uint32_t destination_identity = policy_fs->resolvePolicyId(dip);
+  uint16_t destination_port = dip->port();
+
+  // Initialize log entry in the beginning of downstream processing
   if (!config_->is_upstream_) {
     log_entry_->InitFromRequest(
         policy_fs->pod_ip_, policy_fs->proxy_id_, policy_fs->ingress_, policy_fs->source_identity_,
         callbacks_->streamInfo().downstreamAddressProvider().remoteAddress(), 0,
         callbacks_->streamInfo().downstreamAddressProvider().localAddress(),
         callbacks_->streamInfo(), headers);
-
-    if (policy_fs->ingress_source_identity_ != 0) {
-      allowed_ = policy.allowed(true, policy_fs->ingress_source_identity_, policy_fs->port_,
-                                headers, *log_entry_);
-      ENVOY_CONN_LOG(
-          debug, "cilium.l7policy: Ingress from {} policy lookup for endpoint {} for port {}: {}",
-          conn.ref(), policy_fs->ingress_source_identity_, policy_fs->pod_ip_, policy_fs->port_,
-          allowed_ ? "ALLOW" : "DENY");
-      denied = !allowed_;
-    }
-
-    // Downstream filter leaves L7 LB enforcement and access logging to the upstream
-    // filter
-    if (!denied && policy_fs->is_l7lb_) {
-      return Http::FilterHeadersStatus::Continue;
-    }
   }
 
-  if (!denied) {
-    allowed_ =
-        policy.allowed(policy_fs->ingress_,
-                       policy_fs->ingress_ ? policy_fs->source_identity_ : destination_identity,
-                       destination_port, headers, *log_entry_);
-  }
+  allowed_ = policy_fs->enforceHTTPPolicy(conn.ref(), !config_->is_upstream_, destination_identity,
+                                          destination_port, headers, *log_entry_);
+
   ENVOY_CONN_LOG(
       debug, "cilium.l7policy: {} ({}->{}) {} policy lookup for endpoint {} for port {}: {}",
       conn.ref(), policy_fs->ingress_ ? "ingress" : "egress", policy_fs->source_identity_,
       destination_identity, config_->is_upstream_ ? "upstream" : "downstream", policy_fs->pod_ip_,
       destination_port, allowed_ ? "ALLOW" : "DENY");
 
+  // Downstream filter leaves L7 LB enforcement and access logging to the upstream
+  // filter
+  if (!config_->is_upstream_ && allowed_ && policy_fs->is_l7lb_) {
+    return Http::FilterHeadersStatus::Continue;
+  }
+
   // Update the log entry with the chosen destination address and current headers, as remaining
   // filters, upstream, and/or policy may have altered headers.
   log_entry_->UpdateFromRequest(destination_identity, dst_address, headers);
 
   if (!allowed_) {
+    config_->Log(*log_entry_, ::cilium::EntryType::Denied);
     callbacks_->sendLocalReply(Http::Code::Forbidden, config_->denied_403_body_, nullptr,
                                absl::nullopt, absl::string_view());
-    config_->Log(*log_entry_, ::cilium::EntryType::Denied);
     return Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -149,7 +149,6 @@ public:
   virtual bool allowed(bool ingress, uint32_t remote_id, absl::string_view sni,
                        uint16_t port) const PURE;
 
-  // Returned pointer must not be stored for later use!
   virtual const PortPolicy findPortPolicy(bool ingress, uint16_t port) const PURE;
 
   // Returns true if the policy specifies l7 protocol for the connection, and

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -191,7 +191,7 @@ TestConfig::extractSocketMetadata(Network::ConnectionSocket& socket) {
                      l7proto);
 
   return absl::optional(Cilium::BpfMetadata::SocketMetadata(
-      0, 0, source_identity, is_ingress_, is_l7lb_, port, std::move(pod_ip), nullptr, nullptr,
+      0, 0, source_identity, is_ingress_, is_l7lb_, port, std::move(pod_ip), "", nullptr, nullptr,
       nullptr, original_dst_address, shared_from_this(), 0, std::move(l7proto), ""));
 }
 


### PR DESCRIPTION
Enforce source pod's egress policy, if available, i.e., when the source is a local pod, even in the north/south scenario, where the Ingress IP is used as the upstream source address.