### PR TITLE
renovate: Use ubuntu 22.04 only for builder

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -123,6 +123,19 @@
       ],
     },
     {
+      matchFileNames: [
+        'Dockerfile.builder',
+      ],
+      matchPackageNames: [
+        'docker.io/library/ubuntu',
+      ],
+      allowedVersions: '22.04',
+      matchBaseBranches: [
+        'main',
+        'v1.33',
+      ],
+    },
+    {
       enabled: false,
       matchFileNames: [
         'Dockerfile',


### PR DESCRIPTION
The main reason is glibc dependency, we will perform the upgrade only after cilium 1.17 is the oldest supported version.