### PR TITLE
[v1.32] image: Bump ubuntu version to 24.04

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -109,24 +109,12 @@
     {
       matchFileNames: [
         'Dockerfile',
-      ],
-      matchPackageNames: [
-        'docker.io/library/ubuntu',
-      ],
-      allowedVersions: '24.04',
-      matchBaseBranches: [
-        'main',
-        'v1.31',
-      ],
-    },
-    {
-      matchFileNames: [
         'Dockerfile.builder'
       ],
       matchPackageNames: [
         'docker.io/library/ubuntu',
       ],
-      allowedVersions: '22.04',
+      allowedVersions: '24.04',
       matchBaseBranches: [
         'main',
         'v1.31',

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -3,7 +3,7 @@
 # Also note that if build fails due to C++ internal error or similar,
 # it is possible that the image build needs more RAM than available by
 # default on non-Linux docker installs.
-FROM docker.io/library/ubuntu:22.04@sha256:d80997daaa3811b175119350d84305e1ec9129e1799bba0bd1e3120da3ff52c3 AS base
+FROM docker.io/library/ubuntu:24.04@sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02 AS base
 LABEL maintainer="maintainer@cilium.io"
 ARG TARGETARCH
 # Setup TimeZone to prevent tzdata package asking for it interactively
@@ -27,7 +27,7 @@ RUN apt-get update && \
       # Cilium-envoy build dependencies
       software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-    apt-add-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" && \
+    apt-add-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-17 main" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       clang-17 clang-tools-17 llvm-17-dev lldb-17 lld-17 clang-format-17 libc++-17-dev libc++abi-17-dev && \

--- a/Dockerfile.builder.tests
+++ b/Dockerfile.builder.tests
@@ -5,10 +5,7 @@
 # it is possible that the image build needs more RAM than available by
 # default on non-Linux docker installs.
 #
-# This shoould be the same as Dockerfile.builder except the below:
-# - Ubuntu version is bumped to 22.04
-# - LLVM apt repo is from apt.llvm.org/jammy/ instead of apt.llvm.org/focal/
-FROM docker.io/library/ubuntu:22.04@sha256:9a0bdde4188b896a372804be2384015e90e3f84906b750c1a53539b585fbbe7f AS base
+FROM docker.io/library/ubuntu:24.04@sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02 AS base
 LABEL maintainer="maintainer@cilium.io"
 ARG TARGETARCH
 # Setup TimeZone to prevent tzdata package asking for it interactively
@@ -28,7 +25,7 @@ RUN apt-get update && \
       # Cilium-envoy build dependencies
       software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-    apt-add-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" && \
+    apt-add-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-17 main" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       clang-17 clang-tools-17 llvm-17-dev lldb-17 lld-17 clang-format-17 libc++-17-dev libc++abi-17-dev && \


### PR DESCRIPTION
Once Cilium 1.16 is the min supported version, we can move to ubuntu 24.04.