### PR TITLE
ipcache: Try maps in inverse order for downgrade

### DIFF
--- a/cilium/ipcache.cc
+++ b/cilium/ipcache.cc
@@ -25,7 +25,7 @@ namespace Envoy {
 namespace Cilium {
 
 // IP cache names to look for, in the order of prefefrence
-static const char* ipcache_names[] = {"cilium_ipcache_v2", "cilium_ipcache"};
+static const char* ipcache_names[] = {"cilium_ipcache", "cilium_ipcache_v2"};
 
 // These must be kept in sync with Cilium source code, should refactor
 // them to a separate include file we can include here instead of


### PR DESCRIPTION
Starting with v1.18, we will have a new v2 ipcache map, `cilium_ipcache_v2`. Therefore, on upgrades from v1.17, our proxy currently tries to open the v2 map first, and if it can't find it, it tries the v1 map. That is implemented by commit 6cb4e565c095 ("ipcache: Try multiple maps of different sizes") and works well.

This same commit however made it into cilium-proxy v1.32 which Cilium v1.17 is using. Thus, on downgrades to v1.17, we first try (and succeed) to open the v2 map. Because v1.17 is actually updating entries in the v1 map, we may end up with stale security identities.

To fix this, in the proxy image for v1.17, we need to first open the v1 map and only fallback to the v2 map if the v1 can't be found yet.