### PR TITLE
policy: Change policy resolver back to a shared pointer

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -529,7 +529,7 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
       mark, ingress_source_identity, source_identity, is_ingress_, is_l7lb_, dip->port(),
       std::move(pod_ip), std::move(ingress_policy_name), std::move(src_address),
       std::move(source_addresses.ipv4_), std::move(source_addresses.ipv6_), std::move(dst_address),
-      weak_from_this(), proxy_id_, std::move(proxylib_l7proto), sni));
+      shared_from_this(), proxy_id_, std::move(proxylib_l7proto), sni));
 }
 
 Network::FilterStatus Instance::onAccept(Network::ListenerFilterCallbacks& cb) {

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -39,7 +39,7 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
                  Network::Address::InstanceConstSharedPtr source_address_ipv4,
                  Network::Address::InstanceConstSharedPtr source_address_ipv6,
                  Network::Address::InstanceConstSharedPtr original_dest_address,
-                 const std::weak_ptr<PolicyResolver>& policy_resolver, uint32_t proxy_id,
+                 const PolicyResolverSharedPtr& policy_resolver, uint32_t proxy_id,
                  std::string&& proxylib_l7_proto, absl::string_view sni)
       : ingress_source_identity_(ingress_source_identity), source_identity_(source_identity),
         ingress_(ingress), is_l7lb_(l7lb), port_(port), pod_ip_(std::move(pod_ip)),
@@ -117,7 +117,7 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
   uint32_t proxy_id_;
   std::string proxylib_l7_proto_;
   std::string sni_;
-  std::weak_ptr<PolicyResolver> policy_resolver_;
+  const PolicyResolverSharedPtr policy_resolver_;
 
   uint32_t mark_;
 

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -1177,9 +1177,12 @@ NetworkPolicyMap::~NetworkPolicyMap() {
   ENVOY_LOG(debug, "Cilium L7 NetworkPolicyMap({}): NetworkPolicyMap is deleted NOW!",
             instance_id_);
   // Policy map destruction happens when the last listener with the Cilium bpf_metadata listener
-  // filter has drained out and is finally removed. At this point the listener socket can no
-  // longer receive new traffic and we can simply delete the policy map without synchronizing with
-  // the worker threads.
+  // filter has drained out and is finally removed, and last connection of the old listener is
+  // closed. This does not happen if new listener(s) with references to policy map are created in
+  // the meanwhile.
+  //
+  // Note that this can happen from a worker thread, but since we no longer synchronize with the
+  // worker threads there is no assumption that this would be executed from the main thread only.
   delete load();
 }
 


### PR DESCRIPTION
Change policy resolver back to a shared pointer. This effectively reverts synchronization between the main and worker threads, It should be safe to have the policy map destructor called from any thread, so the weak pointer is no longer needed to avoid it.

This change allows long lived connections on a removed listener to keep on functioning, including receiving policy updates via the singleton policy map.