### PR TITLE
ci: use --curl-parallel=10 on cilium integration tests

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Execute Cilium L7 Connectivity Tests
         shell: bash
-        run: cilium connectivity test --test="l7|sni|tls|ingress|check-log-errors"
+        run: cilium connectivity test --test="l7|sni|tls|ingress|check-log-errors" --curl-parallel=10
 
       - name: Gather Cilium system dump
         if: failure()


### PR DESCRIPTION
Also the set-header tests were succeeding with `--curl-parallel=10` locally today, let's see if we can lock this in.