### PR TITLE
gha: Fix build error due to clang-libc++

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,13 +50,13 @@ jobs:
         run: |
           bazel/setup_clang.sh bin/clang17
           bazelisk shutdown
-          bazel build \
+          CARGO_BAZEL_REPIN=true bazel build \
           -c fastbuild \
           --spawn_strategy=local \
           --discard_analysis_cache \
           --nouse_action_cache \
           --features="-layering_check" \
-          --config=clang-libc++ \
+          --config=clang \
           --config=ci \
           cilium-envoy
 


### PR DESCRIPTION
As per the below release note, Envoy 1.35 no longer has the build config clang-libc++. This commit is to fix the build process in codeql workflow

```
Consolidated clang/gcc toolchains using --config=clang or --config=gcc.
```

Relates: https://github.com/envoyproxy/envoy/releases/tag/v1.35.0