### PR TITLE
ci: Add backendtlspolices crd

### DIFF
--- a/.github/workflows/cilium-gateway-api.yaml
+++ b/.github/workflows/cilium-gateway-api.yaml
@@ -88,6 +88,7 @@ jobs:
           kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
           kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
           kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+          kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
           ## TLSRoute is only available in experimental channel in v0.7.0
           kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
 


### PR DESCRIPTION
This is to fix the below issue in main branch

```
2026-01-28T05:22:59.165874739Z time=2026-01-28T05:22:59.165765929Z level=fatal source=/go/src/github.com/cilium/cilium/pkg/logging/slog.go:159 msg="failed to start: failed to populate object graph: failed to create gateway controller: failed to setup reconciler: failed to setup field indexer \"backendTLSPolicyConfigMaps\": no matches for kind \"BackendTLSPolicy\" in version \"gateway.networking.k8s.io/v1\""
```

Relates: https://github.com/cilium/cilium/pull/43045