### PR TITLE
policy: Support rule precedence

### DIFF
--- a/cilium/api/npds.proto
+++ b/cilium/api/npds.proto
@@ -129,6 +129,11 @@ message TLSContext {
 message PortNetworkPolicyRule {
   reserved 1; // used in Cilium versions upto 1.14
 
+  // Precedence level for this rule. Rules with **higher** numeric values take
+  // precedence, even over deny rules of lower precedence level.
+  // The lowest precedence (zero) is used when not specified.
+  uint32 precedence = 10;
+
   // Traffic on this port is denied for all `remote_policies` if true
   bool deny = 8;
 

--- a/cilium/api/npds.proto
+++ b/cilium/api/npds.proto
@@ -127,6 +127,8 @@ message TLSContext {
 // If all the predicates of a rule match a flow, the flow is matched by the
 // rule.
 message PortNetworkPolicyRule {
+  reserved 1; // used in Cilium versions upto 1.14
+
   // Traffic on this port is denied for all `remote_policies` if true
   bool deny = 8;
 
@@ -143,9 +145,6 @@ message PortNetworkPolicyRule {
   // A flow is matched by this predicate if the identifier of the policy
   // applied on the flow's remote host is contained in this set.
   // Optional. If not specified, any remote host is matched by this predicate.
-  // This field is deprecated, use remote_policies instead.
-  // TODO: Remove when Cilium 1.14 no longer supported.
-  repeated uint64 deprecated_remote_policies_64 = 1;
   repeated uint32 remote_policies = 7;
 
   // Optional downstream TLS context. If present, the incoming connection must

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -492,7 +492,7 @@ public:
       return false;
     }
     if (l7_proto_.length() > 0) {
-      ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicyRules::useProxylib(): returning {}", l7_proto_);
+      ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicyRule::useProxylib(): returning {}", l7_proto_);
       l7_proto = l7_proto_;
       return true;
     }
@@ -508,7 +508,7 @@ public:
     for (const auto& rule : l7_deny_rules_) {
       if (rule.matches(metadata)) {
         ENVOY_LOG(trace,
-                  "Cilium L7 PortNetworkPolicyRules::allowed(): DENY due to "
+                  "Cilium L7 PortNetworkPolicyRule::allowed(): DENY due to "
                   "a matching deny rule {}",
                   rule.name_);
         return false; // request is denied if any deny rule matches
@@ -518,19 +518,19 @@ public:
       for (const auto& rule : l7_allow_rules_) {
         if (rule.matches(metadata)) {
           ENVOY_LOG(trace,
-                    "Cilium L7 PortNetworkPolicyRules::allowed(): ALLOW due "
+                    "Cilium L7 PortNetworkPolicyRule::allowed(): ALLOW due "
                     "to a matching allow rule {}",
                     rule.name_);
           return true;
         }
       }
       ENVOY_LOG(trace,
-                "Cilium L7 PortNetworkPolicyRules::allowed(): DENY due to "
+                "Cilium L7 PortNetworkPolicyRule::allowed(): DENY due to "
                 "all {} allow rules mismatching",
                 l7_allow_rules_.size());
       return false;
     }
-    ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicyRules::allowed(): default ALLOW "
+    ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicyRule::allowed(): default ALLOW "
                      "due to no allow rules");
     return true; // allowed by default
   }
@@ -644,12 +644,16 @@ using PortNetworkPolicyRuleConstSharedPtr = std::shared_ptr<const PortNetworkPol
 class PortNetworkPolicyRules : public Logger::Loggable<Logger::Id::config> {
 public:
   PortNetworkPolicyRules() = default;
-  PortNetworkPolicyRules(const NetworkPolicyMapImpl& parent,
-                         const Protobuf::RepeatedPtrField<cilium::PortNetworkPolicyRule>& rules) {
-    if (rules.empty()) {
-      ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicyRules(): No rules, will allow "
-                       "everything.");
+
+  ~PortNetworkPolicyRules() {
+    if (!Thread::MainThread::isMainOrTestThread()) {
+      IS_ENVOY_BUG("PortNetworkPolicyRules: Destructor executing in a worker thread, while "
+                   "only main thread should destruct xDS resources");
     }
+  }
+
+  void append(const NetworkPolicyMapImpl& parent,
+              const Protobuf::RepeatedPtrField<cilium::PortNetworkPolicyRule>& rules) {
     for (const auto& it : rules) {
       rules_.emplace_back(std::make_shared<PortNetworkPolicyRule>(parent, it));
       if (!rules_.back()->can_short_circuit_) {
@@ -658,12 +662,17 @@ public:
     }
   }
 
-  ~PortNetworkPolicyRules() {
-    if (!Thread::MainThread::isMainOrTestThread()) {
-      IS_ENVOY_BUG("PortNetworkPolicyRules: Destructor executing in a worker thread, while "
-                   "only main thread should destruct xDS resources");
+  void prepend(const NetworkPolicyMapImpl& parent,
+               const Protobuf::RepeatedPtrField<cilium::PortNetworkPolicyRule>& rules) {
+    for (const auto& it : rules) {
+      rules_.emplace(rules_.begin(), std::make_shared<PortNetworkPolicyRule>(parent, it));
+      if (!rules_.front()->can_short_circuit_) {
+        can_short_circuit_ = false;
+      }
     }
   }
+
+  bool empty() const { return rules_.empty(); }
 
   bool allowed(uint32_t proxy_id, uint32_t remote_id, Envoy::Http::RequestHeaderMap& headers,
                Cilium::AccessLog::Entry& log_entry, bool& denied) const {
@@ -807,26 +816,17 @@ public:
 };
 
 // end port is zero on lookup!
-PortPolicy::PortPolicy(const PolicyMap& map, const RulesList& wildcard_rules, uint16_t port)
-    : map_(map), wildcard_rules_(wildcard_rules), port_rules_(map_.find({port, port})),
-      has_http_rules_(hasHttpRules(map_, wildcard_rules_, port_rules_)) {}
-
-bool PortPolicy::hasHttpRules(const PolicyMap& map, const RulesList& wildcard_rules,
-                              const PolicyMap::const_iterator port_rules) {
-  if (port_rules != map.end()) {
-    for (auto& rules : port_rules->second) {
-      if (rules.hasHttpRules()) {
-        return true;
-      }
-    }
-  }
-  for (auto& rules : wildcard_rules) {
-    if (rules.hasHttpRules()) {
-      return true;
-    }
-  }
-  return false;
-}
+PortPolicy::PortPolicy(const PolicyMap& map, uint16_t port)
+    : map_(map), wildcard_rules_([&]() {
+        const auto it = map_.find({0, 0});
+        return it != map_.cend() ? &it->second : nullptr;
+      }()),
+      port_rules_([&]() {
+        const auto it = map_.find({port, port});
+        return it != map_.cend() ? &it->second : nullptr;
+      }()),
+      has_http_rules_((port_rules_ && port_rules_->hasHttpRules()) ||
+                      (wildcard_rules_ && wildcard_rules_->hasHttpRules())) {}
 
 // forRange is used for policy lookups, so it will need to check both port-specific and
 // wildcard-port rules, as either of them could contain rules that must be evaluated (i.e., deny
@@ -835,24 +835,14 @@ bool PortPolicy::forRange(
     std::function<bool(const PortNetworkPolicyRules&, bool& denied)> allowed) const {
   bool allow = false;
   bool denied = false;
-  if (port_rules_ != map_.cend()) {
-    for (auto& rules : port_rules_->second) {
-      // Skip if allowed
-      if (allow && rules.can_short_circuit_) {
-        continue;
-      }
-      if (allowed(rules, denied)) {
-        allow = true;
-      }
+  if (port_rules_) {
+    if (allowed(*port_rules_, denied)) {
+      allow = true;
     }
   }
   // Wildcard port can deny a specific remote, so need to check for it too.
-  for (auto& rules : wildcard_rules_) {
-    // Skip if allowed
-    if (allow && rules.can_short_circuit_) {
-      continue;
-    }
-    if (allowed(rules, denied)) {
+  if (!(allow && wildcard_rules_ && wildcard_rules_->can_short_circuit_)) {
+    if (wildcard_rules_ && allowed(*wildcard_rules_, denied)) {
       allow = true;
     }
   }
@@ -870,18 +860,12 @@ bool PortPolicy::forRange(
 // 3. Wildcard port rules
 //
 bool PortPolicy::forFirstRange(std::function<bool(const PortNetworkPolicyRules&)> f) const {
-  if (port_rules_ != map_.cend()) {
-    for (auto& rules : port_rules_->second) {
-      if (f(rules)) {
-        return true;
-      }
-    }
+  if (port_rules_ && f(*port_rules_)) {
+    return true;
   }
   // Check the wildcard port entry
-  for (auto& rules : wildcard_rules_) {
-    if (f(rules)) {
-      return true;
-    }
+  if (wildcard_rules_ && f(*wildcard_rules_)) {
+    return true;
   }
   return false;
 }
@@ -967,22 +951,22 @@ public:
           }
           end_port = port;
         }
+
         if (port == 0) {
           if (end_port > 0) {
             throw EnvoyException(fmt::format(
                 "PortNetworkPolicy: Invalid port range including the wildcard zero port {}-{}",
                 port, end_port));
           }
-          ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicy(): installing TCP wildcard policy");
-          wildcard_rules_.emplace_back(parent, rule.rules());
-          continue;
         }
+
         ENVOY_LOG(trace,
                   "Cilium L7 PortNetworkPolicy(): installing TCP policy for "
                   "port range {}-{}",
                   port, end_port);
+
         auto rule_range = std::make_pair(port, end_port);
-        auto pair = rules_.emplace(rule_range, RulesList{});
+        auto pair = rules_.emplace(rule_range, PortNetworkPolicyRules{});
         auto it = pair.first;
         if (!pair.second) {
           ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicy(): new entry [{}-{}] overlaps with [{}-{}]",
@@ -1043,7 +1027,7 @@ public:
             // create a new entry below the current one?
             if (port < range.first) {
               auto new_range = std::make_pair(port, std::min(end_port, uint16_t(range.first - 1)));
-              auto new_pair = rules_.emplace(new_range, RulesList{});
+              auto new_pair = rules_.emplace(new_range, PortNetworkPolicyRules{});
               RELEASE_ASSERT(new_pair.second,
                              "duplicate entry when explicitly adding a new range!");
               // update the start range if a new start entry was added, which can happen only at the
@@ -1086,7 +1070,7 @@ public:
           // create a new entry covering the end?
           if (port <= end_port) {
             auto new_range = std::make_pair(port, end_port);
-            auto new_pair = rules_.emplace(new_range, RulesList{});
+            auto new_pair = rules_.emplace(new_range, PortNetworkPolicyRules{});
             RELEASE_ASSERT(new_pair.second,
                            "duplicate entry at end when explicitly adding a new range!");
             it = ++new_pair.first;
@@ -1097,20 +1081,19 @@ public:
         }
         // Add rules to all the overlapping entries
         bool singular = rule_range.first == rule_range.second;
-        auto rules = PortNetworkPolicyRules(parent, rule.rules());
         for (; it != rules_.end() && rangesOverlap(it->first, rule_range); it++) {
           auto range = it->first;
-          auto& list = it->second;
+          auto& rules = it->second;
           ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicy(): Adding rules for [{}-{}] to [{}-{}]",
                     rule_range.first, rule_range.second, range.first, range.second);
           if (singular) {
             // Exact port rules go to the front of the list.
             // This gives precedence for trivial range rules for proxylib parser
             // and TLS context selection.
-            list.push_front(rules);
+            rules.prepend(parent, rule.rules());
           } else {
             // Rules with a non-trivial range go to the back of the list
-            list.push_back(rules);
+            rules.append(parent, rule.rules());
           }
         }
       } else {
@@ -1119,9 +1102,7 @@ public:
     }
   }
 
-  const PortPolicy findPortPolicy(uint16_t port) const {
-    return PortPolicy(rules_, wildcard_rules_, port);
-  }
+  const PortPolicy findPortPolicy(uint16_t port) const { return PortPolicy(rules_, port); }
 
   void toString(int indent, std::string& res) const {
     if (rules_.empty()) {
@@ -1131,23 +1112,12 @@ public:
       for (const auto& entry : rules_) {
         res.append(indent + 2, ' ')
             .append(fmt::format("[{}-{}]:\n", entry.first.first, entry.first.second));
-        for (const auto& rule : entry.second) {
-          rule.toString(indent + 4, res);
-        }
-      }
-    }
-    if (wildcard_rules_.empty()) {
-      res.append(indent, ' ').append("wildcard_rules: []\n");
-    } else {
-      res.append(indent, ' ').append("wildcard_rules:\n");
-      for (const auto& rule : wildcard_rules_) {
-        rule.toString(indent + 2, res);
+        entry.second.toString(indent + 4, res);
       }
     }
   }
 
   PolicyMap rules_;
-  RulesList wildcard_rules_{};
   bool has_http_rules_ = false;
 };
 
@@ -1497,9 +1467,7 @@ NetworkPolicyMap::dumpNetworkPolicyConfigs(const Matchers::StringMatcher& name_m
 class AllowAllEgressPolicyInstanceImpl : public PolicyInstance {
 public:
   AllowAllEgressPolicyInstanceImpl() {
-    auto& list =
-        empty_map_.emplace(std::make_pair(uint16_t(1), uint16_t(1)), RulesList{}).first->second;
-    list.emplace_front(PortNetworkPolicyRules());
+    empty_map_.emplace(std::make_pair(uint16_t(1), uint16_t(1)), PortNetworkPolicyRules{});
   }
 
   bool allowed(bool ingress, uint32_t, uint32_t, uint16_t, Envoy::Http::RequestHeaderMap&,
@@ -1512,8 +1480,7 @@ public:
   }
 
   const PortPolicy findPortPolicy(bool ingress, uint16_t) const override {
-    return ingress ? PortPolicy(empty_map_, empty_rules_, 0)
-                   : PortPolicy(empty_map_, empty_rules_, 1);
+    return ingress ? PortPolicy(empty_map_, 0) : PortPolicy(empty_map_, 1);
   }
 
   bool useProxylib(bool, uint32_t, uint32_t, uint16_t, std::string&) const override {
@@ -1534,11 +1501,9 @@ private:
   PolicyMap empty_map_;
   static const std::string empty_string;
   static const IpAddressPair empty_ips;
-  static const RulesList empty_rules_;
 };
 const std::string AllowAllEgressPolicyInstanceImpl::empty_string = "";
 const IpAddressPair AllowAllEgressPolicyInstanceImpl::empty_ips{};
-const RulesList AllowAllEgressPolicyInstanceImpl::empty_rules_{};
 
 AllowAllEgressPolicyInstanceImpl NetworkPolicyMap::AllowAllEgressPolicy;
 
@@ -1559,7 +1524,7 @@ public:
   }
 
   const PortPolicy findPortPolicy(bool, uint16_t) const override {
-    return PortPolicy(empty_map_, empty_rules, 0);
+    return PortPolicy(empty_map_, 0);
   }
 
   bool useProxylib(bool, uint32_t, uint32_t, uint16_t, std::string&) const override {
@@ -1580,11 +1545,9 @@ private:
   PolicyMap empty_map_;
   static const std::string empty_string;
   static const IpAddressPair empty_ips;
-  static const RulesList empty_rules;
 };
 const std::string DenyAllPolicyInstanceImpl::empty_string = "";
 const IpAddressPair DenyAllPolicyInstanceImpl::empty_ips{};
-const RulesList DenyAllPolicyInstanceImpl::empty_rules{};
 
 DenyAllPolicyInstanceImpl NetworkPolicyMap::DenyAllPolicy;
 

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -4,7 +4,6 @@
 #include <openssl/mem.h>
 
 #include <algorithm>
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -376,12 +375,6 @@ public:
     // rules must be evaluated even if one would allow
     can_short_circuit_ = !deny_;
     for (const auto& remote : rule.remote_policies()) {
-      ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicyRule(): {} remote {} by rule: {}",
-                deny_ ? "Denying" : "Allowing", remote, name_);
-      remotes_.emplace(remote);
-    }
-    // TODO: Remove deprecated_remote_policies_64 when Cilium 1.14 is no longer supported
-    for (const auto& remote : rule.deprecated_remote_policies_64()) {
       ENVOY_LOG(trace, "Cilium L7 PortNetworkPolicyRule(): {} remote {} by rule: {}",
                 deny_ ? "Denying" : "Allowing", remote, name_);
       remotes_.emplace(remote);

--- a/go/cilium/api/npds.pb.go
+++ b/go/cilium/api/npds.pb.go
@@ -426,6 +426,9 @@ func (x *TLSContext) GetAlpnProtocols() []string {
 // rule.
 type PortNetworkPolicyRule struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
+	// Precedence level for this rule. Rules with **higher** numeric values take
+	// precedence, even over deny rules of lower precedence level.
+	Precedence uint32 `protobuf:"varint,10,opt,name=precedence,proto3" json:"precedence,omitempty"`
 	// Traffic on this port is denied for all `remote_policies` if true
 	Deny bool `protobuf:"varint,8,opt,name=deny,proto3" json:"deny,omitempty"`
 	// ProxyID is non-zero if the rule was an allow rule with an explicit listener reference.
@@ -493,6 +496,13 @@ func (x *PortNetworkPolicyRule) ProtoReflect() protoreflect.Message {
 // Deprecated: Use PortNetworkPolicyRule.ProtoReflect.Descriptor instead.
 func (*PortNetworkPolicyRule) Descriptor() ([]byte, []int) {
 	return file_cilium_api_npds_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *PortNetworkPolicyRule) GetPrecedence() uint32 {
+	if x != nil {
+		return x.Precedence
+	}
+	return 0
 }
 
 func (x *PortNetworkPolicyRule) GetDeny() bool {
@@ -1153,8 +1163,12 @@ const file_cilium_api_npds_proto_rawDesc = "" +
 	"\fserver_names\x18\x04 \x03(\tR\vserverNames\x12A\n" +
 	"\x1dvalidation_context_sds_secret\x18\x05 \x01(\tR\x1avalidationContextSdsSecret\x12$\n" +
 	"\x0etls_sds_secret\x18\x06 \x01(\tR\ftlsSdsSecret\x12%\n" +
-	"\x0ealpn_protocols\x18\a \x03(\tR\ralpnProtocols\"\x9d\x04\n" +
-	"\x15PortNetworkPolicyRule\x12\x12\n" +
+	"\x0ealpn_protocols\x18\a \x03(\tR\ralpnProtocols\"\xbd\x04\n" +
+	"\x15PortNetworkPolicyRule\x12\x1e\n" +
+	"\n" +
+	"precedence\x18\n" +
+	" \x01(\rR\n" +
+	"precedence\x12\x12\n" +
 	"\x04deny\x18\b \x01(\bR\x04deny\x12\x19\n" +
 	"\bproxy_id\x18\t \x01(\rR\aproxyId\x12\x12\n" +
 	"\x04name\x18\x05 \x01(\tR\x04name\x12'\n" +

--- a/go/cilium/api/npds.pb.go
+++ b/go/cilium/api/npds.pb.go
@@ -439,10 +439,7 @@ type PortNetworkPolicyRule struct {
 	// A flow is matched by this predicate if the identifier of the policy
 	// applied on the flow's remote host is contained in this set.
 	// Optional. If not specified, any remote host is matched by this predicate.
-	// This field is deprecated, use remote_policies instead.
-	// TODO: Remove when Cilium 1.14 no longer supported.
-	DeprecatedRemotePolicies_64 []uint64 `protobuf:"varint,1,rep,packed,name=deprecated_remote_policies_64,json=deprecatedRemotePolicies64,proto3" json:"deprecated_remote_policies_64,omitempty"`
-	RemotePolicies              []uint32 `protobuf:"varint,7,rep,packed,name=remote_policies,json=remotePolicies,proto3" json:"remote_policies,omitempty"`
+	RemotePolicies []uint32 `protobuf:"varint,7,rep,packed,name=remote_policies,json=remotePolicies,proto3" json:"remote_policies,omitempty"`
 	// Optional downstream TLS context. If present, the incoming connection must
 	// be a TLS connection.
 	DownstreamTlsContext *TLSContext `protobuf:"bytes,3,opt,name=downstream_tls_context,json=downstreamTlsContext,proto3" json:"downstream_tls_context,omitempty"`
@@ -517,13 +514,6 @@ func (x *PortNetworkPolicyRule) GetName() string {
 		return x.Name
 	}
 	return ""
-}
-
-func (x *PortNetworkPolicyRule) GetDeprecatedRemotePolicies_64() []uint64 {
-	if x != nil {
-		return x.DeprecatedRemotePolicies_64
-	}
-	return nil
 }
 
 func (x *PortNetworkPolicyRule) GetRemotePolicies() []uint32 {
@@ -1163,12 +1153,11 @@ const file_cilium_api_npds_proto_rawDesc = "" +
 	"\fserver_names\x18\x04 \x03(\tR\vserverNames\x12A\n" +
 	"\x1dvalidation_context_sds_secret\x18\x05 \x01(\tR\x1avalidationContextSdsSecret\x12$\n" +
 	"\x0etls_sds_secret\x18\x06 \x01(\tR\ftlsSdsSecret\x12%\n" +
-	"\x0ealpn_protocols\x18\a \x03(\tR\ralpnProtocols\"\xda\x04\n" +
+	"\x0ealpn_protocols\x18\a \x03(\tR\ralpnProtocols\"\x9d\x04\n" +
 	"\x15PortNetworkPolicyRule\x12\x12\n" +
 	"\x04deny\x18\b \x01(\bR\x04deny\x12\x19\n" +
 	"\bproxy_id\x18\t \x01(\rR\aproxyId\x12\x12\n" +
-	"\x04name\x18\x05 \x01(\tR\x04name\x12A\n" +
-	"\x1ddeprecated_remote_policies_64\x18\x01 \x03(\x04R\x1adeprecatedRemotePolicies64\x12'\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\x12'\n" +
 	"\x0fremote_policies\x18\a \x03(\rR\x0eremotePolicies\x12H\n" +
 	"\x16downstream_tls_context\x18\x03 \x01(\v2\x12.cilium.TLSContextR\x14downstreamTlsContext\x12D\n" +
 	"\x14upstream_tls_context\x18\x04 \x01(\v2\x12.cilium.TLSContextR\x12upstreamTlsContext\x12!\n" +
@@ -1179,7 +1168,7 @@ const file_cilium_api_npds_proto_rawDesc = "" +
 	"\vkafka_rules\x18e \x01(\v2\x1f.cilium.KafkaNetworkPolicyRulesH\x00R\n" +
 	"kafkaRules\x129\n" +
 	"\bl7_rules\x18f \x01(\v2\x1c.cilium.L7NetworkPolicyRulesH\x00R\al7RulesB\x04\n" +
-	"\x02l7\"`\n" +
+	"\x02l7J\x04\b\x01\x10\x02\"`\n" +
 	"\x16HttpNetworkPolicyRules\x12F\n" +
 	"\n" +
 	"http_rules\x18\x01 \x03(\v2\x1d.cilium.HttpNetworkPolicyRuleB\b\xfaB\x05\x92\x01\x02\b\x01R\thttpRules\"\xd2\x03\n" +

--- a/go/cilium/api/npds.pb.validate.go
+++ b/go/cilium/api/npds.pb.validate.go
@@ -529,6 +529,8 @@ func (m *PortNetworkPolicyRule) validate(all bool) error {
 
 	var errors []error
 
+	// no validation rules for Precedence
+
 	// no validation rules for Deny
 
 	// no validation rules for ProxyId

--- a/proxylib/proxylib/policymap.go
+++ b/proxylib/proxylib/policymap.go
@@ -59,11 +59,6 @@ func newPortNetworkPolicyRule(config *cilium.PortNetworkPolicyRule) (PortNetwork
 		logrus.Debugf("NPDS::PortNetworkPolicyRule: %s remote %d", action, remote)
 		rule.Remotes[remote] = struct{}{}
 	}
-	// TODO: Remove when Cilium 1.14 is no longer supported:
-	for _, remote := range config.GetDeprecatedRemotePolicies_64() {
-		logrus.Debugf("NPDS::PortNetworkPolicyRule: %s remote %d", action, remote)
-		rule.Remotes[uint32(remote)] = struct{}{}
-	}
 
 	// Each parser registers a parsing function to parse it's L7 rules
 	// The registered name must match 'l7_proto', if included in the message,

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -277,10 +277,8 @@ resources:
     [92-92]:
     - rules:
       - remotes: []
-        can_short_circuit: false
         deny: true
       - remotes: [43]
-      can_short_circuit: false
     [93-99]:
     - rules:
       - remotes: [43]
@@ -843,21 +841,17 @@ resources:
   rules:
     [80-80]:
     - rules:
+      - remotes: []
+        deny: true
       - remotes: [43]
         http_rules:
         - headers:
           - name: ":path"
             value: "/allowed"
-      - remotes: []
-        can_short_circuit: false
-        deny: true
-      can_short_circuit: false
     [81-10000]:
     - rules:
       - remotes: []
-        can_short_circuit: false
         deny: true
-      can_short_circuit: false
 egress:
   rules:
     [80-80]:

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -262,15 +262,14 @@ resources:
   rules:
     [23-23]:
     - rules:
-      - remotes: [42]
       - remotes: [45]
+      - remotes: [42]
     [40-79]:
     - rules:
       - remotes: [43]
     [80-80]:
     - rules:
       - remotes: [44]
-    - rules:
       - remotes: [43]
     [81-91]:
     - rules:
@@ -280,16 +279,13 @@ resources:
       - remotes: []
         can_short_circuit: false
         deny: true
-      can_short_circuit: false
-    - rules:
       - remotes: [43]
+      can_short_circuit: false
     [93-99]:
     - rules:
       - remotes: [43]
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -411,15 +407,12 @@ resources:
     [4040-8080]:
     - rules:
       - remotes: [43]
-    - rules:
       - remotes: [44]
     [8081-9999]:
     - rules:
       - remotes: [44]
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -469,15 +462,12 @@ resources:
     [4040-8080]:
     - rules:
       - remotes: [44]
-    - rules:
       - remotes: [43]
     [8081-9999]:
     - rules:
       - remotes: [44]
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -522,12 +512,9 @@ resources:
     [80-80]:
     - rules:
       - remotes: [43]
-    - rules:
       - remotes: [43]
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -563,15 +550,12 @@ resources:
     [80-80]:
     - rules:
       - remotes: [43]
-    - rules:
       - remotes: [43]
     [81-8080]:
     - rules:
       - remotes: [43]
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -672,10 +656,8 @@ resources:
     [4040-9999]:
     - rules:
       - remotes: [43]
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -731,10 +713,8 @@ resources:
         - headers:
           - name: ":path"
             value: "/allowed"
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -791,7 +771,6 @@ resources:
         - headers:
           - name: ":path"
             value: "/allowed"
-  wildcard_rules: []
 egress:
   rules:
     [80-80]:
@@ -801,7 +780,6 @@ egress:
         - headers:
           - name: ":path"
             regex: <hidden>
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -870,7 +848,6 @@ resources:
         - headers:
           - name: ":path"
             value: "/allowed"
-    - rules:
       - remotes: []
         can_short_circuit: false
         deny: true
@@ -881,7 +858,6 @@ resources:
         can_short_circuit: false
         deny: true
       can_short_circuit: false
-  wildcard_rules: []
 egress:
   rules:
     [80-80]:
@@ -891,7 +867,6 @@ egress:
         - headers:
           - name: ":path"
             regex: <hidden>
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -960,14 +935,12 @@ resources:
         - headers:
           - name: ":path"
             value: "/allowed"
-    - rules:
       - remotes: []
         proxy_id: 42
     [81-10000]:
     - rules:
       - remotes: []
         proxy_id: 42
-  wildcard_rules: []
 egress:
   rules:
     [80-80]:
@@ -977,7 +950,6 @@ egress:
         - headers:
           - name: ":path"
             regex: <hidden>
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -1040,14 +1012,12 @@ resources:
         - headers:
           - name: ":path"
             value: "/allowed"
-    - rules:
       - remotes: []
         proxy_id: 99
     [81-10000]:
     - rules:
       - remotes: []
         proxy_id: 99
-  wildcard_rules: []
 egress:
   rules:
     [80-80]:
@@ -1057,7 +1027,6 @@ egress:
         - headers:
           - name: ":path"
             regex: <hidden>
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -1123,16 +1092,13 @@ resources:
         - headers:
           - name: ":method"
             value: "GET"
-    - rules:
       - remotes: [43]
         http_rules:
         - headers:
           - name: ":path"
             value: "/allowed"
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -1195,7 +1161,6 @@ resources:
         - headers:
           - name: ":method"
             value: "GET"
-    - rules:
       - remotes: [43]
         http_rules:
         - headers:
@@ -1208,10 +1173,8 @@ resources:
         - headers:
           - name: ":path"
             value: "/allowed"
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -1282,7 +1245,6 @@ resources:
         - headers:
           - name: ":path"
             value: "/allowed"
-    - rules:
       - remotes: [43]
         http_rules:
         - headers:
@@ -1295,10 +1257,8 @@ resources:
         - headers:
           - name: ":method"
             value: "GET"
-  wildcard_rules: []
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));
@@ -1913,12 +1873,11 @@ resources:
 )EOF"));
 
   std::string expected = R"EOF(ingress:
-  rules: []
-  wildcard_rules:
-  - rules:
+  rules:
+    [0-0]:
+    - rules:
 egress:
   rules: []
-  wildcard_rules: []
 )EOF";
 
   EXPECT_TRUE(validate("10.1.2.3", expected));

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -1902,6 +1902,46 @@ resources:
   EXPECT_FALSE(raw_socket_allowed);
 }
 
+TEST_F(CiliumNetworkPolicyTest, EmptyRulesAllow) {
+  EXPECT_NO_THROW(updateFromYaml(R"EOF(version_info: "1"
+resources:
+- "@type": type.googleapis.com/cilium.NetworkPolicy
+  endpoint_ips:
+  - "10.1.2.3"
+  endpoint_id: 42
+  ingress_per_port_policies: [{}]
+)EOF"));
+
+  std::string expected = R"EOF(ingress:
+  rules: []
+  wildcard_rules:
+  - rules:
+egress:
+  rules: []
+  wildcard_rules: []
+)EOF";
+
+  EXPECT_TRUE(validate("10.1.2.3", expected));
+
+  // Ingress from 43 is denied to ports 80-4039, but allowed on ports 4040-9999:
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 79));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 80));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 81));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 4039));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 4040));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 4041));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 8079));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 8080));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 8081));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 9998));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 9999));
+  EXPECT_TRUE(ingressAllowed("10.1.2.3", 43, 10000));
+
+  // No egress is allowed:
+  EXPECT_FALSE(egressAllowed("10.1.2.3", 43, 8080));
+  EXPECT_FALSE(egressAllowed("10.1.2.3", 44, 8080));
+}
+
 TEST_F(CiliumNetworkPolicyTest, SNIPatternMatching) {
   // Test empty pattern
   SniPattern empty("");


### PR DESCRIPTION
Add new 'precedence' field.

Fix handling of deny rules when looking to TLS context and proxylib reference.

Storage of rules for any given port range is flattened to a single sorted vector, which makes dealing with deny rules and precedence field much more straightforward. This restructuring is visible in the policy debug formatting.