### PR TITLE
[v1.33] bpf_metadata: Skip original source address for same node L7 LB destinations

### DIFF
--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -69,10 +69,11 @@ struct SocketMetadata : public Logger::Loggable<Logger::Id::filter> {
   };
 
   std::shared_ptr<Envoy::Cilium::SourceAddressSocketOption> buildSourceAddressSocketOption(
-      int linger_time, const std::shared_ptr<CiliumDestinationFilterState>& dest_fs = nullptr) {
+      int linger_time, const std::shared_ptr<CiliumDestinationFilterState>& dest_fs = nullptr,
+      const std::shared_ptr<CiliumPolicyFilterState>& policy_fs = nullptr) {
     return std::make_shared<Envoy::Cilium::SourceAddressSocketOption>(
         source_identity_, linger_time, original_source_address_, source_address_ipv4_,
-        source_address_ipv6_, dest_fs);
+        source_address_ipv6_, dest_fs, policy_fs);
   };
 
   // Add ProxyLib L7 protocol as requested application protocol on the socket.
@@ -148,6 +149,7 @@ public:
   // PolicyResolver
   uint32_t resolvePolicyId(const Network::Address::Ip*) const override;
   const PolicyInstance& getPolicy(const std::string&) const override;
+  bool exists(const std::string&) const override;
 
   virtual absl::optional<SocketMetadata> extractSocketMetadata(Network::ConnectionSocket& socket);
 

--- a/cilium/filter_state_cilium_policy.h
+++ b/cilium/filter_state_cilium_policy.h
@@ -26,6 +26,9 @@ public:
 
   virtual uint32_t resolvePolicyId(const Network::Address::Ip*) const PURE;
   virtual const PolicyInstance& getPolicy(const std::string&) const PURE;
+
+  // Returns 'true' if the given policy exists
+  virtual bool exists(const std::string&) const PURE;
 };
 using PolicyResolverSharedPtr = std::shared_ptr<PolicyResolver>;
 
@@ -53,6 +56,8 @@ public:
   uint32_t resolvePolicyId(const Network::Address::Ip* ip) const {
     return policy_resolver_->resolvePolicyId(ip);
   }
+
+  bool exists(const std::string& ip) const { return policy_resolver_->exists(ip); }
 
   const PolicyInstance& getPolicy() const { return policy_resolver_->getPolicy(pod_ip_); }
 

--- a/cilium/socket_option_source_address.h
+++ b/cilium/socket_option_source_address.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "envoy/config/core/v3/socket_option.pb.h"
@@ -29,7 +30,8 @@ public:
       Network::Address::InstanceConstSharedPtr original_source_address = nullptr,
       Network::Address::InstanceConstSharedPtr ipv4_source_address = nullptr,
       Network::Address::InstanceConstSharedPtr ipv6_source_address = nullptr,
-      std::shared_ptr<CiliumDestinationFilterState> dest_fs = nullptr);
+      std::shared_ptr<CiliumDestinationFilterState> dest_fs = nullptr,
+      std::shared_ptr<CiliumPolicyFilterState> policy_fs = nullptr);
 
   absl::optional<Network::Socket::Option::Details>
   getOptionDetails(const Network::Socket&,
@@ -55,6 +57,7 @@ public:
   Network::Address::InstanceConstSharedPtr ipv4_source_address_;
   Network::Address::InstanceConstSharedPtr ipv6_source_address_;
   std::shared_ptr<CiliumDestinationFilterState> dest_fs_;
+  std::shared_ptr<CiliumPolicyFilterState> policy_fs_;
 };
 
 } // namespace Cilium


### PR DESCRIPTION
We already skip using the original source address/port for non-L7 LB destinations in the same node. This is needed to avoid 5-tuple collisions in cases where the destination happens to have an HTTP policy.

Do the same for east/west L7 LB (e.g., GAMMA) if the chosen destination is in the same node.

Same node destinations receive the source security identity via an skb_mark, so the original source address is not needed for policy enforcement at the destination.