### PR TITLE
extensions: enable DNS cluster extension

### DIFF
--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -18,7 +18,7 @@ EXTENSIONS = {
     #
 
     # "envoy.clusters.aggregate":                         "//source/extensions/clusters/aggregate:cluster",
-    # "envoy.clusters.dns":                               "//source/extensions/clusters/dns:dns_cluster_lib",
+    "envoy.clusters.dns": "//source/extensions/clusters/dns:dns_cluster_lib",
     "envoy.clusters.dynamic_forward_proxy": "//source/extensions/clusters/dynamic_forward_proxy:cluster",
     "envoy.clusters.eds": "//source/extensions/clusters/eds:eds_lib",
     # "envoy.clusters.redis":                             "//source/extensions/clusters/redis:redis_cluster",


### PR DESCRIPTION
This commit enables the DNS cluster extension that should be used to configure DNS cluster-related aspects instead of doing this directly via deprecated properties on the cluster.