### PR TITLE
build: fix clang-tidy

### DIFF
--- a/cilium/network_filter.cc
+++ b/cilium/network_filter.cc
@@ -24,6 +24,7 @@
 #include "source/common/protobuf/utility.h"
 
 #include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "cilium/accesslog.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/api/network_filter.pb.h"


### PR DESCRIPTION
Currenty the clang-tidy check fails with the following error due to
a missing direct include.

```
cilium/network_filter.cc:99:43: error: no header providing "absl::string_view" is directly included [misc-include-cleaner,-warnings-as-errors]
                                     absl::string_view sni, StreamInfo::StreamInfo& stream_info) {
```

This commit fixes this by adding the missing include.

e.g. https://github.com/cilium/proxy/actions/runs/16365883373/job/46242872159?pr=1459

Signed-off-by: Marco Hofstetter <marco.hofstetter@isovalent.com>
