### PR TITLE
ingress: Use ingress IPs as socket source address

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -432,13 +432,6 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
       return absl::nullopt;
     }
 
-    // Use original source address with L7 LB for local endpoint sources if requested, as policy
-    // enforcement after the proxy depends on it (i.e., for "east/west" LB).
-    // Keep the original source address for the matching IP version, create a new source IP for
-    // the other version (with the same source port number) in case an upstream of a different
-    // IP version is chosen.
-    source_addresses = getIPAddressPairFrom(src_address, policy->getEndpointIPs());
-
     // Original source address is now in one of 'ipv[46]_source_address'
     src_address = nullptr;
   } else if (is_l7lb_ && !use_original_source_address_ /* North/South L7 LB */) {
@@ -511,7 +504,7 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
 
   if (is_l7lb_ && use_original_source_address_ /* E/W L7LB */) {
     // Mark with source endpoint ID for east/west l7 LB. This causes the upstream packets to be
-    // processed by the the source endpoint's policy enforcement in the datapath.
+    // processed by the source endpoint's policy enforcement in the datapath.
     mark = 0x0900 | policy->getEndpointID() << 16;
   } else {
     // Mark with source identity

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -557,9 +557,8 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadata) {
   EXPECT_EQ(1, source_addresses_socket_option->linger_time_);
 
   EXPECT_EQ(nullptr, source_addresses_socket_option->original_source_address_);
-  EXPECT_EQ("10.1.1.1:41234", source_addresses_socket_option->ipv4_source_address_->asString());
-  EXPECT_EQ("[face::1:1:1]:41234",
-            source_addresses_socket_option->ipv6_source_address_->asString());
+  EXPECT_EQ("10.1.1.42:0", source_addresses_socket_option->ipv4_source_address_->asString());
+  EXPECT_EQ("[face::42]:0", source_addresses_socket_option->ipv6_source_address_->asString());
 
   auto cilium_mark_socket_option = socket_metadata->buildCiliumMarkSocketOption();
   EXPECT_NE(nullptr, cilium_mark_socket_option);


### PR DESCRIPTION
The resolved backend IP could be the same client IP, which causes the
packet drop. This commit is to use the socket original source IP as
Ingress IP when use-original-source-address is set as true, just a note
that the policy enforcement is based on EndpointIP in socket mark instead.

Relates: https://github.com/cilium/cilium/pull/39530
Relates: https://github.com/cilium/cilium/issues/39531
