### PR TITLE
cilium: Update the generic error message

### DIFF
--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -36,7 +36,7 @@ namespace Cilium {
 
 namespace {
 
-constexpr absl::string_view NotReadyReason{"TLS error: Secret is not supplied by SDS"};
+constexpr absl::string_view NotReadyReason{"Socket is not ready"};
 
 // This SslSocketWrapper wraps a real SslSocket and hooks it up with
 // TLS configuration derived from Cilium Network Policy.


### PR DESCRIPTION
SDS secret unavailability is not the only reason for socket error, for example, port binding failure could be another reason. This commit is to change the confusing error message.