### PR TITLE
GH: Fix ci-check-format workflow

### DIFF
--- a/.github/workflows/ci-check-format.yaml
+++ b/.github/workflows/ci-check-format.yaml
@@ -68,7 +68,6 @@ jobs:
       - name: Checkout PR Source Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           fetch-depth: 2
 
@@ -77,7 +76,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
           echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
           # git diff filter has everything else than deleted files (those need not be tidied)
-          echo "TIDY_SOURCES=$(git diff-tree --name-only -r --diff-filter=ACMRTUXB ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -E '(.h$|.cc$)' | tr '\n' ' ')" >> $GITHUB_ENV
+          echo "TIDY_SOURCES=$(git diff --name-only --diff-filter=d HEAD^1 HEAD -- '*.h' '*.cc' | tr '\n' ' ')" >> $GITHUB_ENV
 
       - name: Wait for build image
         uses: ./.github/workflows/wait-for-image


### PR DESCRIPTION
Do not set ref on PR checkout for tidy so that ref range HEAD^1 HEAD covers all the changes in the PR.

Fixes: #1760
