### PR TITLE
[v1.32] gha: Use the oldest Cilium supported version

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -26,7 +26,7 @@ env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION: v0.27.0
   CILIUM_REPO_OWNER: cilium
-  CILIUM_REPO_REF: main
+  CILIUM_REPO_REF: v1.15
   CILIUM_CLI_REF: latest
   CURL_PARALLEL: ${{ vars.CURL_PARALLEL || 10 }}
 


### PR DESCRIPTION
Cilium stable branches are with cilium/proxy v1.32, while Cilium main branch is with cilium/proxy main. So it's better to test v1.32 with the oldest cilium supported version (e.g. v1.15) instead of main.