### PR TITLE
extensions: enable RBAC mtls authenticated extension

### DIFF
--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -461,7 +461,7 @@ EXTENSIONS = {
     # RBAC principals
     #
 
-    # "envoy.rbac.principals.mtls_authenticated":        "//source/extensions/filters/common/rbac/principals/mtls_authenticated:config",
+    "envoy.rbac.principals.mtls_authenticated": "//source/extensions/filters/common/rbac/principals/mtls_authenticated:config",
 
     #
     # DNS Resolver


### PR DESCRIPTION
This commit enables the extension `envoy.rbac.principals.mtls_authenticated`.