### PR TITLE
policy: Enhance validating regualar expressions

### DIFF
--- a/cilium/api/npds.proto
+++ b/cilium/api/npds.proto
@@ -162,8 +162,26 @@ message PortNetworkPolicyRule {
 
   // Optional allowed SNIs in TLS handshake.
   // The validation pattern here is synced with the corresponding k8s type in cilium/cilium.
-  repeated string server_names = 6
-      [(validate.rules).repeated = {items: {string: {pattern: "^([-a-zA-Z0-9_*]+[.]?)+$"}}}];
+  // The validation pattern consists of one or more dot-delimited subdomains, where each
+  // subdomain can be:
+  // - '*',
+  // - '**', or
+  // - a pattern of one or more valid DNS name characters, optionally including non-consecutive
+  //   wildcard specifiers ('*')
+  //
+  // The pattern consists of repeating parts:
+  // <DNSCHARS> = "[-a-zA-Z0-9_]"
+  // <SUBDOMAIN> = "[*]?<DNSCHARS>+([*]<DNSCHARS>+)*[*]?"
+  // <SUBPATTERN> = "([*]{1,2}|<SUBDOMAIN>)"
+  // PATTERN = "^(<SUBPATTERN>[.])*<SUBPATTERN>$"
+  repeated string server_names = 6 [(validate.rules).repeated = {
+    items: {
+      string: {
+        pattern: "^(([*]{1,2}|[*]?[-a-zA-Z0-9_]+([*][-a-zA-Z0-9_]+)*[*]?)[.])*"
+                 "([*]{1,2}|[*]?[-a-zA-Z0-9_]+([*][-a-zA-Z0-9_]+)*[*]?)$"
+      }
+    }
+  }];
 
   // Optional L7 protocol parser name. This is only used if the parser is not
   // one of the well knows ones. If specified, the l7 parser having this name

--- a/go/cilium/api/npds.pb.go
+++ b/go/cilium/api/npds.pb.go
@@ -452,6 +452,18 @@ type PortNetworkPolicyRule struct {
 	UpstreamTlsContext *TLSContext `protobuf:"bytes,4,opt,name=upstream_tls_context,json=upstreamTlsContext,proto3" json:"upstream_tls_context,omitempty"`
 	// Optional allowed SNIs in TLS handshake.
 	// The validation pattern here is synced with the corresponding k8s type in cilium/cilium.
+	// The validation pattern consists of one or more dot-delimited subdomains, where each
+	// subdomain can be:
+	//   - '*',
+	//   - '**', or
+	//   - a pattern of one or more valid DNS name characters, optionally including non-consecutive
+	//     wildcard specifiers ('*')
+	//
+	// The pattern consists of repeating parts:
+	// <DNSCHARS> = "[-a-zA-Z0-9_]"
+	// <SUBDOMAIN> = "[*]?<DNSCHARS>+([*]<DNSCHARS>+)*[*]?"
+	// <SUBPATTERN> = "([*]{1,2}|<SUBDOMAIN>)"
+	// PATTERN = "^(<SUBPATTERN>[.])*<SUBPATTERN>$"
 	ServerNames []string `protobuf:"bytes,6,rep,name=server_names,json=serverNames,proto3" json:"server_names,omitempty"`
 	// Optional L7 protocol parser name. This is only used if the parser is not
 	// one of the well knows ones. If specified, the l7 parser having this name
@@ -1165,7 +1177,7 @@ const file_cilium_api_npds_proto_rawDesc = "" +
 	"\fserver_names\x18\x04 \x03(\tR\vserverNames\x12A\n" +
 	"\x1dvalidation_context_sds_secret\x18\x05 \x01(\tR\x1avalidationContextSdsSecret\x12$\n" +
 	"\x0etls_sds_secret\x18\x06 \x01(\tR\ftlsSdsSecret\x12%\n" +
-	"\x0ealpn_protocols\x18\a \x03(\tR\ralpnProtocols\"\xe3\x04\n" +
+	"\x0ealpn_protocols\x18\a \x03(\tR\ralpnProtocols\"\xbe\x05\n" +
 	"\x15PortNetworkPolicyRule\x12\x1e\n" +
 	"\n" +
 	"precedence\x18\n" +
@@ -1176,8 +1188,8 @@ const file_cilium_api_npds_proto_rawDesc = "" +
 	"\x04name\x18\x05 \x01(\tR\x04name\x12'\n" +
 	"\x0fremote_policies\x18\a \x03(\rR\x0eremotePolicies\x12H\n" +
 	"\x16downstream_tls_context\x18\x03 \x01(\v2\x12.cilium.TLSContextR\x14downstreamTlsContext\x12D\n" +
-	"\x14upstream_tls_context\x18\x04 \x01(\v2\x12.cilium.TLSContextR\x12upstreamTlsContext\x12G\n" +
-	"\fserver_names\x18\x06 \x03(\tB$\xfaB!\x92\x01\x1e\"\x1cr\x1a2\x18^([-a-zA-Z0-9_*]+[.]?)+$R\vserverNames\x12\x19\n" +
+	"\x14upstream_tls_context\x18\x04 \x01(\v2\x12.cilium.TLSContextR\x12upstreamTlsContext\x12\xa1\x01\n" +
+	"\fserver_names\x18\x06 \x03(\tB~\xfaB{\x92\x01x\"vrt2r^(([*]{1,2}|[*]?[-a-zA-Z0-9_]+([*][-a-zA-Z0-9_]+)*[*]?)[.])*([*]{1,2}|[*]?[-a-zA-Z0-9_]+([*][-a-zA-Z0-9_]+)*[*]?)$R\vserverNames\x12\x19\n" +
 	"\bl7_proto\x18\x02 \x01(\tR\al7Proto\x12?\n" +
 	"\n" +
 	"http_rules\x18d \x01(\v2\x1e.cilium.HttpNetworkPolicyRulesH\x00R\thttpRules\x12B\n" +

--- a/go/cilium/api/npds.pb.validate.go
+++ b/go/cilium/api/npds.pb.validate.go
@@ -601,7 +601,7 @@ func (m *PortNetworkPolicyRule) validate(all bool) error {
 		if !_PortNetworkPolicyRule_ServerNames_Pattern.MatchString(item) {
 			err := PortNetworkPolicyRuleValidationError{
 				field:  fmt.Sprintf("ServerNames[%v]", idx),
-				reason: "value does not match regex pattern \"^([-a-zA-Z0-9_*]+[.]?)+$\"",
+				reason: "value does not match regex pattern \"^(([*]{1,2}|[*]?[-a-zA-Z0-9_]+([*][-a-zA-Z0-9_]+)*[*]?)[.])*([*]{1,2}|[*]?[-a-zA-Z0-9_]+([*][-a-zA-Z0-9_]+)*[*]?)$\"",
 			}
 			if !all {
 				return err
@@ -821,7 +821,7 @@ var _ interface {
 	ErrorName() string
 } = PortNetworkPolicyRuleValidationError{}
 
-var _PortNetworkPolicyRule_ServerNames_Pattern = regexp.MustCompile("^([-a-zA-Z0-9_*]+[.]?)+$")
+var _PortNetworkPolicyRule_ServerNames_Pattern = regexp.MustCompile("^(([*]{1,2}|[*]?[-a-zA-Z0-9_]+([*][-a-zA-Z0-9_]+)*[*]?)[.])*([*]{1,2}|[*]?[-a-zA-Z0-9_]+([*][-a-zA-Z0-9_]+)*[*]?)$")
 
 // Validate checks the field values on HttpNetworkPolicyRules with the rules
 // defined in the proto definition for this message. If any rules are

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -1902,6 +1902,7 @@ TEST_F(CiliumNetworkPolicyTest, SNIPatternMatching) {
   EXPECT_THROW_WITH_REGEX(SniPattern(engine, "***"), EnvoyException, exception_msg_regex)
   EXPECT_THROW_WITH_REGEX(SniPattern(engine, "example.***.com"), EnvoyException,
                           exception_msg_regex)
+  EXPECT_THROW_WITH_REGEX(SniPattern(engine, "example.c**"), EnvoyException, exception_msg_regex)
   EXPECT_THROW_WITH_REGEX(SniPattern(engine, "example.com."), EnvoyException, exception_msg_regex)
   EXPECT_THROW_WITH_REGEX(SniPattern(engine, "example..com"), EnvoyException, exception_msg_regex)
   EXPECT_THROW_WITH_REGEX(SniPattern(engine, "^example.com$"), EnvoyException, exception_msg_regex)
@@ -2017,6 +2018,16 @@ TEST_F(CiliumNetworkPolicyTest, SNIPatternMatching) {
   EXPECT_FALSE(all_wildcard_labels.matches("test.sub.example.com"));
   EXPECT_FALSE(all_wildcard_labels.matches("sub.test.example.com"));
   EXPECT_FALSE(all_wildcard_labels.matches(""));
+
+  // Multiple wildcard labels with multilevel subdomain prefix wildcard.
+  SniPattern multi_wildcard_label(engine, "sub.*exa*.com");
+  EXPECT_TRUE(multi_wildcard_label.matches("sub.example.com"));
+  EXPECT_TRUE(multi_wildcard_label.matches("sub.examples.com"));
+  EXPECT_TRUE(multi_wildcard_label.matches("sub.exa.com"));
+  EXPECT_FALSE(multi_wildcard_label.matches("sub.foobar.com"));
+  EXPECT_FALSE(multi_wildcard_label.matches("test.sub.example.com"));
+  EXPECT_FALSE(multi_wildcard_label.matches("sub.test.example.com"));
+  EXPECT_FALSE(multi_wildcard_label.matches(""));
 }
 
 TEST_F(CiliumNetworkPolicyTest, OrderedRules) {


### PR DESCRIPTION
Use validating regular expression that does not allow consecutive wildcard specifiers (`*`), except for two (`**`) as multiple subdomain wildcard specifier that does not combine with any specific characters. Add test to make sure patterns where multiple subdomain wildcard pattern is not delineated with the domain separator (`.`) fail validation.

Protobuf validation pattern is the same except for the explicit anchoring that is needed for protoc-gen-validate, but not for the `isValid()` that uses `RE2::FullMatch()`. PGV pattern does not allow for empty strings, while in `isValid()` we explicitly allow empty patterns for testing purposes.