### PR TITLE
gha: Use workflow_call for Cilium Integration test

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -18,6 +18,8 @@ jobs:
     timeout-minutes: 360
     name: Build and push multi-arch images
     runs-on: ubuntu-latest-64-cores-256gb
+    outputs:
+      sha: ${{ steps.tag.outputs.sha }}
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -147,3 +149,16 @@ jobs:
         run: |
           echo "Digests:"
           echo "quay.io/${{ github.repository_owner }}/cilium-envoy-dev:${{ github.event.pull_request.head.sha }}@${{ steps.docker_build_ci.outputs.digest }}"
+
+  cilium-intergration-tests:
+    name: Cilium Integration Tests
+    needs: build-and-push-prs
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    uses: ./.github/workflows/cilium-integration-tests.yaml
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name }}
+      commit_ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit

--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -1,18 +1,19 @@
 name: Cilium Integration Tests
 on:
-  push:
-    branches:
-      - main
-  pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      repository:
+        description: 'Github Repository to run the workflow on.'
+        type: string
+        required: true
+        default: cilium/proxy
+      commit_ref:
+        description: 'Git commit ref for image.'
+        type: string
+        required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  group: ${{ github.workflow }}-${{ inputs.repository || github.event.pull_request.number || github.event.after }}
   cancel-in-progress: true
 
 # By specifying the access of one of the scopes, all of those that are not specified are set to 'none'.
@@ -45,11 +46,11 @@ jobs:
           echo "PROXY_GITHUB_REPO=github.com/cilium/proxy" >> $GITHUB_ENV
 
       - name: Prepare variables for PR
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: inputs.commit_ref != ''
         run: |
           echo "PROXY_IMAGE=quay.io/cilium/cilium-envoy-dev" >> $GITHUB_ENV
-          echo "PROXY_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-          echo "PROXY_GITHUB_REPO=github.com/${{github.event.pull_request.head.repo.full_name}}" >> $GITHUB_ENV
+          echo "PROXY_TAG=${{ inputs.commit_ref }}" >> $GITHUB_ENV
+          echo "PROXY_GITHUB_REPO=github.com/${{ inputs.repository }}" >> $GITHUB_ENV
 
       - name: Checkout Cilium ${{ env.CILIUM_REPO_REF }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -176,7 +177,6 @@ jobs:
         if: failure()
         shell: bash
         run: cilium sysdump --output-filename cilium-sysdump-final
-
 
       - name: Upload Cilium system dump
         if: failure()


### PR DESCRIPTION
The goal is to avoid extra waiting time, while building the images.

Testing was done with temp commit, here is the sample run https://github.com/cilium/proxy/actions/runs/15178091834/job/42682174454?pr=1178