### PR TITLE
renovate: Allow golang <1.24

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,33 @@
   ],
   packageRules: [
     {
+      "groupName": "Go",
+      "matchDepNames": [
+        "go",
+        "docker.io/library/golang"
+      ],
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/golang",
+        "go"
+      ],
+      "allowedVersions": "<1.25",
+      "matchBaseBranches": [
+        "main",
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/golang",
+        "go"
+      ],
+      "allowedVersions": "<1.24",
+      "matchBaseBranches": [
+        "v1.31",
+      ]
+    },
+    {
       groupName: 'all go dependencies main',
       groupSlug: 'all-go-deps-main',
       matchFileNames: [


### PR DESCRIPTION
This is just to make sure we don't intentionally upgrade go version, which may (or may not) break cilium/cilium upstream. If there is tangile benefit, we can remove such constraint later.