### PR TITLE
ci: Use cilium 1.17 for Gateway API test

### DIFF
--- a/.github/workflows/cilium-gateway-api.yaml
+++ b/.github/workflows/cilium-gateway-api.yaml
@@ -27,7 +27,7 @@ env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION: v0.31.0
   CILIUM_REPO_OWNER: cilium
-  CILIUM_REPO_REF: main
+  CILIUM_REPO_REF: v1.17
   CILIUM_CLI_REF: latest
   CURL_PARALLEL: ${{ vars.CURL_PARALLEL || 10 }}
 


### PR DESCRIPTION
Using Cilium 1.17 for Gateway API test as it is the oldest stable release with 1.35.

Relates: https://github.com/cilium/cilium/pull/43988