### PR TITLE
clang: Add clang macro check

### DIFF
--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -1215,10 +1215,14 @@ bool NetworkPolicyMap::isNewStream() {
 // removeInitManager must be called at the end of each policy update
 void NetworkPolicyMap::removeInitManager() {
   // Remove the local init manager from the transport factory context
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnull-dereference"
+#endif
   transport_factory_context_->setInitManager(*static_cast<Init::Manager*>(nullptr));
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 }
 
 // onConfigUpdate parses the new network policy resources, allocates a new policy map and atomically


### PR DESCRIPTION
This is to avoid the below issue, as local dev might be using GCC instead of clang.

```
cilium/network_policy.cc:1218: error: ignoring '#pragma clang diagnostic' [-Werror=unknown-pragmas]
 1218 | #pragma clang diagnostic push
      |
cilium/network_policy.cc:1219: error: ignoring '#pragma clang diagnostic' [-Werror=unknown-pragmas]
 1219 | #pragma clang diagnostic ignored "-Wnull-dereference"
      |
cilium/network_policy.cc:1221: error: ignoring '#pragma clang diagnostic' [-Werror=unknown-pragmas]
 1221 | #pragma clang diagnostic pop
 ```