### PR TITLE
update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -17,7 +17,7 @@ jobs:
   build-and-push-prs:
     timeout-minutes: 360
     name: Build and push multi-arch images
-    runs-on: ubuntu-latest-64-cores-256gb
+    runs-on: oracle-vm-32cpu-128gb-x86-64
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     steps:

--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -18,7 +18,7 @@ jobs:
   test-cache-refresh:
     timeout-minutes: 360
     name: Build test cache and push images
-    runs-on: ubuntu-latest-64-cores-256gb
+    runs-on: oracle-vm-32cpu-128gb-x86-64
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -117,7 +117,7 @@ jobs:
   build-cache-and-push-images:
     timeout-minutes: 360
     name: Build cache and push images
-    runs-on: ubuntu-latest-64-cores-256gb
+    runs-on: oracle-vm-32cpu-128gb-x86-64
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/ci-clang-tidy.yaml
+++ b/.github/workflows/ci-clang-tidy.yaml
@@ -16,7 +16,7 @@ jobs:
   tidy:
     timeout-minutes: 60
     name: Lint source style
-    runs-on: ubuntu-latest-64-cores-256gb
+    runs-on: oracle-vm-32cpu-128gb-x86-64
     steps:
       - name: Checkout PR Source Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -39,7 +39,7 @@ jobs:
   tests:
     timeout-minutes: 360
     name: Run integration tests on amd64
-    runs-on: ubuntu-latest-64-cores-256gb
+    runs-on: oracle-vm-32cpu-128gb-x86-64
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
             language: 'actions'
           - runner: ubuntu-24.04
             language: 'go'
-          - runner: ubuntu-latest-64-cores-256gb
+          - runner: oracle-vm-32cpu-128gb-x86-64
             language: 'cpp'
     steps:
       - name: Checkout repository


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. You can also join `#cncf-ci-infra` channel on CNCF Slack.

> [!NOTE]
Oracle Cloud has a feature called OCPU, which comes with 2 VCPUs by default. The VM `oracle-vm-32cpu-128gb-x86-64` we provide has effectively 64 cores, so the number of CPUs is the same (but the memory is half of what you use at the moment)