### PR TITLE
Policy refactor to fix logging, avoid unnecessary steps

### DIFF
--- a/cilium/accesslog.cc
+++ b/cilium/accesslog.cc
@@ -83,6 +83,8 @@ void AccessLog::Entry::initFromConnection(
     const std::string& policy_name, uint32_t proxy_id, bool ingress, uint32_t source_identity,
     const Network::Address::InstanceConstSharedPtr& source_address, uint32_t destination_identity,
     const Network::Address::InstanceConstSharedPtr& destination_address, TimeSource* time_source) {
+  request_logged_ = false;
+
   entry_.set_policy_name(policy_name);
   entry_.set_proxy_id(proxy_id);
   entry_.set_is_ingress(ingress);

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -113,7 +113,8 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
   bool ingress_;
   bool is_l7lb_;
   uint16_t port_;
-  std::string pod_ip_;              // pod policy to enforce, if any
+  std::string pod_ip_; // pod policy to enforce, if any; empty only when there is no local pod (i.e.
+                       // north/south l7lb)
   std::string ingress_policy_name_; // Ingress policy to enforce, if any
   uint32_t proxy_id_;
   std::string proxylib_l7_proto_;

--- a/cilium/filter_state_cilium_policy.cc
+++ b/cilium/filter_state_cilium_policy.cc
@@ -39,7 +39,7 @@ bool CiliumPolicyFilterState::enforceNetworkPolicy(const Network::Connection& co
 
     if (!port_policy.allowed(proxy_id_, remote_id, sni)) {
       ENVOY_CONN_LOG(debug, "Pod policy DENY on proxy_id: {} id: {} port: {} sni: \"{}\"", conn,
-                     proxy_id_, remote_id, destination_port, sni);
+                     proxy_id_, remote_id, port, sni);
       return false;
     }
 
@@ -59,8 +59,7 @@ bool CiliumPolicyFilterState::enforceNetworkPolicy(const Network::Connection& co
         ENVOY_CONN_LOG(debug,
                        "Ingress network policy {} DROP for source identity and destination "
                        "reserved ingress identity: {} proxy_id: {} port: {} sni: \"{}\"",
-                       conn, ingress_policy_name_, ingress_source_identity_, proxy_id_,
-                       destination_port, sni);
+                       conn, ingress_policy_name_, ingress_source_identity_, proxy_id_, port_, sni);
         return false;
       }
     }
@@ -81,55 +80,57 @@ bool CiliumPolicyFilterState::enforceNetworkPolicy(const Network::Connection& co
   return true;
 }
 
-bool CiliumPolicyFilterState::enforceHTTPPolicy(const Network::Connection& conn, bool is_downstream,
-                                                uint32_t destination_identity,
-                                                uint16_t destination_port,
-                                                /* INOUT */ Http::RequestHeaderMap& headers,
-                                                /* INOUT */ AccessLog::Entry& log_entry) const {
-  // enforce pod policy first, if any.
-  // - ingress enforcement in downstream
-  // - egress enforcement in upstream
-  // - unless !L7LB, where both are done on downstream filter (only)
-  // =>
-  // - is_l7lb_: ingress_ == is_downstream
-  // - !is_l7lb_: is_downstream
-  if (pod_ip_.length() > 0 && (is_l7lb_ ? is_downstream == ingress_ : is_downstream)) {
-    const auto& policy = policy_resolver_->getPolicy(pod_ip_);
-    auto remote_id = ingress_ ? source_identity_ : destination_identity;
-    auto port = ingress_ ? port_ : destination_port;
-    if (!policy.allowed(ingress_, proxy_id_, remote_id, port, headers, log_entry)) {
-      ENVOY_CONN_LOG(debug, "Pod HTTP policy DENY on proxy_id: {} id: {} port: {}", conn, proxy_id_,
-                     remote_id, port);
-      return false;
-    }
-  }
-
-  // enforce Ingress policy 2nd, if any, always on the upstream
-  if (!is_downstream && ingress_policy_name_.length() > 0) {
-    log_entry.entry_.set_policy_name(ingress_policy_name_);
-    const auto& policy = policy_resolver_->getPolicy(ingress_policy_name_);
-
-    // Enforce ingress policy for Ingress, on the original destination port
-    if (ingress_source_identity_ != 0) {
-      if (!policy.allowed(true, proxy_id_, ingress_source_identity_, port_, headers, log_entry)) {
-        ENVOY_CONN_LOG(debug,
-                       "Ingress HTTP policy {} DROP for source identity: {} proxy_id: {} port: {}",
-                       conn, ingress_policy_name_, ingress_source_identity_, proxy_id_, port_);
-        return false;
-      }
-    }
-
-    // Enforce egress policy for Ingress
-    if (!policy.allowed(false, proxy_id_, destination_identity, destination_port, headers,
-                        log_entry)) {
-      ENVOY_CONN_LOG(
-          debug, "Egress HTTP policy {} DROP for destination identity: {} proxy_id: {} port: {}",
-          conn, ingress_policy_name_, destination_identity, proxy_id_, destination_port);
-      return false;
-    }
+bool CiliumPolicyFilterState::enforcePodHTTPPolicy(const Network::Connection& conn,
+                                                   uint32_t destination_identity,
+                                                   uint16_t destination_port,
+                                                   /* INOUT */ Http::RequestHeaderMap& headers,
+                                                   /* INOUT */ AccessLog::Entry& log_entry) const {
+  const auto& policy = policy_resolver_->getPolicy(pod_ip_);
+  auto remote_id = ingress_ ? source_identity_ : destination_identity;
+  auto port = ingress_ ? port_ : destination_port;
+  if (!policy.allowed(ingress_, proxy_id_, remote_id, port, headers, log_entry)) {
+    ENVOY_CONN_LOG(debug,
+                   "cilium.l7policy: Pod {} HTTP {} policy DENY on proxy_id: {} id: {} port: {}",
+                   conn, pod_ip_, ingress_ ? "ingress" : "egress", proxy_id_, remote_id, port);
+    return false;
   }
 
   // Connection allowed by policy
+  ENVOY_CONN_LOG(debug,
+                 "cilium.l7policy: Pod {} HTTP {} policy ALLOW on proxy_id: {} id: {} port: {}",
+                 conn, pod_ip_, ingress_ ? "ingress" : "egress", proxy_id_, remote_id, port);
+  return true;
+}
+
+bool CiliumPolicyFilterState::enforceIngressHTTPPolicy(
+    const Network::Connection& conn, uint32_t destination_identity, uint16_t destination_port,
+    /* INOUT */ Http::RequestHeaderMap& headers,
+    /* INOUT */ AccessLog::Entry& log_entry) const {
+  log_entry.entry_.set_policy_name(ingress_policy_name_);
+  log_entry.request_logged_ = false; // we reuse the same entry we used for the pod policy
+
+  const auto& policy = policy_resolver_->getPolicy(ingress_policy_name_);
+
+  // Enforce ingress policy for Ingress, on the original destination port
+  if (ingress_source_identity_ != 0) {
+    if (!policy.allowed(true, proxy_id_, ingress_source_identity_, port_, headers, log_entry)) {
+      ENVOY_CONN_LOG(debug, "Ingress {} HTTP ingress policy DROP on proxy_id: {} id: {} port: {}",
+                     conn, ingress_policy_name_, proxy_id_, ingress_source_identity_, port_);
+      return false;
+    }
+  }
+
+  // Enforce egress policy for Ingress
+  if (!policy.allowed(false, proxy_id_, destination_identity, destination_port, headers,
+                      log_entry)) {
+    ENVOY_CONN_LOG(debug, "Ingress {} HTTP egress policy DROP on proxy_id: {} id: {}  port: {}",
+                   conn, ingress_policy_name_, proxy_id_, destination_identity, destination_port);
+    return false;
+  }
+
+  // Connection allowed by policy
+  ENVOY_CONN_LOG(debug, "Ingress {} HTTP policy ALLOW on proxy_id: {} id: {}  port: {}", conn,
+                 ingress_policy_name_, proxy_id_, destination_identity, destination_port);
   return true;
 }
 

--- a/cilium/filter_state_cilium_policy.h
+++ b/cilium/filter_state_cilium_policy.h
@@ -62,10 +62,15 @@ public:
                             /* OUT */ std::string& l7_proto,
                             /* INOUT */ AccessLog::Entry& log_entry) const;
 
-  bool enforceHTTPPolicy(const Network::Connection& conn, bool is_downstream,
-                         uint32_t destination_identity, uint16_t destination_port,
-                         /* INOUT */ Http::RequestHeaderMap& headers,
-                         /* INOUT */ AccessLog::Entry& log_entry) const;
+  bool enforcePodHTTPPolicy(const Network::Connection& conn, uint32_t destination_identity,
+                            uint16_t destination_port,
+                            /* INOUT */ Http::RequestHeaderMap& headers,
+                            /* INOUT */ AccessLog::Entry& log_entry) const;
+
+  bool enforceIngressHTTPPolicy(const Network::Connection& conn, uint32_t destination_identity,
+                                uint16_t destination_port,
+                                /* INOUT */ Http::RequestHeaderMap& headers,
+                                /* INOUT */ AccessLog::Entry& log_entry) const;
 
   // policyUseUpstreamDestinationAddress returns 'true' if policy enforcement should be done on the
   // basis of the upstream destination address.

--- a/cilium/l7policy.h
+++ b/cilium/l7policy.h
@@ -111,7 +111,6 @@ private:
   ConfigSharedPtr config_;
   Http::StreamDecoderFilterCallbacks* callbacks_ = nullptr;
 
-  bool allowed_ = false;
   AccessLog::Entry* log_entry_ = nullptr;
 
   OptRef<Http::RequestHeaderMap> latched_headers_;

--- a/cilium/network_filter.h
+++ b/cilium/network_filter.h
@@ -16,6 +16,8 @@
 #include "cilium/accesslog.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/api/network_filter.pb.h"
+#include "cilium/filter_state_cilium_destination.h"
+#include "cilium/filter_state_cilium_policy.h"
 #include "cilium/proxylib.h"
 
 namespace Envoy {
@@ -62,6 +64,14 @@ public:
   Network::FilterStatus onWrite(Buffer::Instance&, bool end_stream) override;
 
 private:
+  // helper to be used either directly from onNewConnection (no L7 LB),
+  // or from upstream callback (l7 lb)
+  bool enforceNetworkPolicy(const Cilium::CiliumPolicyFilterState* policy_fs,
+                            Cilium::CiliumDestinationFilterState* dest_fs,
+                            uint32_t destination_identity,
+                            Network::Address::InstanceConstSharedPtr dst_address,
+                            absl::string_view sni, StreamInfo::StreamInfo& stream_info);
+
   const ConfigSharedPtr config_;
   Network::ReadFilterCallbacks* callbacks_ = nullptr;
   uint32_t remote_id_ = 0;

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -87,6 +87,10 @@ protected:
   PortPolicy(const PolicyMap& map, const RulesList& wildcard_rules, uint16_t port);
 
 public:
+  // If hasHttpRules() returns false, then HTTP policy enforcement can be skipped,
+  // given that Network layer policy has already been enforced.
+  bool hasHttpRules() const { return has_http_rules_; }
+
   // useProxylib returns true if a proxylib parser should be used.
   // 'l7_proto' is set to the parser name in that case.
   bool useProxylib(uint32_t proxy_id, uint32_t remote_id, std::string& l7_proto) const;
@@ -119,9 +123,13 @@ private:
   bool forRange(std::function<bool(const PortNetworkPolicyRules&, bool& denied)> allowed) const;
   bool forFirstRange(std::function<bool(const PortNetworkPolicyRules&)> f) const;
 
+  static bool hasHttpRules(const PolicyMap& map, const RulesList& wildcard_rules,
+                           const PolicyMap::const_iterator port_rules);
+
   const PolicyMap& map_;
   const RulesList& wildcard_rules_;
   const PolicyMap::const_iterator port_rules_; // iterator to 'map_'
+  const bool has_http_rules_;
 };
 
 class IpAddressPair {

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -104,6 +104,10 @@ protected:
   testing::AssertionResult allowed(bool ingress, const std::string& pod_ip, uint64_t remote_id,
                                    uint16_t port, Http::TestRequestHeaderMapImpl&& headers) {
     const auto& policy = policy_map_->getPolicyInstance(pod_ip, false);
+    // test network layer policy first
+    if (!policy.allowed(ingress, proxy_id_, remote_id, "", port)) {
+      return testing::AssertionFailure();
+    }
     Cilium::AccessLog::Entry log_entry;
     return policy.allowed(ingress, proxy_id_, remote_id, port, headers, log_entry)
                ? testing::AssertionSuccess()


### PR DESCRIPTION
Prepare network filter for future dual upstream/downstream change by only using the current upstream callback for L7 LB enforcement. Now that network level policy for non-L7 LB is performed directly in the downstream filter's onNewConnection() callback, the connection will be rejected on network policy deny before the HTTP level policy is enforced. Some tests needed to be updated to reflect this change by waiting for disconnect rather than HTTP '403' in these cases. This change also causes HTTP access logging to not happen to any traffic that is already dropped by the network level policy. Note that for L7 LB (i.e., Ingress, Gateway API) there is no change.

The case where this change could have production difference is when the network level policy rule enforces an SNI, as in these cases we may have emitted a drop type access log with HTTP header information instead of just the network level drop message.

Fix debug logging where a HTTP ALLOW was logged even when the enforcement was actually skipped in the downstream HTTP filter. This was a logging defect only, so there is no production impact due to this fix.

Finally, skip HTTP policy enforcement if the policy has no HTTP rules. This is possible since the network level policy is always enforced before the HTTP policy (per request), so the HTTP level enforcement only makes a difference when there are HTTP rules.

This last change relies on the current network level policy being enforced on each HTTP request. This needs to be revisited when the network level policy is only enforced on new upstream connections.

This change improves the max rate of requests passing through a CEC defined listener by ~15%.