### PR TITLE
l7lb: Pass original source address in option for east/west

### DIFF
--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -170,8 +170,7 @@ private:
   uint32_t resolveSourceIdentity(const PolicyInstance& policy, const Network::Address::Ip* sip,
                                  const Network::Address::Ip* dip, bool ingress, bool is_l7_lb);
 
-  IpAddressPair getIpAddressPairFrom(const Network::Address::InstanceConstSharedPtr source_address,
-                                     const IpAddressPair& addresses);
+  IpAddressPair getIpAddressPairWithPort(uint16_t port, const IpAddressPair& addresses);
 
   const Network::Address::Ip* selectIpVersion(const Network::Address::IpVersion version,
                                               const IpAddressPair& source_addresses);

--- a/cilium/socket_option_source_address.cc
+++ b/cilium/socket_option_source_address.cc
@@ -3,6 +3,7 @@
 #include <sys/socket.h>
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -56,6 +57,12 @@ bool SourceAddressSocketOption::setOption(
   }
 
   Network::Address::InstanceConstSharedPtr source_address = original_source_address_;
+
+  // Do not use source address of wrong IP version
+  if (source_address && source_address->ip() && source_address->ip()->version() != *ip_version) {
+    source_address = nullptr;
+  }
+
   if (!source_address && (ipv4_source_address_ || ipv6_source_address_)) {
     // Select source address based on the socket address family
     source_address = ipv6_source_address_;

--- a/tests/metadata_config_test.cc
+++ b/tests/metadata_config_test.cc
@@ -561,7 +561,7 @@ TEST_F(MetadataConfigTest, EastWestL7LbMetadata) {
   EXPECT_NE(nullptr, source_addresses_socket_option);
   EXPECT_EQ(1, source_addresses_socket_option->linger_time_);
 
-  EXPECT_EQ(nullptr, source_addresses_socket_option->original_source_address_);
+  EXPECT_EQ("10.1.1.1:41234", source_addresses_socket_option->original_source_address_->asString());
   EXPECT_EQ("10.1.1.1:41234", source_addresses_socket_option->ipv4_source_address_->asString());
   EXPECT_EQ("[face::1:1:1]:41234",
             source_addresses_socket_option->ipv6_source_address_->asString());


### PR DESCRIPTION
Source address socket option uses 'hashKey' function to choose the
upstream connection pool. 'hashKey' has no access to the socket (which
has not been created yet), so it needs access to the original source
address which can be either IPv4 or IPv6 to be able to pass in the
original source address and port in the resulting hash.

This fixes the issue with east/west l7lb that caused upstream connection
pool being shared between all local endpoints with the same security
identity, while using the original source address. This manifested as
connection pool attempting to create more than one connection with the
same 5-tuple, which failed and resulted in '503' responses in HTTP.

Fixes: #65