### PR TITLE
WIP: use cncf hosted gha runners

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -17,7 +17,7 @@ jobs:
   build-and-push-prs:
     timeout-minutes: 360
     name: Build and push multi-arch images
-    runs-on: ubuntu-latest-64-cores-256gb
+    runs-on: oracle-64cpu-384gb-x86-64
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -18,7 +18,7 @@ jobs:
   test-cache-refresh:
     timeout-minutes: 360
     name: Build test cache and push images
-    runs-on: ubuntu-latest-64-cores-256gb
+    runs-on: oracle-64cpu-384gb-x86-64
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -117,7 +117,7 @@ jobs:
   build-cache-and-push-images:
     timeout-minutes: 360
     name: Build cache and push images
-    runs-on: ubuntu-latest-64-cores-256gb
+    runs-on: oracle-64cpu-384gb-x86-64
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -39,7 +39,7 @@ jobs:
   tests:
     timeout-minutes: 360
     name: Run integration tests on amd64
-    runs-on: ubuntu-latest-64-cores-256gb
+    runs-on: oracle-64cpu-384gb-x86-64
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners in Oracle that we're wanting projects to use rather than the GitHub hosted ones, which are now incur a cost to use. This PR is currently a WIP to work through any tests that break or dependencies that may be missing. <3

Please direct any questions to myself, @krook and @RobertKielty