### PR TITLE
bpf_metadata: Skip using original source address if destination is local host

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -273,7 +273,7 @@ uint32_t Config::resolvePolicyId(const Network::Address::Ip* ip) const {
 
   // default destination identity to the world if needed
   if (id == 0) {
-    id = Cilium::ID::WORLD;
+    id = Cilium::ID::World;
     ENVOY_LOG(trace, "bpf_metadata: Identity for IP defaults to WORLD", ip->addressAsString());
   }
 
@@ -363,6 +363,10 @@ const PolicyInstance& Config::getPolicy(const std::string& pod_ip) const {
   }
 
   return npmap_->getPolicyInstance(pod_ip, allow_egress);
+}
+
+bool Config::exists(const std::string& pod_ip) const {
+  return npmap_ != nullptr && npmap_->exists(pod_ip);
 }
 
 absl::optional<Cilium::BpfMetadata::SocketMetadata>
@@ -470,7 +474,7 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
 
     // Resolve source identity for the Ingress address
     source_identity = resolvePolicyId(ingress_ip);
-    if (source_identity == Cilium::ID::WORLD) {
+    if (source_identity == Cilium::ID::World) {
       // No security ID available for the configured source IP
       ENVOY_LOG(warn,
                 "cilium.bpf_metadata (north/south L7 LB): Unknown local Ingress IP source address "
@@ -481,7 +485,8 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
 
     // Original source address is never used for north/south LB
     src_address = nullptr;
-  } else if (!use_original_source_address_ || (npmap_ != nullptr && npmap_->exists(other_ip))) {
+  } else if (!use_original_source_address_ || destination_identity == Cilium::ID::Host ||
+             (npmap_ != nullptr && npmap_->exists(other_ip))) {
     // Otherwise only use the original source address if permitted and the destination is not
     // in the same node.
     //

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -68,8 +68,8 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
   std::shared_ptr<Envoy::Cilium::SourceAddressSocketOption> buildSourceAddressSocketOption(
       int linger_time, const std::shared_ptr<CiliumDestinationFilterState>& dest_fs = nullptr) {
     return std::make_shared<Envoy::Cilium::SourceAddressSocketOption>(
-        source_identity_, linger_time, original_source_address_, source_address_ipv4_,
-        source_address_ipv6_, dest_fs);
+        source_identity_, policy_resolver_, linger_time, original_source_address_,
+        source_address_ipv4_, source_address_ipv6_, dest_fs);
   };
 
   // Add ProxyLib L7 protocol as requested application protocol on the socket.
@@ -144,6 +144,7 @@ public:
   // PolicyResolver
   uint32_t resolvePolicyId(const Network::Address::Ip*) const override;
   const PolicyInstance& getPolicy(const std::string&) const override;
+  bool exists(const std::string&) const override;
 
   virtual absl::optional<SocketMetadata> extractSocketMetadata(Network::ConnectionSocket& socket);
 

--- a/cilium/filter_state_cilium_policy.h
+++ b/cilium/filter_state_cilium_policy.h
@@ -26,6 +26,7 @@ public:
 
   virtual uint32_t resolvePolicyId(const Network::Address::Ip*) const PURE;
   virtual const PolicyInstance& getPolicy(const std::string&) const PURE;
+  virtual bool exists(const std::string&) const PURE;
 };
 using PolicyResolverSharedPtr = std::shared_ptr<PolicyResolver>;
 

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -154,7 +154,7 @@ public:
           return it->second;
         }
       }
-      return ID::UNKNOWN;
+      return ID::Unknown;
     }
 
     uint64_t resolve(absl::uint128 addr6) const {
@@ -164,7 +164,7 @@ public:
           return it->second;
         }
       }
-      return ID::UNKNOWN;
+      return ID::Unknown;
     }
 
     uint64_t resolve(const Network::Address::Ip* addr) const {
@@ -176,7 +176,7 @@ public:
       if (ipv6) {
         return resolve(ipv6->address());
       }
-      return ID::WORLD;
+      return ID::World;
     }
 
   protected:
@@ -195,7 +195,7 @@ public:
 
   uint64_t resolve(const Network::Address::Ip* addr) const {
     const ThreadLocalHostMap* hostmap = getHostMap();
-    return (hostmap != nullptr) ? hostmap->resolve(addr) : ID::UNKNOWN;
+    return (hostmap != nullptr) ? hostmap->resolve(addr) : ID::Unknown;
   }
 
   void logmaps(const std::string& msg) {

--- a/cilium/policy_id.h
+++ b/cilium/policy_id.h
@@ -6,8 +6,19 @@ namespace Envoy {
 namespace Cilium {
 
 enum ID : uint64_t {
-  UNKNOWN = 0,
-  WORLD = 2,
+  Unknown = 0,
+  Host = 1,
+  World = 2,
+  Unmanaged = 3,
+  Health = 4,
+  Init = 5,
+  RemoteNode = 6,
+  KubeApiServer = 7,
+  Ingress = 8,
+  WorldIPv4 = 9,
+  WorldIPv6 = 10,
+  EncryptedOverlay = 11,
+
   // LocalIdentityFlag is the bit in the numeric identity that identifies
   // a numeric identity to have local scope
   LocalIdentityFlag = 1 << 24,

--- a/cilium/socket_option_source_address.h
+++ b/cilium/socket_option_source_address.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "envoy/config/core/v3/socket_option.pb.h"
@@ -25,7 +26,8 @@ class SourceAddressSocketOption : public Network::Socket::Option,
                                   public Logger::Loggable<Logger::Id::filter> {
 public:
   SourceAddressSocketOption(
-      uint32_t source_identity, int linger_time = -1,
+      uint32_t source_identity, const PolicyResolverSharedPtr& policy_resolver,
+      int linger_time = -1,
       Network::Address::InstanceConstSharedPtr original_source_address = nullptr,
       Network::Address::InstanceConstSharedPtr ipv4_source_address = nullptr,
       Network::Address::InstanceConstSharedPtr ipv6_source_address = nullptr,
@@ -45,6 +47,11 @@ public:
   bool isSupported() const override { return true; }
 
   uint32_t source_identity_;
+
+  // need information about the destination policy/identity to decide if original source address can
+  // be used or not.
+  const PolicyResolverSharedPtr policy_resolver_;
+
   int linger_time_;
 
   Network::Address::InstanceConstSharedPtr original_source_address_;


### PR DESCRIPTION
Original source address need not and can not be used if the destination is a local pod, or a local host. Add the local host case to bpf_metadata filter, and add handling of both cases to socket_option_source_address, as at that time the chosen destination is known.

In principle, we should not need these checks in bpf_metadata any more, but tests/ currently depends on them.