### PR TITLE
gha: Remove un-used command/env/file

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -66,7 +66,6 @@ jobs:
 
       - name: Prep for build
         run: |
-          echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
           echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder.tests | awk '{ print $3 }')" >> $GITHUB_ENV
 
       - name: Checking if cilium-envoy-builder image exists


### PR DESCRIPTION
This variable is not used in github action workflow, so better just remove it.

Makefile derives the value from git command.