### PR TITLE
code-ql: Add scheduled run weekly

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,9 @@ name: CodeQL
 
 on: 
   workflow_dispatch:
+  schedule:
+    # Run at the end of every Monday
+    - cron: '0 0 * * 1'
 
 jobs:
   analyze:


### PR DESCRIPTION
Let's run it at the end of every Monday, we don't really need to care
about timezone.
