### PR TITLE
v1.32 Backports 2025-04-09

### DIFF
--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -1211,10 +1211,14 @@ bool NetworkPolicyMap::isNewStream() {
 // removeInitManager must be called at the end of each each policy update
 void NetworkPolicyMap::removeInitManager() {
   // Remove the local init manager from the transport factory context
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnull-dereference"
+#endif
   transport_factory_context_->setInitManager(*static_cast<Init::Manager*>(nullptr));
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 }
 
 // onConfigUpdate parses the new network policy resources, allocates a new policy map and atomically


### PR DESCRIPTION
 * [ ] #1241 (@sayboras) - There is no functional change, but it will improve the experience for local dev on v1.32

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 1241
```
