### PR TITLE
renovate: Correct package name in Go group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,14 +45,14 @@
       matchDepNames: [
         'go',
         'docker.io/library/golang',
-        '.github/workflows/**'
+        'actions/setup-go'
       ],
     },
     {
       matchPackageNames: [
         'docker.io/library/golang',
         'go',
-        '.github/workflows/**'
+        'actions/setup-go'
       ],
       allowedVersions: '<1.25',
       matchBaseBranches: [

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         # renovate: datasource=golang-version depName=go
-        go-version: 1.24.7
+        go-version: 1.25.1
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:

--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           # renovate: datasource=golang-version depName=go
-          go-version: 1.24.7
+          go-version: 1.25.1
 
       - name: Redirect proxy module
         shell: bash


### PR DESCRIPTION
The goal is to have go upgrade done in one simple PR instead of 2 separate PRs as per below example.

- github action https://github.com/cilium/proxy/pull/1568
- others https://github.com/cilium/proxy/pull/1569

Fixes: 93d0d64e780465efe778011a9686ec578ce56e51