### PR TITLE
network_filter: don't propagate SNI in case of L7LB

### DIFF
--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -185,7 +185,10 @@ Network::FilterStatus Instance::onNewConnection() {
 
   // Pass metadata from tls_inspector to the filterstate, if any & not already
   // set via upstream cluster config.
-  if (!sni.empty()) {
+  // Only do this in non-L7LB case where the proxy intercepts the traffic for policy enforcement.
+  if (!policy_fs->is_l7lb_ && !sni.empty()) {
+    ENVOY_CONN_LOG(trace, "cilium.network: Passing SNI {} to upstream connection", conn, sni);
+
     auto filter_state = conn.streamInfo().filterState();
     auto have_sni =
         filter_state->hasData<Network::UpstreamServerName>(Network::UpstreamServerName::key());


### PR DESCRIPTION
Historically, SNI was always propagated from downstream to upstream
in case of E/W Cilium policy enforcement.

But this should not be done in case of L7 loadbalancing, where the
upstream connection might have a completely different TLS configuration
where this SNI propagation (and validation) could potentially break
the upstream TLS handshake.

Therefore, this commit modifies the condition to only perform the
propagation if it's not L7LB.

Signed-off-by: Marco Hofstetter <marco.hofstetter@isovalent.com>
