### PR TITLE
gha: Fix codeql build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
           --features="-layering_check" \
           --config=clang-libc++ \
           --config=ci \
-          //cilium/...
+          cilium-envoy
 
       - name: Autobuild
         if: matrix.config.language != 'cpp'


### PR DESCRIPTION
We don't need to regenerate the API, just run the build

Fixes: #1246

Testing is done via https://github.com/cilium/proxy/actions/runs/14260547976