### PR TITLE
gh: Fix ambiguous reference to 'main'

### DIFF
--- a/.github/workflows/ci-clang-tidy.yaml
+++ b/.github/workflows/ci-clang-tidy.yaml
@@ -31,7 +31,7 @@ jobs:
           echo "ENVOY_VERSION=$(cat ENVOY_VERSION)" >> $GITHUB_ENV
           echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
           # git diff filter has everything else than deleted files (those need not be tidied)
-          echo "TIDY_SOURCES=$(git diff --name-only --diff-filter=ACMRTUXB main | grep -E '(.h$|.cc$)' | tr '\n' ' ')" >> $GITHUB_ENV
+          echo "TIDY_SOURCES=$(git diff --name-only --diff-filter=ACMRTUXB origin/main | grep -E '(.h$|.cc$)' | tr '\n' ' ')" >> $GITHUB_ENV
 
       - name: Wait for cilium-envoy-builder to be available
         timeout-minutes: 45


### PR DESCRIPTION
Use 'origin/main' instead of plain 'main'.