### PR TITLE
Change policy resolver back to a shared pointer

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -190,11 +190,8 @@ createHostMap(Server::Configuration::ListenerFactoryContext& context) {
 std::shared_ptr<const Cilium::NetworkPolicyMap>
 createPolicyMap(Server::Configuration::FactoryContext& context, Cilium::CtMapSharedPtr& ct) {
   return context.serverFactoryContext().singletonManager().getTyped<const Cilium::NetworkPolicyMap>(
-      SINGLETON_MANAGER_REGISTERED_NAME(cilium_network_policy), [&context, &ct] {
-        auto map = std::make_shared<Cilium::NetworkPolicyMap>(context, ct);
-        map->startSubscription();
-        return map;
-      });
+      SINGLETON_MANAGER_REGISTERED_NAME(cilium_network_policy),
+      [&context, &ct] { return std::make_shared<Cilium::NetworkPolicyMap>(context, ct); });
 }
 
 } // namespace
@@ -530,7 +527,7 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
       mark, ingress_source_identity, source_identity, is_ingress_, is_l7lb_, dip->port(),
       std::move(pod_ip), std::move(ingress_policy_name), std::move(src_address),
       std::move(source_addresses.ipv4_), std::move(source_addresses.ipv6_), std::move(dst_address),
-      weak_from_this(), proxy_id_, std::move(proxylib_l7proto), sni)};
+      shared_from_this(), proxy_id_, std::move(proxylib_l7proto), sni)};
 }
 
 Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -39,7 +39,7 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
                  Network::Address::InstanceConstSharedPtr source_address_ipv4,
                  Network::Address::InstanceConstSharedPtr source_address_ipv6,
                  Network::Address::InstanceConstSharedPtr original_dest_address,
-                 const std::weak_ptr<PolicyResolver>& policy_resolver, uint32_t proxy_id,
+                 const PolicyResolverSharedPtr& policy_resolver, uint32_t proxy_id,
                  std::string&& proxylib_l7_proto, absl::string_view sni)
       : ingress_source_identity_(ingress_source_identity), source_identity_(source_identity),
         ingress_(ingress), is_l7lb_(l7lb), port_(port), pod_ip_(std::move(pod_ip)),
@@ -118,7 +118,7 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
   uint32_t proxy_id_;
   std::string proxylib_l7_proto_;
   std::string sni_;
-  std::weak_ptr<PolicyResolver> policy_resolver_;
+  const PolicyResolverSharedPtr policy_resolver_;
 
   uint32_t mark_;
 

--- a/cilium/filter_state_cilium_policy.cc
+++ b/cilium/filter_state_cilium_policy.cc
@@ -26,19 +26,12 @@ bool CiliumPolicyFilterState::enforceNetworkPolicy(const Network::Connection& co
                                                    /* OUT */ bool& use_proxy_lib,
                                                    /* OUT */ std::string& l7_proto,
                                                    /* INOUT */ AccessLog::Entry& log_entry) const {
-  const auto resolver = policy_resolver_.lock();
   use_proxy_lib = false;
   l7_proto = "";
 
-  if (!resolver) {
-    // No policy resolver
-    ENVOY_CONN_LOG(debug, "No policy resolver", conn);
-    return false;
-  }
-
   // enforce pod policy first, if any
   if (pod_ip_.length() > 0) {
-    const auto& policy = resolver->getPolicy(pod_ip_);
+    const auto& policy = policy_resolver_->getPolicy(pod_ip_);
     auto remote_id = ingress_ ? source_identity_ : destination_identity;
     auto port = ingress_ ? port_ : destination_port;
 
@@ -57,7 +50,7 @@ bool CiliumPolicyFilterState::enforceNetworkPolicy(const Network::Connection& co
   // enforce Ingress policy 2nd, if any
   if (ingress_policy_name_.length() > 0) {
     log_entry.entry_.set_policy_name(ingress_policy_name_);
-    const auto& policy = resolver->getPolicy(ingress_policy_name_);
+    const auto& policy = policy_resolver_->getPolicy(ingress_policy_name_);
 
     // Enforce ingress policy for Ingress, on the original destination port
     if (ingress_source_identity_ != 0) {
@@ -93,14 +86,6 @@ bool CiliumPolicyFilterState::enforceHTTPPolicy(const Network::Connection& conn,
                                                 uint16_t destination_port,
                                                 /* INOUT */ Http::RequestHeaderMap& headers,
                                                 /* INOUT */ AccessLog::Entry& log_entry) const {
-  const auto resolver = policy_resolver_.lock();
-
-  if (!resolver) {
-    // No policy resolver
-    ENVOY_CONN_LOG(debug, "No policy resolver", conn);
-    return false;
-  }
-
   // enforce pod policy first, if any.
   // - ingress enforcement in downstream
   // - egress enforcement in upstream
@@ -109,7 +94,7 @@ bool CiliumPolicyFilterState::enforceHTTPPolicy(const Network::Connection& conn,
   // - is_l7lb_: ingress_ == is_downstream
   // - !is_l7lb_: is_downstream
   if (pod_ip_.length() > 0 && (is_l7lb_ ? is_downstream == ingress_ : is_downstream)) {
-    const auto& policy = resolver->getPolicy(pod_ip_);
+    const auto& policy = policy_resolver_->getPolicy(pod_ip_);
     auto remote_id = ingress_ ? source_identity_ : destination_identity;
     auto port = ingress_ ? port_ : destination_port;
     if (!policy.allowed(ingress_, proxy_id_, remote_id, port, headers, log_entry)) {
@@ -122,7 +107,7 @@ bool CiliumPolicyFilterState::enforceHTTPPolicy(const Network::Connection& conn,
   // enforce Ingress policy 2nd, if any, always on the upstream
   if (!is_downstream && ingress_policy_name_.length() > 0) {
     log_entry.entry_.set_policy_name(ingress_policy_name_);
-    const auto& policy = resolver->getPolicy(ingress_policy_name_);
+    const auto& policy = policy_resolver_->getPolicy(ingress_policy_name_);
 
     // Enforce ingress policy for Ingress, on the original destination port
     if (ingress_source_identity_ != 0) {

--- a/cilium/filter_state_cilium_policy.h
+++ b/cilium/filter_state_cilium_policy.h
@@ -16,7 +16,6 @@
 #include "absl/strings/string_view.h"
 #include "cilium/accesslog.h"
 #include "cilium/network_policy.h"
-#include "cilium/policy_id.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -28,6 +27,7 @@ public:
   virtual uint32_t resolvePolicyId(const Network::Address::Ip*) const PURE;
   virtual const PolicyInstance& getPolicy(const std::string&) const PURE;
 };
+using PolicyResolverSharedPtr = std::shared_ptr<PolicyResolver>;
 
 // FilterState that holds relevant connection & policy information that can be retrieved
 // by the Cilium network- and HTTP policy filters via filter state.
@@ -37,7 +37,7 @@ public:
   CiliumPolicyFilterState(uint32_t ingress_source_identity, uint32_t source_identity, bool ingress,
                           bool l7lb, uint16_t port, std::string&& pod_ip,
                           std::string&& ingress_policy_name,
-                          const std::weak_ptr<PolicyResolver>& policy_resolver, uint32_t proxy_id,
+                          const PolicyResolverSharedPtr& policy_resolver, uint32_t proxy_id,
                           absl::string_view sni)
       : ingress_source_identity_(ingress_source_identity), source_identity_(source_identity),
         ingress_(ingress), is_l7lb_(l7lb), port_(port), pod_ip_(std::move(pod_ip)),
@@ -51,20 +51,10 @@ public:
   }
 
   uint32_t resolvePolicyId(const Network::Address::Ip* ip) const {
-    const auto resolver = policy_resolver_.lock();
-    if (resolver) {
-      return resolver->resolvePolicyId(ip);
-    }
-    return Cilium::ID::WORLD; // default to WORLD policy ID if resolver is no longer available
+    return policy_resolver_->resolvePolicyId(ip);
   }
 
-  const PolicyInstance& getPolicy() const {
-    const auto resolver = policy_resolver_.lock();
-    if (resolver) {
-      return resolver->getPolicy(pod_ip_);
-    }
-    return NetworkPolicyMap::getDenyAllPolicy();
-  }
+  const PolicyInstance& getPolicy() const { return policy_resolver_->getPolicy(pod_ip_); }
 
   bool enforceNetworkPolicy(const Network::Connection& conn, uint32_t destination_identity,
                             uint16_t destination_port, const absl::string_view sni,
@@ -95,7 +85,7 @@ public:
   std::string sni_;
 
 private:
-  const std::weak_ptr<PolicyResolver> policy_resolver_;
+  const PolicyResolverSharedPtr policy_resolver_;
 };
 } // namespace Cilium
 } // namespace Envoy

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -23,6 +23,7 @@
 #include "envoy/server/factory_context.h"
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
+#include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/type/matcher/v3/metadata.pb.h"
@@ -55,7 +56,7 @@
 namespace Envoy {
 namespace Cilium {
 
-uint64_t NetworkPolicyMap::instance_id_ = 0;
+uint64_t NetworkPolicyMapImpl::instance_id_ = 0;
 
 IpAddressPair::IpAddressPair(const cilium::NetworkPolicy& proto) {
   for (const auto& ip_addr : proto.endpoint_ips()) {
@@ -75,7 +76,7 @@ IpAddressPair::IpAddressPair(const cilium::NetworkPolicy& proto) {
 
 class HeaderMatch : public Logger::Loggable<Logger::Id::config> {
 public:
-  HeaderMatch(const NetworkPolicyMap& parent, const cilium::HeaderMatch& config)
+  HeaderMatch(const NetworkPolicyMapImpl& parent, const cilium::HeaderMatch& config)
       : name_(config.name()), value_(config.value()), match_action_(config.match_action()),
         mismatch_action_(config.mismatch_action()) {
     if (config.value_sds_secret().length() > 0) {
@@ -208,7 +209,8 @@ public:
 
 class HttpNetworkPolicyRule : public Logger::Loggable<Logger::Id::config> {
 public:
-  HttpNetworkPolicyRule(const NetworkPolicyMap& parent, const cilium::HttpNetworkPolicyRule& rule) {
+  HttpNetworkPolicyRule(const NetworkPolicyMapImpl& parent,
+                        const cilium::HttpNetworkPolicyRule& rule) {
     ENVOY_LOG(trace, "Cilium L7 HttpNetworkPolicyRule():");
     headers_.reserve(rule.headers().size());
     for (const auto& header : rule.headers()) {
@@ -334,7 +336,7 @@ public:
 
 class L7NetworkPolicyRule : public Logger::Loggable<Logger::Id::config> {
 public:
-  L7NetworkPolicyRule(const NetworkPolicyMap& parent, const cilium::L7NetworkPolicyRule& rule)
+  L7NetworkPolicyRule(const NetworkPolicyMapImpl& parent, const cilium::L7NetworkPolicyRule& rule)
       : name_(rule.name()) {
     for (const auto& matcher : rule.metadata_rule()) {
       metadata_matchers_.emplace_back(matcher,
@@ -366,7 +368,8 @@ private:
 
 class PortNetworkPolicyRule : public Logger::Loggable<Logger::Id::config> {
 public:
-  PortNetworkPolicyRule(const NetworkPolicyMap& parent, const cilium::PortNetworkPolicyRule& rule)
+  PortNetworkPolicyRule(const NetworkPolicyMapImpl& parent,
+                        const cilium::PortNetworkPolicyRule& rule)
       : name_(rule.name()), deny_(rule.deny()), proxy_id_(rule.proxy_id()),
         l7_proto_(rule.l7_proto()) {
     // Deny rules can not be short circuited, i.e., if any deny rules are present, then all
@@ -648,7 +651,7 @@ using PortNetworkPolicyRuleConstSharedPtr = std::shared_ptr<const PortNetworkPol
 class PortNetworkPolicyRules : public Logger::Loggable<Logger::Id::config> {
 public:
   PortNetworkPolicyRules() = default;
-  PortNetworkPolicyRules(const NetworkPolicyMap& parent,
+  PortNetworkPolicyRules(const NetworkPolicyMapImpl& parent,
                          const Protobuf::RepeatedPtrField<cilium::PortNetworkPolicyRule>& rules) {
     if (rules.empty()) {
       ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicyRules(): No rules, will allow "
@@ -905,7 +908,7 @@ bool inline rangesOverlap(const PortRange& a, const PortRange& b) {
 
 class PortNetworkPolicy : public Logger::Loggable<Logger::Id::config> {
 public:
-  PortNetworkPolicy(const NetworkPolicyMap& parent,
+  PortNetworkPolicy(const NetworkPolicyMapImpl& parent,
                     const Protobuf::RepeatedPtrField<cilium::PortNetworkPolicy>& rules) {
     for (const auto& rule : rules) {
       // Only TCP supported for HTTP
@@ -1109,7 +1112,7 @@ public:
 // methods.
 class PolicyInstanceImpl : public PolicyInstance {
 public:
-  PolicyInstanceImpl(const NetworkPolicyMap& parent, uint64_t hash,
+  PolicyInstanceImpl(const NetworkPolicyMapImpl& parent, uint64_t hash,
                      const cilium::NetworkPolicy& proto)
       : conntrack_map_name_(proto.conntrack_map_name()), endpoint_id_(proto.endpoint_id()),
         hash_(hash), policy_proto_(proto), endpoint_ips_(proto), parent_(parent),
@@ -1164,7 +1167,7 @@ public:
   const IpAddressPair endpoint_ips_;
 
 private:
-  const NetworkPolicyMap& parent_;
+  const NetworkPolicyMapImpl& parent_;
   const PortNetworkPolicy ingress_;
   const PortNetworkPolicy egress_;
 };
@@ -1172,6 +1175,47 @@ private:
 // Common base constructor
 // This is used directly for testing with a file-based subscription
 NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& context)
+    : context_(context.serverFactoryContext()) {
+  impl_ = std::make_unique<NetworkPolicyMapImpl>(context);
+
+  if (context_.admin().has_value()) {
+    ENVOY_LOG(debug, "Registering NetworkPolicies to config tracker");
+    config_tracker_entry_ = context_.admin()->getConfigTracker().add(
+        "networkpolicies", [this](const Matchers::StringMatcher& name_matcher) {
+          return dumpNetworkPolicyConfigs(name_matcher);
+        });
+    RELEASE_ASSERT(config_tracker_entry_, "");
+  }
+}
+
+// This is used in production
+NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& context,
+                                   Cilium::CtMapSharedPtr& ct)
+    : NetworkPolicyMap(context) {
+  getImpl().setConntrackMap(ct);
+  getImpl().startSubscription();
+}
+
+NetworkPolicyMap::~NetworkPolicyMap() {
+  ENVOY_LOG(debug,
+            "Cilium L7 NetworkPolicyMap: posting NetworkPolicyMapImpl deletion to main thread");
+
+  // Policy map destruction happens when the last listener with the Cilium bpf_metadata listener
+  // filter has drained out and is finally removed, and last connection of the old listener is
+  // closed. This does not happen if new listener(s) with references to policy map are created in
+  // the meanwhile.
+  //
+  // Destruction of the NetworkPolicyMapImpl must be made from the main thread to ensure integrity
+  // of SDS subscription management. Since this can be called from a worker thread of the last
+  // connection we must post the destruction to the main thread dispatcher.
+  //
+  // Move the NetworkPolicyMapImpl to the lambda capture so that it goes out of scope and gets
+  // deleted in the main thread.
+
+  context_.mainThreadDispatcher().post([impl = std::move(impl_)]() {});
+}
+
+NetworkPolicyMapImpl::NetworkPolicyMapImpl(Server::Configuration::FactoryContext& context)
     : context_(context.serverFactoryContext()), map_ptr_(nullptr),
       npds_stats_scope_(context_.serverScope().createScope("cilium.npds.")),
       policy_stats_scope_(context_.serverScope().createScope("cilium.policy.")),
@@ -1193,62 +1237,43 @@ NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& contex
 
   // Allocate an initial policy map so that the map pointer is never a nullptr
   store(new RawPolicyMap());
-  ENVOY_LOG(trace, "NetworkPolicyMap({}) created.", instance_id_);
-
-  if (context_.admin().has_value()) {
-    ENVOY_LOG(debug, "Registering NetworkPolicies to config tracker");
-    config_tracker_entry_ = context_.admin()->getConfigTracker().add(
-        "networkpolicies", [this](const Matchers::StringMatcher& name_matcher) {
-          return dumpNetworkPolicyConfigs(name_matcher);
-        });
-    RELEASE_ASSERT(config_tracker_entry_, "");
-  }
+  ENVOY_LOG(trace, "NetworkPolicyMapImpl({}) created.", instance_id_);
 }
 
-// This is used in production
-NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& context,
-                                   Cilium::CtMapSharedPtr& ct)
-    : NetworkPolicyMap(context) {
-  ctmap_ = ct;
-}
-
-NetworkPolicyMap::~NetworkPolicyMap() {
-  ENVOY_LOG(debug, "Cilium L7 NetworkPolicyMap({}): NetworkPolicyMap is deleted NOW!",
+// NetworkPolicyMapImpl destructor must only be called from the main thread.
+NetworkPolicyMapImpl::~NetworkPolicyMapImpl() {
+  ENVOY_LOG(debug, "Cilium L7 NetworkPolicyMapImpl({}): NetworkPolicyMap is deleted NOW!",
             instance_id_);
-  // Policy map destruction happens when the last listener with the Cilium bpf_metadata listener
-  // filter has drained out and is finally removed. At this point the listener socket can no
-  // longer receive new traffic and we can simply delete the policy map without synchronizing with
-  // the worker threads.
   delete load();
 }
 
-// Both subscribe() call and subscription_->start() use
-// shared_from_this(), which cannot be called before a shared
-// pointer is formed by the caller of the constructor, hence this
-// can't be called from the constructor!
-void NetworkPolicyMap::startSubscription() {
+void NetworkPolicyMapImpl::startSubscription() {
   subscription_ = subscribe("type.googleapis.com/cilium.NetworkPolicy", context_.localInfo(),
                             context_.clusterManager(), context_.mainThreadDispatcher(),
                             context_.api().randomGenerator(), *npds_stats_scope_, *this,
                             std::make_shared<NetworkPolicyDecoder>());
 }
 
-bool NetworkPolicyMap::isNewStream() {
+void NetworkPolicyMapImpl::tlsWrapperMissingPolicyInc() const {
+  stats_.tls_wrapper_missing_policy_.inc();
+}
+
+bool NetworkPolicyMapImpl::isNewStream() {
   auto sub = dynamic_cast<Config::GrpcSubscriptionImpl*>(subscription_.get());
   if (!sub) {
-    ENVOY_LOG(error, "Cilium NetworkPolicyMap: Cannot get GrpcSubscriptionImpl");
+    ENVOY_LOG(error, "Cilium NetworkPolicyMapImpl: Cannot get GrpcSubscriptionImpl");
     return false;
   }
   auto mux = dynamic_cast<GrpcMuxImpl*>(sub->grpcMux().get());
   if (!mux) {
-    ENVOY_LOG(error, "Cilium NetworkPolicyMap: Cannot get GrpcMuxImpl");
+    ENVOY_LOG(error, "Cilium NetworkPolicyMapImpl: Cannot get GrpcMuxImpl");
     return false;
   }
   return mux->isNewStream();
 }
 
 // removeInitManager must be called at the end of each policy update
-void NetworkPolicyMap::removeInitManager() {
+void NetworkPolicyMapImpl::removeInitManager() {
   // Remove the local init manager from the transport factory context
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -1264,11 +1289,11 @@ void NetworkPolicyMap::removeInitManager() {
 // swaps it in place of the old policy map. Throws if any of the 'resources' can not be
 // parsed. Otherwise an OK status is returned without pausing NPDS gRPC stream, causing a new
 // request (ACK) to be sent immediately, without waiting SDS secrets to be loaded.
-absl::Status
-NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourceRef>& resources,
-                                 const std::string& version_info) {
-  ENVOY_LOG(debug, "NetworkPolicyMap::onConfigUpdate({}), {} resources, version: {}", instance_id_,
-            resources.size(), version_info);
+absl::Status NetworkPolicyMapImpl::onConfigUpdate(
+    const std::vector<Envoy::Config::DecodedResourceRef>& resources,
+    const std::string& version_info) {
+  ENVOY_LOG(debug, "NetworkPolicyMapImpl::onConfigUpdate({}), {} resources, version: {}",
+            instance_id_, resources.size(), version_info);
   stats_.updates_total_.inc();
 
   // Reopen IPcache for every new stream. Cilium agent re-creates IP cache on restart,
@@ -1293,6 +1318,8 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
   // SDS secrets will use this!
   transport_factory_context_->setInitManager(version_init_manager);
 
+  absl::flat_hash_set<std::string> ctmaps_to_be_closed;
+
   const auto* old_map = load();
   {
     absl::flat_hash_set<std::string> ctmaps_to_keep;
@@ -1308,7 +1335,6 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
           throw EnvoyException("Network Policy has no endpoint ips");
         }
         ctmaps_to_keep.insert(config.conntrack_map_name());
-        ctmaps_to_be_closed_.erase(config.conntrack_map_name());
 
         // First find the old config to figure out if an update is needed.
         const uint64_t new_hash = MessageUtil::hash(config);
@@ -1348,11 +1374,15 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
     version_init_manager.initialize(Init::WatcherImpl(version_name, []() {}));
 
     // Add old ctmaps to be closed
+    //
+    // NOTE: Support for local CT maps was removed in Cilium 1.17. This clean-up code can be
+    // simplified by always keeping the global map open when Cilium 1.17 is the oldest supported
+    // version.
     for (auto& pair : *old_map) {
       // insert conntrack map names we don't want to keep
       auto& ct_map_name = pair.second->conntrack_map_name_;
       if (ctmaps_to_keep.find(ct_map_name) == ctmaps_to_keep.end()) {
-        ctmaps_to_be_closed_.insert(ct_map_name);
+        ctmaps_to_be_closed.insert(ct_map_name);
       }
     }
 
@@ -1361,30 +1391,27 @@ NetworkPolicyMap::onConfigUpdate(const std::vector<Envoy::Config::DecodedResourc
     old_map = exchange(new_map);
   }
 
-  // 'this' may be already deleted when the main thread gets to execute the cleanup.
-  // Manage this by taking a shared_ptr on 'this' for the duration of the posted lambda.
-  std::shared_ptr<NetworkPolicyMap> shared_this = shared_from_this();
-
-  runAfterAllThreads([shared_this, old_map]() {
+  // Delete the old map once all worker threads have entered their event queues, as this
+  // is proof that they no longer refer to the old map.
+  runAfterAllThreads([ctmap = ctmap_, ctmaps_to_be_closed, old_map]() {
     // Clean-up in the main thread after all threads have scheduled
-    if (shared_this->ctmap_) {
-      shared_this->ctmap_->closeMaps(shared_this->ctmaps_to_be_closed_);
+    if (ctmap) {
+      ctmap->closeMaps(ctmaps_to_be_closed);
     }
-    shared_this->ctmaps_to_be_closed_.clear();
     delete old_map;
   });
 
   return absl::OkStatus();
 }
 
-void NetworkPolicyMap::onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason,
-                                            const EnvoyException*) {
+void NetworkPolicyMapImpl::onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason,
+                                                const EnvoyException*) {
   // We need to allow server startup to continue, even if we have a bad
   // config.
   ENVOY_LOG(debug, "Network Policy Update failed, keeping existing policy.");
 }
 
-void NetworkPolicyMap::runAfterAllThreads(std::function<void()> cb) const {
+void NetworkPolicyMapImpl::runAfterAllThreads(std::function<void()> cb) const {
   // We can guarantee the callback 'cb' runs in the main thread after all worker threads have
   // entered their event loop, and thus relinquished all state, such as policy lookup results that
   // were stored in their call stack, by posting and empty function to their event queues and
@@ -1392,7 +1419,7 @@ void NetworkPolicyMap::runAfterAllThreads(std::function<void()> cb) const {
   //
   // For now we rely on the implementation dependent fact that the reference returned by
   // context_.threadLocal() actually is a ThreadLocal::Instance reference, where
-  // runOnAllWorkerThreads() is exposed. Withtout this cast we'd need to use a dummy thread local
+  // runOnAllWorkerThreads() is exposed. Without this cast we'd need to use a dummy thread local
   // variable that would take a thread local slot for no other purpose than to avoid this type cast.
   dynamic_cast<ThreadLocal::Instance&>(context_.threadLocal()).runOnAllWorkerThreads([]() {}, cb);
 }
@@ -1403,7 +1430,7 @@ NetworkPolicyMap::dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_m
 
   std::vector<uint64_t> policy_endpoint_ids;
   auto config_dump = std::make_unique<cilium::NetworkPoliciesConfigDump>();
-  for (const auto& item : *load()) {
+  for (const auto& item : *getImpl().load()) {
     // filter duplicates (policies are stored per endpoint ip)
     if (std::find(policy_endpoint_ids.begin(), policy_endpoint_ids.end(),
                   item.second->policy_proto_.endpoint_id()) != policy_endpoint_ids.end()) {
@@ -1519,7 +1546,7 @@ DenyAllPolicyInstanceImpl NetworkPolicyMap::DenyAllPolicy;
 PolicyInstance& NetworkPolicyMap::getDenyAllPolicy() { return DenyAllPolicy; }
 
 const PolicyInstance*
-NetworkPolicyMap::getPolicyInstanceImpl(const std::string& endpoint_ip) const {
+NetworkPolicyMapImpl::getPolicyInstanceImpl(const std::string& endpoint_ip) const {
   const auto* map = load();
   auto it = map->find(endpoint_ip);
   if (it != map->end()) {
@@ -1541,7 +1568,7 @@ NetworkPolicyMap::getPolicyInstanceImpl(const std::string& endpoint_ip) const {
 // for Cilium Ingress when there is no egress policy enforcement for the Ingress traffic.
 const PolicyInstance& NetworkPolicyMap::getPolicyInstance(const std::string& endpoint_ip,
                                                           bool default_allow_egress) const {
-  const auto* policy = getPolicyInstanceImpl(endpoint_ip);
+  const auto* policy = getImpl().getPolicyInstanceImpl(endpoint_ip);
   return policy != nullptr      ? *policy
          : default_allow_egress ? *static_cast<PolicyInstance*>(&AllowAllEgressPolicy)
                                 : *static_cast<PolicyInstance*>(&DenyAllPolicy);

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -40,7 +40,6 @@
 
 #include "absl/container/btree_map.h"
 #include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
@@ -217,39 +216,17 @@ struct PolicyStats {
 
 using RawPolicyMap = absl::flat_hash_map<std::string, std::shared_ptr<const PolicyInstanceImpl>>;
 
-class DenyAllPolicyInstanceImpl;
-class AllowAllEgressPolicyInstanceImpl;
-
-class NetworkPolicyMap : public Singleton::Instance,
-                         public Envoy::Config::SubscriptionCallbacks,
-                         public std::enable_shared_from_this<NetworkPolicyMap>,
-                         public Logger::Loggable<Logger::Id::config> {
+class NetworkPolicyMapImpl : public Envoy::Config::SubscriptionCallbacks,
+                             public Logger::Loggable<Logger::Id::config> {
 public:
-  NetworkPolicyMap(Server::Configuration::FactoryContext& context);
-  NetworkPolicyMap(Server::Configuration::FactoryContext& context, Cilium::CtMapSharedPtr& ct);
-  ~NetworkPolicyMap() override;
+  NetworkPolicyMapImpl(Server::Configuration::FactoryContext& context);
+  ~NetworkPolicyMapImpl() override;
 
-  // subscription_->start() calls onConfigUpdate(), which uses
-  // shared_from_this(), which cannot be called before a shared
-  // pointer is formed by the caller of the constructor, hence this
-  // can't be called from the constructor!
   void startSubscription();
 
   // This is used for testing with a file-based subscription
   void startSubscription(std::unique_ptr<Envoy::Config::Subscription>&& subscription) {
     subscription_ = std::move(subscription);
-  }
-
-  const PolicyInstance& getPolicyInstance(const std::string& endpoint_policy_name,
-                                          bool allow_egress) const;
-
-  static DenyAllPolicyInstanceImpl DenyAllPolicy;
-  static PolicyInstance& getDenyAllPolicy();
-  static AllowAllEgressPolicyInstanceImpl AllowAllEgressPolicy;
-  static PolicyInstance& getAllowAllEgressPolicy();
-
-  bool exists(const std::string& endpoint_policy_name) const {
-    return getPolicyInstanceImpl(endpoint_policy_name) != nullptr;
   }
 
   // run the given function after all the threads have scheduled
@@ -274,7 +251,7 @@ public:
     return *transport_factory_context_;
   }
 
-  void tlsWrapperMissingPolicyInc() const { stats_.tls_wrapper_missing_policy_.inc(); }
+  void tlsWrapperMissingPolicyInc() const;
 
 private:
   // Helpers for atomic swap of the policy map pointer.
@@ -321,8 +298,6 @@ private:
 
   bool isNewStream();
 
-  friend class CiliumNetworkPolicyTest;
-
   static uint64_t instance_id_;
 
   Server::Configuration::ServerFactoryContext& context_;
@@ -335,16 +310,52 @@ private:
   std::shared_ptr<Server::Configuration::TransportSocketFactoryContextImpl>
       transport_factory_context_;
 
-  Cilium::CtMapSharedPtr ctmap_;
-  absl::flat_hash_set<std::string> ctmaps_to_be_closed_;
-
   std::unique_ptr<Envoy::Config::Subscription> subscription_;
+
+protected:
+  friend class NetworkPolicyMap;
+  friend class CiliumNetworkPolicyTest;
+
+  void setConntrackMap(Cilium::CtMapSharedPtr& ct) { ctmap_ = ct; }
+
+  Cilium::CtMapSharedPtr ctmap_;
+  PolicyStats stats_;
+};
+
+class DenyAllPolicyInstanceImpl;
+class AllowAllEgressPolicyInstanceImpl;
+
+class NetworkPolicyMap : public Singleton::Instance, public Logger::Loggable<Logger::Id::config> {
+public:
+  NetworkPolicyMap(Server::Configuration::FactoryContext& context);
+  NetworkPolicyMap(Server::Configuration::FactoryContext& context, Cilium::CtMapSharedPtr& ct);
+  ~NetworkPolicyMap() override;
+
+  // This is used for testing with a file-based subscription
+  void startSubscription(std::unique_ptr<Envoy::Config::Subscription>&& subscription) {
+    getImpl().startSubscription(std::move(subscription));
+  }
+
+  const PolicyInstance& getPolicyInstance(const std::string& endpoint_policy_name,
+                                          bool allow_egress) const;
+
+  static DenyAllPolicyInstanceImpl DenyAllPolicy;
+  static PolicyInstance& getDenyAllPolicy();
+  static AllowAllEgressPolicyInstanceImpl AllowAllEgressPolicy;
+  static PolicyInstance& getAllowAllEgressPolicy();
+
+  bool exists(const std::string& endpoint_policy_name) const {
+    return getImpl().getPolicyInstanceImpl(endpoint_policy_name) != nullptr;
+  }
+
+  NetworkPolicyMapImpl& getImpl() const { return *impl_; }
+
+private:
+  Server::Configuration::ServerFactoryContext& context_;
+  std::unique_ptr<NetworkPolicyMapImpl> impl_;
 
   ProtobufTypes::MessagePtr dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_matcher);
   Server::ConfigTracker::EntryOwnerPtr config_tracker_entry_;
-
-protected:
-  PolicyStats stats_;
 };
 using NetworkPolicyMapSharedPtr = std::shared_ptr<const NetworkPolicyMap>;
 

--- a/cilium/secret_watcher.cc
+++ b/cilium/secret_watcher.cc
@@ -51,7 +51,7 @@ GetSdsConfigFunc getSDSConfig = &getCiliumSDSConfig;
 void setSDSConfigFunc(GetSdsConfigFunc func) { getSDSConfig = func; }
 void resetSDSConfigFunc() { getSDSConfig = &getCiliumSDSConfig; }
 
-SecretWatcher::SecretWatcher(const NetworkPolicyMap& parent, const std::string& sds_name)
+SecretWatcher::SecretWatcher(const NetworkPolicyMapImpl& parent, const std::string& sds_name)
     : parent_(parent), name_(sds_name),
       secret_provider_(secretProvider(parent.transportFactoryContext(), sds_name)),
       update_secret_(readAndWatchSecret()) {}
@@ -89,7 +89,7 @@ absl::Status SecretWatcher::store() {
 
 const std::string* SecretWatcher::load() const { return ptr_.load(std::memory_order_acquire); }
 
-TLSContext::TLSContext(const NetworkPolicyMap& parent, const std::string& name)
+TLSContext::TLSContext(const NetworkPolicyMapImpl& parent, const std::string& name)
     : manager_(parent.transportFactoryContext().sslContextManager()),
       scope_(parent.transportFactoryContext().serverFactoryContext().serverScope()),
       init_target_(fmt::format("TLS Context {} secret", name), []() {}) {}
@@ -134,7 +134,7 @@ void setCommonConfig(const cilium::TLSContext config,
 
 } // namespace
 
-DownstreamTLSContext::DownstreamTLSContext(const NetworkPolicyMap& parent,
+DownstreamTLSContext::DownstreamTLSContext(const NetworkPolicyMapImpl& parent,
                                            const cilium::TLSContext config)
     : TLSContext(parent, "server") {
   // Server config always needs the TLS certificate to present to the client
@@ -184,7 +184,8 @@ DownstreamTLSContext::DownstreamTLSContext(const NetworkPolicyMap& parent,
   }
 }
 
-UpstreamTLSContext::UpstreamTLSContext(const NetworkPolicyMap& parent, cilium::TLSContext config)
+UpstreamTLSContext::UpstreamTLSContext(const NetworkPolicyMapImpl& parent,
+                                       cilium::TLSContext config)
     : TLSContext(parent, "client") {
   // Client context always needs the trusted CA for server certificate validation
   // TODO: Default to system default trusted CAs?

--- a/cilium/secret_watcher.h
+++ b/cilium/secret_watcher.h
@@ -33,7 +33,7 @@ void resetSDSConfigFunc();
 
 class SecretWatcher : public Logger::Loggable<Logger::Id::config> {
 public:
-  SecretWatcher(const NetworkPolicyMap& parent, const std::string& sds_name);
+  SecretWatcher(const NetworkPolicyMapImpl& parent, const std::string& sds_name);
   ~SecretWatcher();
 
   const std::string& name() const { return name_; }
@@ -44,7 +44,7 @@ private:
   absl::Status store();
   const std::string* load() const;
 
-  const NetworkPolicyMap& parent_;
+  const NetworkPolicyMapImpl& parent_;
   const std::string name_;
   std::atomic<std::string*> ptr_{nullptr};
   Secret::GenericSecretConfigProviderSharedPtr secret_provider_;
@@ -58,7 +58,7 @@ public:
   TLSContext() = delete;
 
 protected:
-  TLSContext(const NetworkPolicyMap& parent, const std::string& name);
+  TLSContext(const NetworkPolicyMapImpl& parent, const std::string& name);
 
   Envoy::Ssl::ContextManager& manager_;
   Stats::Scope& scope_;
@@ -68,7 +68,7 @@ protected:
 
 class DownstreamTLSContext : protected TLSContext {
 public:
-  DownstreamTLSContext(const NetworkPolicyMap& parent, const cilium::TLSContext config);
+  DownstreamTLSContext(const NetworkPolicyMapImpl& parent, const cilium::TLSContext config);
   ~DownstreamTLSContext() { manager_.removeContext(server_context_); }
 
   const Ssl::ContextConfig& getTlsContextConfig() const { return *server_config_; }
@@ -87,7 +87,7 @@ using DownstreamTLSContextPtr = std::unique_ptr<DownstreamTLSContext>;
 
 class UpstreamTLSContext : protected TLSContext {
 public:
-  UpstreamTLSContext(const NetworkPolicyMap& parent, cilium::TLSContext config);
+  UpstreamTLSContext(const NetworkPolicyMapImpl& parent, cilium::TLSContext config);
   ~UpstreamTLSContext() { manager_.removeContext(client_context_); }
 
   const Ssl::ContextConfig& getTlsContextConfig() const { return *client_config_; }

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -114,7 +114,7 @@ createPolicyMap(const std::string& config,
         auto map = std::make_shared<Cilium::NetworkPolicyMap>(context);
         auto subscription = std::make_unique<Envoy::Config::FilesystemSubscriptionImpl>(
             context.serverFactoryContext().mainThreadDispatcher(),
-            Envoy::Config::makePathConfigSource(policy_path), *map,
+            Envoy::Config::makePathConfigSource(policy_path), map->getImpl(),
             std::make_shared<Cilium::NetworkPolicyDecoder>(), stats,
             ProtobufMessage::getNullValidationVisitor(), context.serverFactoryContext().api());
         map->startSubscription(std::move(subscription));

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -84,8 +84,9 @@ protected:
     THROW_IF_NOT_OK_REF(decoded_resources_or_error.status());
     const auto decoded_resources = std::move(decoded_resources_or_error.value().get());
 
-    EXPECT_TRUE(
-        policy_map_->onConfigUpdate(decoded_resources->refvec_, message.version_info()).ok());
+    EXPECT_TRUE(policy_map_->getImpl()
+                    .onConfigUpdate(decoded_resources->refvec_, message.version_info())
+                    .ok());
     return message.version_info();
   }
 
@@ -200,7 +201,9 @@ protected:
     return tlsAllowed(false, pod_ip, remote_id, port, sni, tls_socket_required, raw_socket_allowed);
   }
 
-  std::string updatesRejectedStatName() { return policy_map_->stats_.updates_rejected_.name(); }
+  std::string updatesRejectedStatName() {
+    return policy_map_->getImpl().stats_.updates_rejected_.name();
+  }
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   std::shared_ptr<NetworkPolicyMap> policy_map_;
@@ -213,7 +216,7 @@ TEST_F(CiliumNetworkPolicyTest, UpdatesRejectedStatName) {
 }
 
 TEST_F(CiliumNetworkPolicyTest, EmptyPolicyUpdate) {
-  EXPECT_TRUE(policy_map_->onConfigUpdate({}, "1").ok());
+  EXPECT_TRUE(policy_map_->getImpl().onConfigUpdate({}, "1").ok());
   EXPECT_FALSE(validate("10.1.2.3", "")); // Policy not found
 }
 


### PR DESCRIPTION
Change policy resolver back to a shared pointer, and manage `NetworkPolicyMap` destruction explicitly by splitting the map to singleton and `NetworkPolicyMapImpl` and by posting the `NetworkPolicyMapImpl` to the main thread for deletion. This effectively reverts https://github.com/cilium/proxy/pull/1016.

`NetworkPolicyMapImpl` is managed via an unique_ptr, which required the removal of use of `shared_from_this`, which was possible due to simplified clean-up of the old map now that an atomic swap is used for the policy map update.

This change allows long lived connections on a removed listener to keep on functioning, including receiving policy updates via the singleton policy map.
