### PR TITLE
fix: Correct string format for ipcache key

### DIFF
--- a/cilium/ipcache.h
+++ b/cilium/ipcache.h
@@ -41,9 +41,10 @@ PACKED_STRUCT(struct IpCacheKey {
   std::string asString() const {
     if (family == ENDPOINT_KEY_IPV4) {
       auto ip = ntohl(ip4);
-      return fmt::format("%d.%d.%d.%d/%d", uint8_t(ip >> 24), uint8_t(ip >> 16), uint8_t(ip >> 8),
+      return fmt::format("{}.{}.{}.{}/{}", uint8_t(ip >> 24), uint8_t(ip >> 16), uint8_t(ip >> 8),
                          uint8_t(ip), lpm_key.prefixlen - 32);
-    } else if (family == ENDPOINT_KEY_IPV6) {
+    }
+    if (family == ENDPOINT_KEY_IPV6) {
       return fmt::format("{:x}:{:x}:{:x}:{:x}/{}", ntohl(ip6[0]), ntohl(ip6[1]), ntohl(ip6[2]),
                          ntohl(ip6[3]), lpm_key.prefixlen - 32);
     }


### PR DESCRIPTION
This is to avoid the below in debug logs.

```
[cilium/ipcache.cc:152] cilium.ipcache: Looking up key: %d.%d.%d.%d/%d
...
```