### PR TITLE
gha: Avoid conflict group name for Cilium Integration test

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -13,7 +13,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.repository || github.event.pull_request.number || github.event.after }}
+  group: ${{ github.workflow }}-${{ inputs.repository }}-${{ github.event.pull_request.number || github.event.after || inputs.commit_ref }}
   cancel-in-progress: true
 
 # By specifying the access of one of the scopes, all of those that are not specified are set to 'none'.


### PR DESCRIPTION
Using inputs.repository as main indicator might cause workflow being canceled if multiple PRs are running in both main and stable branches. This commit is to change the key to pull request, or github.event.after or commit ref.