### PR TITLE
deps: Bump ubuntu runtime image to 24.04

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,6 +82,18 @@
     {
       matchFileNames: [
         'Dockerfile',
+      ],
+      matchPackageNames: [
+        'docker.io/library/ubuntu',
+      ],
+      allowedVersions: '24.04',
+      matchBaseBranches: [
+        'main',
+        'v1.31',
+      ],
+    },
+    {
+      matchFileNames: [
         'Dockerfile.builder'
       ],
       matchPackageNames: [

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ COPY --from=check-format /cilium/proxy/format-output.txt /
 #
 # Extract installed cilium-envoy binaries to an otherwise empty image
 #
-FROM docker.io/library/ubuntu:22.04@sha256:ed1544e454989078f5dec1bfdabd8c5cc9c48e0705d07b678ab6ae3fb61952d2
+FROM docker.io/library/ubuntu:24.04@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782
 LABEL maintainer="maintainer@cilium.io"
 # install ca-certificates package
 RUN apt-get update && apt-get upgrade -y \


### PR DESCRIPTION
We still need builder image with ubuntu 22.04 till the oldest cilium/cilium is 1.17.

Testing is done in upstream https://github.com/cilium/cilium/pull/38137

Fixes: https://github.com/cilium/proxy/issues/1200