### PR TITLE
gha: Add login step for quay.io

### DIFF
--- a/.github/workflows/build-envoy-images-release.yaml
+++ b/.github/workflows/build-envoy-images-release.yaml
@@ -85,6 +85,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Login to quay.io
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ENVOY_USERNAME }}
+          password: ${{ secrets.QUAY_ENVOY_PASSWORD }}
+
       - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Prep for build


### PR DESCRIPTION
Fixes: b2011b733cac83caa6be869abd9ca61f37aaeaa2

--- 

The below failure was in main

```
Error: buildx failed with: ERROR: failed to build: failed to solve: failed to push quay.io/cilium/cilium-envoy-builder:main-archive-latest: unauthorized: access to the requested resource is not authorized
```