### PR TITLE
ipcache: Add cache before performing bpf lookups

### DIFF
--- a/cilium/api/bpf_metadata.proto
+++ b/cilium/api/bpf_metadata.proto
@@ -74,4 +74,11 @@ message BpfMetadata {
   // Network Policy xDS (NPDS) will only be used if this is 'true' or 'bpf_root' is non-empty.
   // If 'use_nphds' is 'false' ipcache named by 'ipcache_name' is used instead.
   bool use_nphds = 13;
+
+  // Duration to reuse ipcache results until the entry is looked up from bpf ipcache again.
+  // Defaults to 3 milliseconds.
+  google.protobuf.Duration cache_entry_ttl = 14;
+
+  // Cache is garbage collected at interval 10 times the ttl (default 30 ms).
+  google.protobuf.Duration cache_gc_interval = 15;
 }

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -1,13 +1,14 @@
 #pragma once
 
+#include <chrono>
 #include <cstddef>
-#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "envoy/api/io_error.h"
+#include "envoy/common/random_generator.h"
 #include "envoy/network/address.h"
 #include "envoy/network/filter.h"
 #include "envoy/network/listener_filter_buffer.h"
@@ -30,6 +31,8 @@
 namespace Envoy {
 namespace Cilium {
 namespace BpfMetadata {
+
+#define DEFAULT_CACHE_ENTRY_TTL_MS 3
 
 struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
   SocketMetadata(uint32_t mark, uint32_t ingress_source_identity, uint32_t source_identity,
@@ -160,6 +163,8 @@ public:
   Network::Address::InstanceConstSharedPtr ipv6_source_address_;
   bool enforce_policy_on_l7lb_;
   std::string l7lb_policy_name_;
+  std::chrono::milliseconds ipcache_entry_ttl_;
+  Random::RandomGenerator& random_;
 
   std::shared_ptr<const Cilium::NetworkPolicyMap> npmap_{};
   Cilium::CtMapSharedPtr ct_maps_{};

--- a/cilium/ipcache.cc
+++ b/cilium/ipcache.cc
@@ -1,72 +1,42 @@
 #include "ipcache.h"
 
-#include <netinet/in.h>
-
 #include <cerrno> // IWYU pragma: keep
-#include <cstdint>
+#include <chrono>
 #include <cstring>
 #include <memory>
 #include <string>
 
-#include "envoy/common/platform.h"
 #include "envoy/network/address.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/singleton/manager.h"
 
-#include "source/common/common/lock_guard.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/utility.h"
 
 #include "absl/numeric/int128.h"
+#include "absl/synchronization/mutex.h"
 #include "cilium/bpf.h"
 #include "linux/bpf.h"
-#include "linux/type_mapper.h"
 
 namespace Envoy {
 namespace Cilium {
 
-// These must be kept in sync with Cilium source code, should refactor
-// them to a separate include file we can include here instead of
-// copying them!
+bool operator==(const IpCacheKey& a, const IpCacheKey& b) { return memcmp(&a, &b, sizeof(a)) == 0; }
 
-using __be32 = uint32_t; // Beware of the byte order!
-using __u64 = uint64_t;
-using __u32 = uint32_t;
-using __u16 = uint16_t;
-using __u8 = uint8_t;
-
-PACKED_STRUCT(struct IpCacheKey {
-  struct bpf_lpm_trie_key lpm_key;
-  __u16 pad1;
-  __u8 pad2;
-  __u8 family;
-  union {
-    struct {
-      __u32 ip4;
-      __u32 pad4;
-      __u32 pad5;
-      __u32 pad6;
-    };
-    __u32 ip6[4];
-  };
-});
-
-struct RemoteEndpointInfo {
-  using SecLabelType = __u32;
-  SecLabelType sec_label;
-  char buf[60]; // Enough space for all fields after the 'sec_label'
-};
-
-#define ENDPOINT_KEY_IPV4 1
-#define ENDPOINT_KEY_IPV6 2
+template <typename H> H AbslHashValue(H state, const IpCacheKey& key) {
+  // Combine the hash of each member into the state
+  H h = H::combine_contiguous(std::move(state), reinterpret_cast<const char*>(&key), sizeof(key));
+  return h;
+}
 
 SINGLETON_MANAGER_REGISTRATION(cilium_ipcache);
 
 IpCacheSharedPtr IpCache::newIpCache(Server::Configuration::ServerFactoryContext& context,
-                                     const std::string& path) {
+                                     const std::string& path,
+                                     std::chrono::milliseconds cache_gc_interval) {
   auto ipcache = context.singletonManager().getTyped<Cilium::IpCache>(
-      SINGLETON_MANAGER_REGISTERED_NAME(cilium_ipcache), [&path] {
-        auto ipcache = std::make_shared<Cilium::IpCache>(path);
+      SINGLETON_MANAGER_REGISTERED_NAME(cilium_ipcache), [&path, &context, &cache_gc_interval] {
+        auto ipcache = std::make_shared<Cilium::IpCache>(context, path, cache_gc_interval);
         if (!ipcache->open()) {
           ipcache.reset();
         }
@@ -75,7 +45,7 @@ IpCacheSharedPtr IpCache::newIpCache(Server::Configuration::ServerFactoryContext
 
   // Override the current path even on an existing singleton
   if (ipcache) {
-    ipcache->setPath(path);
+    ipcache->setConfig(path, cache_gc_interval);
   }
   return ipcache;
 }
@@ -85,22 +55,53 @@ IpCacheSharedPtr IpCache::getIpCache(Server::Configuration::ServerFactoryContext
       SINGLETON_MANAGER_REGISTERED_NAME(cilium_ipcache));
 }
 
-IpCache::IpCache(const std::string& path)
-    : Bpf(BPF_MAP_TYPE_LPM_TRIE, sizeof(struct IpCacheKey),
-          sizeof(RemoteEndpointInfo::SecLabelType), sizeof(struct RemoteEndpointInfo)),
-      path_(path) {}
+IpCache::IpCache(Server::Configuration::ServerFactoryContext& context, const std::string& path,
+                 std::chrono::milliseconds cache_gc_interval)
+    : Bpf(BPF_MAP_TYPE_LPM_TRIE, sizeof(struct IpCacheKey), sizeof(SecLabelType),
+          sizeof(struct RemoteEndpointInfo)),
+      dispatcher_(context.mainThreadDispatcher()),
+      cache_gc_timer_(dispatcher_.createTimer([this]() { cacheGc(); })),
+      cache_gc_interval_(cache_gc_interval), time_source_(context.timeSource()), path_(path) {
+  // Timer for cache GC
+  if (cache_gc_interval_ != std::chrono::milliseconds(0)) {
+    cache_gc_timer_->enableTimer(cache_gc_interval_);
+  }
+}
 
-void IpCache::setPath(const std::string& path) {
-  Thread::LockGuard guard(path_mutex_);
+void IpCache::cacheGc() {
+  {
+    absl::WriterMutexLock lock(&mutex_);
+    for (auto it = cache_.begin(); it != cache_.end(); it++) {
+      auto age = time_source_.monotonicTime() - it->second.time_stamp;
+      if (age >= std::chrono::milliseconds(1)) {
+        ENVOY_LOG(trace, "cilium.ipcache: local cache GC deleting old entry {}:{}",
+                  it->first.asString(), it->second.sec_label);
+        cache_.erase(it);
+      }
+    }
+  }
+  cache_gc_timer_->enableTimer(cache_gc_interval_);
+}
+
+void IpCache::setConfig(const std::string& path, std::chrono::milliseconds cache_gc_interval) {
+  absl::WriterMutexLock lock(&mutex_);
+  // update GC interval?
+  if (cache_gc_interval != cache_gc_interval_) {
+    cache_gc_timer_->disableTimer();
+    cache_gc_interval_ = cache_gc_interval;
+    if (cache_gc_interval_ != std::chrono::milliseconds(0)) {
+      cache_gc_timer_->enableTimer(cache_gc_interval_);
+    }
+  }
+  // re-open on path change
   if (path != path_) {
     path_ = path;
-    // re-open on path change
     openLocked();
   }
 }
 
 bool IpCache::open() {
-  Thread::LockGuard guard(path_mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   return openLocked();
 }
 
@@ -113,7 +114,7 @@ bool IpCache::openLocked() {
   return false;
 }
 
-uint32_t IpCache::resolve(const Network::Address::Ip* ip) {
+uint32_t IpCache::resolve(const Network::Address::Ip* ip, std::chrono::microseconds cache_ttl) {
   struct IpCacheKey key {};
   struct RemoteEndpointInfo value {};
 
@@ -128,17 +129,39 @@ uint32_t IpCache::resolve(const Network::Address::Ip* ip) {
     memcpy(&key.ip6, &ip6, sizeof key.ip6); // NOLINT(safe-memcpy)
   }
 
-  if (key.family == ENDPOINT_KEY_IPV4) {
-    ENVOY_LOG(trace, "cilium.ipcache: Looking up key: {:x}, prefixlen: {}", ntohl(key.ip4),
-              key.lpm_key.prefixlen - 32);
-  } else if (key.family == ENDPOINT_KEY_IPV6) {
-    ENVOY_LOG(trace, "cilium.ipcache: Looking up key: {:x}:{:x}:{:x}:{:x}, prefixlen {}",
-              ntohl(key.ip6[0]), ntohl(key.ip6[1]), ntohl(key.ip6[2]), ntohl(key.ip6[3]),
-              key.lpm_key.prefixlen - 32);
+  bool ok;
+  bool use_cache = cache_ttl > std::chrono::microseconds(0);
+  {
+    // Read lock prevents ipcache lookups while ipcache is being reopened.
+    absl::ReaderMutexLock lock(&mutex_);
+
+    // local cache lookup
+    if (use_cache) {
+      const auto it = cache_.find(key);
+      if (it != cache_.cend()) {
+        auto age = time_source_.monotonicTime() - it->second.time_stamp;
+        if (age < cache_ttl) {
+          // use cached value
+          ENVOY_LOG(trace, "cilium.ipcache: {} has cached ID {}", ip->addressAsString(),
+                    it->second.sec_label);
+          return it->second.sec_label;
+        }
+      }
+    }
+
+    ENVOY_LOG(trace, "cilium.ipcache: Looking up key: {}", key.asString());
+    ok = lookup(&key, &value);
   }
 
-  if (lookup(&key, &value)) {
+  if (ok) {
     ENVOY_LOG(debug, "cilium.ipcache: {} has ID {}", ip->addressAsString(), value.sec_label);
+
+    // cache result
+    if (use_cache) {
+      absl::WriterMutexLock lock(&mutex_);
+      cache_.insert_or_assign(key,
+                              CachedEndpointInfo{value.sec_label, time_source_.monotonicTime()});
+    }
     return value.sec_label;
   }
   ENVOY_LOG(info, "cilium.ipcache: bpf map lookup failed: {}", Envoy::errorDetails(errno));

--- a/cilium/ipcache.h
+++ b/cilium/ipcache.h
@@ -1,36 +1,117 @@
 #pragma once
 
+#include <netinet/in.h>
+
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
 
+#include "envoy/common/platform.h"
+#include "envoy/common/time.h"
+#include "envoy/event/timer.h"
 #include "envoy/network/address.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/singleton/instance.h"
 
-#include "source/common/common/thread.h"
-
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
 #include "cilium/bpf.h"
+#include "linux/bpf.h"
+#include "linux/type_mapper.h"
 
 namespace Envoy {
 namespace Cilium {
 
+// These must be kept in sync with Cilium source code, should refactor
+// them to a separate include file we can include here instead of
+// copying them!
+
+using __be32 = uint32_t; // Beware of the byte order!
+using __u64 = uint64_t;
+using __u32 = uint32_t;
+using __u16 = uint16_t;
+using __u8 = uint8_t;
+
+#define ENDPOINT_KEY_IPV4 1
+#define ENDPOINT_KEY_IPV6 2
+
+PACKED_STRUCT(struct IpCacheKey {
+  std::string asString() const {
+    if (family == ENDPOINT_KEY_IPV4) {
+      auto ip = ntohl(ip4);
+      return fmt::format("%d.%d.%d.%d/%d", uint8_t(ip >> 24), uint8_t(ip >> 16), uint8_t(ip >> 8),
+                         uint8_t(ip), lpm_key.prefixlen - 32);
+    } else if (family == ENDPOINT_KEY_IPV6) {
+      return fmt::format("{:x}:{:x}:{:x}:{:x}/{}", ntohl(ip6[0]), ntohl(ip6[1]), ntohl(ip6[2]),
+                         ntohl(ip6[3]), lpm_key.prefixlen - 32);
+    }
+    return "invalid ipcache key";
+  }
+
+  struct bpf_lpm_trie_key lpm_key;
+  __u16 pad1;
+  __u8 pad2;
+  __u8 family;
+  union {
+    struct {
+      __u32 ip4;
+      __u32 pad4;
+      __u32 pad5;
+      __u32 pad6;
+    };
+    __u32 ip6[4];
+  };
+});
+
+bool operator==(const IpCacheKey& a, const IpCacheKey& b);
+
+template <typename H> H AbslHashValue(H state, const IpCacheKey& key);
+
+using SecLabelType = __u32;
+
+struct RemoteEndpointInfo {
+  SecLabelType sec_label;
+  char buf[60]; // Enough space for all fields after the 'sec_label'
+};
+
+struct CachedEndpointInfo {
+  SecLabelType sec_label;
+  MonotonicTime time_stamp;
+};
+
+using IpCacheMap = absl::flat_hash_map<struct IpCacheKey, struct CachedEndpointInfo>;
+
 class IpCache : public Singleton::Instance, public Bpf {
 public:
   static std::shared_ptr<IpCache> newIpCache(Server::Configuration::ServerFactoryContext& context,
-                                             const std::string& path);
+                                             const std::string& path,
+                                             std::chrono::milliseconds cache_gc_interval);
   static std::shared_ptr<IpCache> getIpCache(Server::Configuration::ServerFactoryContext& context);
 
-  IpCache(const std::string& path);
-  void setPath(const std::string& path);
-  bool open();
-  bool openLocked();
+  IpCache(Server::Configuration::ServerFactoryContext& context, const std::string& path,
+          std::chrono::milliseconds cache_gc_interval);
 
-  uint32_t resolve(const Network::Address::Ip* ip);
+  void setConfig(const std::string& path, std::chrono::milliseconds cache_gc_interval)
+      ABSL_LOCKS_EXCLUDED(mutex_);
+  bool open() ABSL_LOCKS_EXCLUDED(mutex_);
+
+  uint32_t resolve(const Network::Address::Ip* ip, std::chrono::microseconds cache_ttl)
+      ABSL_LOCKS_EXCLUDED(mutex_);
 
 private:
-  Thread::MutexBasicLockable path_mutex_;
+  bool openLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void cacheGc() ABSL_LOCKS_EXCLUDED(mutex_);
+
+  Event::Dispatcher& dispatcher_;
+  Event::TimerPtr cache_gc_timer_;
+  std::chrono::milliseconds cache_gc_interval_;
+  TimeSource& time_source_;
+
+  absl::Mutex mutex_;
   std::string path_;
+  IpCacheMap cache_;
 };
 
 using IpCacheSharedPtr = std::shared_ptr<IpCache>;

--- a/go/cilium/api/bpf_metadata.pb.go
+++ b/go/cilium/api/bpf_metadata.pb.go
@@ -79,9 +79,14 @@ type BpfMetadata struct {
 	// Use Network Policy Hosts xDS (NPHDS) protocol to sync IP/ID mappings.
 	// Network Policy xDS (NPDS) will only be used if this is 'true' or 'bpf_root' is non-empty.
 	// If 'use_nphds' is 'false' ipcache named by 'ipcache_name' is used instead.
-	UseNphds      bool `protobuf:"varint,13,opt,name=use_nphds,json=useNphds,proto3" json:"use_nphds,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	UseNphds bool `protobuf:"varint,13,opt,name=use_nphds,json=useNphds,proto3" json:"use_nphds,omitempty"`
+	// Duration to reuse ipcache results until the entry is looked up from bpf ipcache again.
+	// Defaults to 3 milliseconds.
+	CacheEntryTtl *durationpb.Duration `protobuf:"bytes,14,opt,name=cache_entry_ttl,json=cacheEntryTtl,proto3" json:"cache_entry_ttl,omitempty"`
+	// Cache is garbage collected at interval 10 times the ttl (default 30 ms).
+	CacheGcInterval *durationpb.Duration `protobuf:"bytes,15,opt,name=cache_gc_interval,json=cacheGcInterval,proto3" json:"cache_gc_interval,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *BpfMetadata) Reset() {
@@ -205,11 +210,25 @@ func (x *BpfMetadata) GetUseNphds() bool {
 	return false
 }
 
+func (x *BpfMetadata) GetCacheEntryTtl() *durationpb.Duration {
+	if x != nil {
+		return x.CacheEntryTtl
+	}
+	return nil
+}
+
+func (x *BpfMetadata) GetCacheGcInterval() *durationpb.Duration {
+	if x != nil {
+		return x.CacheGcInterval
+	}
+	return nil
+}
+
 var File_cilium_api_bpf_metadata_proto protoreflect.FileDescriptor
 
 const file_cilium_api_bpf_metadata_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcilium/api/bpf_metadata.proto\x12\x06cilium\x1a\x1egoogle/protobuf/duration.proto\"\xff\x04\n" +
+	"\x1dcilium/api/bpf_metadata.proto\x12\x06cilium\x1a\x1egoogle/protobuf/duration.proto\"\x89\x06\n" +
 	"\vBpfMetadata\x12\x19\n" +
 	"\bbpf_root\x18\x01 \x01(\tR\abpfRoot\x12\x1d\n" +
 	"\n" +
@@ -225,7 +244,9 @@ const file_cilium_api_bpf_metadata_proto_rawDesc = "" +
 	" \x01(\tR\x0el7lbPolicyName\x12G\n" +
 	"\x1eoriginal_source_so_linger_time\x18\v \x01(\rH\x00R\x1aoriginalSourceSoLingerTime\x88\x01\x01\x12!\n" +
 	"\fipcache_name\x18\f \x01(\tR\vipcacheName\x12\x1b\n" +
-	"\tuse_nphds\x18\r \x01(\bR\buseNphdsB!\n" +
+	"\tuse_nphds\x18\r \x01(\bR\buseNphds\x12A\n" +
+	"\x0fcache_entry_ttl\x18\x0e \x01(\v2\x19.google.protobuf.DurationR\rcacheEntryTtl\x12E\n" +
+	"\x11cache_gc_interval\x18\x0f \x01(\v2\x19.google.protobuf.DurationR\x0fcacheGcIntervalB!\n" +
 	"\x1f_original_source_so_linger_timeB.Z,github.com/cilium/proxy/go/cilium/api;ciliumb\x06proto3"
 
 var (
@@ -247,11 +268,13 @@ var file_cilium_api_bpf_metadata_proto_goTypes = []any{
 }
 var file_cilium_api_bpf_metadata_proto_depIdxs = []int32{
 	1, // 0: cilium.BpfMetadata.policy_update_warning_limit:type_name -> google.protobuf.Duration
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	1, // 1: cilium.BpfMetadata.cache_entry_ttl:type_name -> google.protobuf.Duration
+	1, // 2: cilium.BpfMetadata.cache_gc_interval:type_name -> google.protobuf.Duration
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_cilium_api_bpf_metadata_proto_init() }

--- a/go/cilium/api/bpf_metadata.pb.validate.go
+++ b/go/cilium/api/bpf_metadata.pb.validate.go
@@ -108,6 +108,64 @@ func (m *BpfMetadata) validate(all bool) error {
 
 	// no validation rules for UseNphds
 
+	if all {
+		switch v := interface{}(m.GetCacheEntryTtl()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, BpfMetadataValidationError{
+					field:  "CacheEntryTtl",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, BpfMetadataValidationError{
+					field:  "CacheEntryTtl",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetCacheEntryTtl()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return BpfMetadataValidationError{
+				field:  "CacheEntryTtl",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetCacheGcInterval()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, BpfMetadataValidationError{
+					field:  "CacheGcInterval",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, BpfMetadataValidationError{
+					field:  "CacheGcInterval",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetCacheGcInterval()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return BpfMetadataValidationError{
+				field:  "CacheGcInterval",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if m.OriginalSourceSoLingerTime != nil {
 		// no validation rules for OriginalSourceSoLingerTime
 	}


### PR DESCRIPTION
Add a shared cache for Cilium ipcache lookups with configurable cache entry TTL, defaults to 3ms. Stale cache entries are replaced as soon as they are encountered by lookups, and also on a GC timer that runs at interval 10x the TTL (default every 30ms).

Two new BpfMetadata config values are defined:
```
  // Duration to reuse ipcache results until the entry is looked up from bpf ipcache again.
  // Defaults to 3 milliseconds.
  google.protobuf.Duration cache_entry_ttl = 14;

  // Cache is garbage collected at interval 10 times the ttl (default 30 ms).
  google.protobuf.Duration cache_gc_interval = 15;
```
On cache lookup a random jitter value of upto 1 ms is subtracted from `cache_entry_ttl` to avoid all the worker threads synchronizing on non-cached ipcache lookups.

This change improves the max rate of requests passing through a CEC defined listener by ~35%.
