### PR TITLE
Revert "ci: Use cilium 1.17 for integration test"

### DIFF
--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -27,7 +27,7 @@ env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION: v0.29.0
   CILIUM_REPO_OWNER: cilium
-  CILIUM_REPO_REF: v1.17
+  CILIUM_REPO_REF: v1.15
   CILIUM_CLI_REF: latest
   CURL_PARALLEL: ${{ vars.CURL_PARALLEL || 10 }}
 


### PR DESCRIPTION
This reverts commit a241113e94bb38fedf9dd14a8bab9de12253ee49.

Relates: https://github.com/cilium/cilium/pull/40244