### PR TITLE
cilium: Reduce locking in privileged service client

### DIFF
--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -359,6 +359,7 @@ envoy_cc_library(
     deps = [
         "//starter:privileged_service_protocol",
         "@envoy//envoy/api:os_sys_calls_interface",
+        "@envoy//source/common/common:thread_lib",
         "@envoy//source/common/singleton:threadsafe_singleton",
     ],
 )

--- a/cilium/privileged_service_client.cc
+++ b/cilium/privileged_service_client.cc
@@ -34,8 +34,8 @@ ProtocolClient::ProtocolClient()
     : Protocol(CILIUM_PRIVILEGED_SERVICE_FD), call_mutex_(PTHREAD_MUTEX_INITIALIZER), seq_(0) {
   // Check that the Envoy process isn't running with privileges.
   // The only exception is CAP_NET_BIND_SERVICE (if explicitly excluded from being dropped).
-  RELEASE_ASSERT((get_capabilities(CAP_EFFECTIVE) & ~(1UL << CAP_NET_BIND_SERVICE)) == 0 &&
-                     (get_capabilities(CAP_PERMITTED) & ~(1UL << CAP_NET_BIND_SERVICE)) == 0,
+  RELEASE_ASSERT((getCapabilities(CAP_EFFECTIVE) & ~(1UL << CAP_NET_BIND_SERVICE)) == 0 &&
+                     (getCapabilities(CAP_PERMITTED) & ~(1UL << CAP_NET_BIND_SERVICE)) == 0,
                  "cilium-envoy running with privileges, exiting");
 
   if (!checkPrivilegedService()) {
@@ -65,14 +65,14 @@ ssize_t ProtocolClient::transact(MessageHeader& req, size_t req_len, const void*
   RELEASE_ASSERT(rc == 0, "pthread_mutex_lock");
 
   req.msg_seq_ = ++seq_;
-  ssize_t size = send_fd_msg(&req, req_len, data, data_len, *fd);
+  ssize_t size = sendFdMsg(&req, req_len, data, data_len, *fd);
   if (!assert && size_t(size) != req_len + data_len) {
     goto out;
   }
   RELEASE_ASSERT(size != 0, "Cilium privileged service closed pipe");
   RELEASE_ASSERT(size > 0, "Cilium privileged service send failed");
 
-  size = recv_fd_msg(&resp, sizeof(resp), buf, bufsize, fd);
+  size = recvFdMsg(&resp, sizeof(resp), buf, bufsize, fd);
   if (!assert && size_t(size) < sizeof(resp)) {
     goto out;
   }

--- a/cilium/privileged_service_client.cc
+++ b/cilium/privileged_service_client.cc
@@ -7,7 +7,6 @@
 #include <asm-generic/socket.h>
 #include <linux/capability.h>
 #include <linux/limits.h>
-#include <pthread.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -22,6 +21,7 @@
 #include "envoy/api/os_sys_calls_common.h"
 
 #include "source/common/common/assert.h"
+#include "source/common/common/lock_guard.h"
 #include "source/common/common/logger.h"
 
 #include "starter/privileged_service_protocol.h"
@@ -30,8 +30,7 @@ namespace Envoy {
 namespace Cilium {
 namespace PrivilegedService {
 
-ProtocolClient::ProtocolClient()
-    : Protocol(CILIUM_PRIVILEGED_SERVICE_FD), call_mutex_(PTHREAD_MUTEX_INITIALIZER), seq_(0) {
+ProtocolClient::ProtocolClient() : Protocol(CILIUM_PRIVILEGED_SERVICE_FD), seq_(0) {
   // Check that the Envoy process isn't running with privileges.
   // The only exception is CAP_NET_BIND_SERVICE (if explicitly excluded from being dropped).
   RELEASE_ASSERT((getCapabilities(CAP_EFFECTIVE) & ~(1UL << CAP_NET_BIND_SERVICE)) == 0 &&
@@ -39,6 +38,7 @@ ProtocolClient::ProtocolClient()
                  "cilium-envoy running with privileges, exiting");
 
   if (!checkPrivilegedService()) {
+    ENVOY_LOG(warn, "Cilium privileged service not present");
     // No Cilium privileged service detected
     close();
   }
@@ -57,47 +57,133 @@ ProtocolClient::ProtocolClient()
 
 ssize_t ProtocolClient::transact(MessageHeader& req, size_t req_len, const void* data,
                                  size_t data_len, int* fd, Response& resp, void* buf,
-                                 size_t bufsize, bool assert) {
-  uint32_t expected_response_type = resp.hdr_.msg_type_;
+                                 size_t buf_size) {
+  RELEASE_ASSERT(buf_size <= RESPONSE_BUF_SIZE, "ProtocolClient::transact: invalid bufsize");
+  uint32_t seq;
 
-  // Serialize calls to cilium privileged service
-  int rc = pthread_mutex_lock(&call_mutex_);
-  RELEASE_ASSERT(rc == 0, "pthread_mutex_lock");
+  // get next atomic sequence number
+  do {
+    seq = ++seq_;
+  } while (seq == 0); // zero is reserved for "no response"
+  req.msg_seq_ = seq;
 
-  req.msg_seq_ = ++seq_;
+  // Set up a waiter in the stack before we send anything so that the waiter exists as soon as it is
+  // possible for a concurrent receiver to receive the response.
+  Waiter waiter;
+  insert(seq, &waiter);
+
+  // send message after a waiter has been established.
   ssize_t size = sendFdMsg(&req, req_len, data, data_len, *fd);
-  if (!assert && size_t(size) != req_len + data_len) {
-    goto out;
-  }
-  RELEASE_ASSERT(size != 0, "Cilium privileged service closed pipe");
-  RELEASE_ASSERT(size > 0, "Cilium privileged service send failed");
 
-  size = recvFdMsg(&resp, sizeof(resp), buf, bufsize, fd);
-  if (!assert && size_t(size) < sizeof(resp)) {
-    goto out;
-  }
-  RELEASE_ASSERT(size != 0, "Cilium privileged service closed pipe");
-  RELEASE_ASSERT(size < 0 || size_t(size) >= sizeof(resp),
-                 "Cilium privileged service truncated response");
-  RELEASE_ASSERT(resp.hdr_.msg_seq_ == req.msg_seq_,
-                 "Cilium privileged service response out of sequence");
-  RELEASE_ASSERT(resp.hdr_.msg_type_ == expected_response_type,
-                 "Cilium privileged service unexpected response type");
+  if (size > 0) {
+    RELEASE_ASSERT(size_t(size) == req_len + data_len, "truncated request");
 
-out:
-  rc = pthread_mutex_unlock(&call_mutex_);
-  RELEASE_ASSERT(rc == 0, "pthread_mutex_unlock");
-  return size;
+    // receive removes the waiter from 'waiters_' before returning
+    receive(waiter, seq);
+  } else {
+    remove(seq);
+  }
+
+  return waiter.getResponse(seq, resp, buf, buf_size, fd);
+}
+
+// receive
+// 1. Waits to become the receiver, checking for a response one each wake-up
+// 2. Loops receiving responses when becoming the exclusive receiver,
+//    passing resonses to other waiters until its own response is received.
+// 3. Removes the waiter from 'waiters_' before returning.
+void ProtocolClient::receive(Waiter& waiter, uint32_t seq) noexcept {
+  // Loop waiting until we have a response or become the receiver.
+  // 'mutex_' is released when exiting the loop.
+  bool done = false;
+  bool receiver_active;
+  {
+    Thread::LockGuard guard(mutex_);
+    while (true) {
+      // Check if we have our response.
+      if (waiter.seq() != 0) {
+        waiters_.erase(seq);
+        receiver_active = is_receiver_active_;
+        done = true;
+        break;
+      }
+
+      // Check if we can become the receiver.
+      if (!is_receiver_active_) {
+        receiver_active = is_receiver_active_ = true;
+        break;
+      }
+
+      // 'mutex_' is released for the duration of the wait.
+      wait();
+    }
+  }
+
+  // mutex_ not held any more
+  // Return if done
+  if (done) {
+    if (!receiver_active) {
+      // Notify another waiter (if any) to possibly become the new receiver.
+      // This sure there always is a receiver if there are any waiters.
+      notifyOne();
+    }
+    return;
+  }
+
+  // No locks are held, but we just exclusively set the is_receiver_active_ = true above.
+  // Receiver accesses it's own waiter (the 'waiter') without locking.
+  // Other waiters are accessed only while holding 'mutex_'.
+
+  // Receive until we have a response or an error
+  while (true) {
+    ssize_t size = waiter.recvFdMsg(*this);
+    if (size < 0) {
+      ENVOY_LOG(debug, "privileged service failed with {} (errno {})", size, errno);
+      break;
+    }
+
+    // Is the response for us?
+    if (waiter.seq() == seq) {
+      break;
+    }
+
+    // The response is for one of the waiters, pass it on
+    {
+      Thread::LockGuard guard(mutex_);
+      auto it = waiters_.find(waiter.seq());
+      RELEASE_ASSERT(it != waiters_.end(), fmt::format("no waiter found for seq {}", waiter.seq()));
+      // copy received data to the found waiter
+      *it->second = waiter;
+      // clear the waiter of the current receiver
+      waiter.clear();
+    }
+
+    // have to notify all waiters for the right one to be woken up from the wait.
+    notifyAll();
+  }
+
+  // Pass receiver duties to one of the other waiters & remove the waiter from 'waiters_' while we
+  // still have the mutex.
+  {
+    Thread::LockGuard guard(mutex_);
+    is_receiver_active_ = false;
+    waiters_.erase(seq);
+  }
+
+  // wake up one waiter to take the receiver role
+  notifyOne();
 }
 
 bool ProtocolClient::checkPrivilegedService() {
   // Dump the effective capabilities of the privileged service process
   DumpRequest req;
   Response resp;
-  uint8_t buf[1024];
+  uint8_t buf[RESPONSE_BUF_SIZE];
   int fd = -1;
-  ssize_t size = transact(req.hdr_, sizeof(req), nullptr, 0, &fd, resp, buf, sizeof(buf), false);
+
+  ssize_t size = transact(req.hdr_, sizeof(req), nullptr, 0, &fd, resp, buf, sizeof(buf));
   if (size < ssize_t(sizeof(resp))) {
+    ENVOY_LOG_MISC(warn, "Cilium privileged service detection failed with return code: {}", size);
     return false;
   }
   std::string str(reinterpret_cast<char*>(buf), size - sizeof(resp));

--- a/cilium/privileged_service_client.h
+++ b/cilium/privileged_service_client.h
@@ -7,13 +7,21 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 #include "envoy/api/os_sys_calls_common.h"
 
+#include "source/common/common/assert.h"
+#include "source/common/common/lock_guard.h"
+#include "source/common/common/logger.h"
+#include "source/common/common/thread.h"
 #include "source/common/singleton/threadsafe_singleton.h"
 
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
 #include "starter/privileged_service_protocol.h"
 
 namespace Envoy {
@@ -24,8 +32,10 @@ class SocketMarkOption;
 
 namespace PrivilegedService {
 
+#define RESPONSE_BUF_SIZE 1024
+
 // ProtocolClient implements the client logic for communicating with the privileged service.
-class ProtocolClient : public Protocol {
+class ProtocolClient : public Protocol, Logger::Loggable<Logger::Id::filter> {
 public:
   ProtocolClient();
 
@@ -48,10 +58,120 @@ private:
   bool haveCiliumPrivilegedService() const { return isOpen(); }
 
   ssize_t transact(MessageHeader& req, size_t req_len, const void* data, size_t datalen, int* fd,
-                   Response& resp, void* buf = nullptr, size_t bufsize = 0, bool assert = true);
+                   Response& resp, void* buf = nullptr, size_t buf_size = 0);
 
-  pthread_mutex_t call_mutex_;
-  uint32_t seq_;
+  std::atomic<uint32_t> seq_;
+
+  // Waiter has space for a response. While placed in the 'waiters_' map, all access to the
+  // waiter must happen while holding 'mutex_', except for the designated receiver may
+  // access it's own waiter without the mutex.
+  class Waiter {
+  public:
+    Waiter() = default;
+
+    // Returns non-zero sequence number after a response has been received.
+    uint32_t seq() const { return resp_.hdr_.msg_seq_; }
+
+    // Returns received message type
+    MessageType msgType() const { return static_cast<MessageType>(resp_.hdr_.msg_type_); }
+
+    ssize_t recvFdMsg(ProtocolClient& client) {
+      size_ = client.recvFdMsg(&resp_, sizeof(resp_), buf_, sizeof(buf_), &fd_);
+      if (size_ >= 0) {
+        // Failing release asserts cause an exit and an automated restart. This is the only way
+        // to recover from privilaged service failures.
+        RELEASE_ASSERT(size_ != 0, "Cilium privileged service closed pipe");
+        // Must have enough data to decode the response header
+        RELEASE_ASSERT(size_t(size_) >= sizeof(Response),
+                       "Cilium privileged service truncated response");
+        RELEASE_ASSERT(msgType() == MessageType::TypeResponse,
+                       "Cilium privileged service unexpected response type");
+      }
+      return size_;
+    }
+
+    ssize_t getResponse(uint32_t expected_seq_n, Response& resp, void* buf, size_t buf_size,
+                        int* fd) const {
+      auto received_seq = seq();
+      RELEASE_ASSERT(
+          received_seq == 0 && size_ <= 0 || received_seq == expected_seq_n,
+          fmt::format("waiter: invalid response sequence: {} != {}", received_seq, expected_seq_n));
+
+      ssize_t size = size_;
+      if (size_t(size) > sizeof(resp)) {
+        auto copy_size = size_t(size) - sizeof(resp);
+        if (copy_size > buf_size) {
+          // truncate response
+          size -= copy_size - buf_size;
+          copy_size = buf_size;
+        }
+        memcpy(buf, buf_, copy_size); // NOLINT(safe-memcpy)
+      }
+      resp = resp_;
+      if (fd) {
+        *fd = fd_;
+      }
+
+      return size;
+    }
+
+    Waiter& operator=(Waiter& other) {
+      size_ = other.size_;
+      fd_ = other.fd_;
+      resp_ = other.resp_;
+      if (size_ > ssize_t(sizeof(resp_))) {
+        size_t copy_size = size_t(size_) - sizeof(resp_);
+        if (copy_size <= sizeof(buf_)) {
+          memcpy(buf_, other.buf_, copy_size); // NOLINT(safe-memcpy)
+        }
+      }
+      return *this;
+    }
+
+    void clear() {
+      size_ = 0;
+      fd_ = -1;
+      resp_ = {};
+    }
+
+  private:
+    // 'size_' non-zero after a the response has been received
+    ssize_t size_{};
+    int fd_;
+    Response resp_;
+    char buf_[RESPONSE_BUF_SIZE];
+  };
+
+  void insert(uint32_t seq, Waiter* waiter) {
+    Thread::LockGuard guard(mutex_);
+    auto ret = waiters_.emplace(seq, waiter);
+    RELEASE_ASSERT(ret.second, "waiter emplace failed");
+  }
+
+  void remove(uint32_t seq) {
+    Thread::LockGuard guard(mutex_);
+    waiters_.erase(seq);
+  }
+
+  // receive is declared as noexcept to guarantee it will return normally, rather than via
+  // an exception, if the program continues running. This allows for safe removal of the Waiter
+  // from Waiters before the Waiter is destructed.
+  void receive(Waiter&, uint32_t seq) noexcept;
+
+private:
+  using WaitersMap = absl::flat_hash_map<uint32_t, Waiter*>;
+
+  Thread::MutexBasicLockable mutex_;
+  WaitersMap waiters_ ABSL_GUARDED_BY(mutex_);
+  bool is_receiver_active_ ABSL_GUARDED_BY(mutex_) = false;
+
+  void wait() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) { cond_.wait(mutex_); }
+
+  void notifyOne() ABSL_LOCKS_EXCLUDED(mutex_) { cond_.notifyOne(); }
+
+  void notifyAll() ABSL_LOCKS_EXCLUDED(mutex_) { cond_.notifyAll(); }
+
+  Thread::CondVar cond_;
 };
 
 using Singleton = Envoy::ThreadSafeSingleton<ProtocolClient>;

--- a/cilium/privileged_service_client.h
+++ b/cilium/privileged_service_client.h
@@ -45,7 +45,7 @@ protected:
 
 private:
   bool checkPrivilegedService();
-  bool haveCiliumPrivilegedService() const { return is_open(); }
+  bool haveCiliumPrivilegedService() const { return isOpen(); }
 
   ssize_t transact(MessageHeader& req, size_t req_len, const void* data, size_t datalen, int* fd,
                    Response& resp, void* buf = nullptr, size_t bufsize = 0, bool assert = true);

--- a/starter/main.cc
+++ b/starter/main.cc
@@ -2,18 +2,15 @@
 #error "Linux platform file is part of non-Linux build."
 #endif
 
+#include <cerrno>
 #include <cstring>
-#include <errno.h>
 #include <sys/prctl.h>
-#include <sys/types.h>
 #include <sys/wait.h>
-#include <syscall.h>
 #include <unistd.h>
 #include <vector>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/syscall.h>
 
@@ -57,7 +54,7 @@ int main(int argc, char** argv) {
   }
 
   // Check that we have the required capabilities
-  uint64_t caps = Envoy::Cilium::PrivilegedService::get_capabilities(CAP_EFFECTIVE);
+  uint64_t caps = Envoy::Cilium::PrivilegedService::getCapabilities(CAP_EFFECTIVE);
   if ((caps & (1UL << CAP_NET_ADMIN)) == 0 ||
       (caps & (1UL << CAP_SYS_ADMIN | 1UL << CAP_BPF)) == 0) {
     fprintf(stderr, "CAP_NET_ADMIN and either CAP_SYS_ADMIN or CAP_BPF capabilities are needed for "
@@ -151,9 +148,9 @@ int main(int argc, char** argv) {
       exp_perm_cap = (1UL << CAP_NET_BIND_SERVICE);
     }
     RELEASE_ASSERT(
-        Envoy::Cilium::PrivilegedService::get_capabilities(CAP_EFFECTIVE) == exp_eff_cap &&
-            Envoy::Cilium::PrivilegedService::get_capabilities(CAP_PERMITTED) == exp_perm_cap &&
-            Envoy::Cilium::PrivilegedService::get_capabilities(CAP_INHERITABLE) == 0,
+        Envoy::Cilium::PrivilegedService::getCapabilities(CAP_EFFECTIVE) == exp_eff_cap &&
+            Envoy::Cilium::PrivilegedService::getCapabilities(CAP_PERMITTED) == exp_perm_cap &&
+            Envoy::Cilium::PrivilegedService::getCapabilities(CAP_INHERITABLE) == 0,
         "Failed dropping privileges");
 
     // Dup the client end to CILIUM_PRIVILEGED_SERVICE_FD

--- a/starter/privileged_service_protocol.h
+++ b/starter/privileged_service_protocol.h
@@ -75,16 +75,13 @@ struct MessageHeader {
   MessageHeader(MessageType t) : msg_type_(t) {}
 };
 
-// Response passes the return value and errno code from the system call, followed by optional
-// data depending on the request type. Note that file descriptor return value is passed using the
-// message control channel (ref. man 2 recvmsg).
+// Response passes the return value and errno code from the system call.
+// Note that file descriptor return value is passed using the message control channel (ref. man 2
+// recvmsg).
 struct Response {
-  Response() : hdr_(TypeResponse) {}
-
-  struct MessageHeader hdr_;
-  int return_value_;
-  int errno_;
-  uint8_t data_[];
+  struct MessageHeader hdr_{};
+  int return_value_ = 0;
+  int errno_ = 0;
 };
 
 // Dump requests consists only of the message header, but with the TYPE_DUMP_REQUEST.


### PR DESCRIPTION
Change the calls to "privileged services" to only take the `calls_mutex_` for receiving responses.

Set up a `Waiter` for each caller so that the active receiver can pass responses to them. The active receiver stops receiving as soon as it gets its own response, and passes the receiver role to another "waiter".

Any changes to this code should be tested with a performance tool maximally loading all the available worker threads (e.g., `wrk`).

This partially addresses the performance regression introduced in #315.

On a local kind environment this improves `wrk -t50 -c100` request rate through a CEC-defined Envoy listener from 6221 req/sec to 13593 req/sec.

Fixes: #315