### PR TITLE
ci: run cilium tests concurrently

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -163,7 +163,14 @@ jobs:
 
       - name: Execute Cilium L7 Connectivity Tests
         shell: bash
-        run: cilium connectivity test --test="l7|sni|tls|ingress|check-log-errors" --curl-parallel=${{ env.CURL_PARALLEL }} --collect-sysdump-on-failure --flush-ct --sysdump-hubble-flows-count=100000 --sysdump-hubble-flows-timeout=15s
+        run: |
+          cilium connectivity test \
+          --test="l7|sni|tls|ingress|check-log-errors" \
+          --curl-parallel=${{ env.CURL_PARALLEL }} \
+          --collect-sysdump-on-failure --flush-ct \
+          --sysdump-hubble-flows-count=100000 \
+          --sysdump-hubble-flows-timeout=15s \
+          --test-concurrency=5
 
       - name: Gather Cilium system dump
         if: failure()


### PR DESCRIPTION
Not a big deal but it's a bit faster now:
- [Before](https://github.com/cilium/proxy/actions/runs/15165303106/job/42641420030): ~13 min 
- [After](https://github.com/cilium/proxy/actions/runs/15166520621/job/42645662595?pr=1355): ~6 min