### PR TITLE
[bpf_metadata] Make use of npds_config if configured

### DIFF
--- a/cilium/BUILD
+++ b/cilium/BUILD
@@ -46,7 +46,6 @@ envoy_cc_library(
         "//cilium:grpc_subscription_lib",
         "//cilium:ipcache_lib",
         "//cilium/api:npds_cc_proto",
-        "@envoy//envoy/config:subscription_interface",
         "@envoy//envoy/singleton:manager_interface",
         "@envoy//source/common/common:logger_lib",
         "@envoy//source/common/config:opaque_resource_decoder_lib",
@@ -348,6 +347,7 @@ envoy_cc_library(
         "@envoy//source/common/common:logger_lib",
         "@envoy//source/common/network:address_lib",
         "@envoy//source/common/router:config_utility_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
 

--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -14,6 +14,7 @@
 
 #include "envoy/api/io_error.h"
 #include "envoy/common/exception.h"
+#include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/core/v3/socket_option.pb.h"
 #include "envoy/network/address.h"
 #include "envoy/network/filter.h"
@@ -169,6 +170,27 @@ REGISTER_FACTORY(UdpBpfMetadataConfigFactory,
 } // namespace Server
 
 namespace Cilium {
+
+// Hard-coded Cilium gRPC cluster
+// Note: No rate-limit settings are used, consider if needed.
+const envoy::config::core::v3::ConfigSource getCiliumXDSAPIConfig() {
+  auto config_source = envoy::config::core::v3::ConfigSource();
+  /* config_source.initial_fetch_timeout is set to 50 millliseconds.
+   * This applies only to SDS Secrets for now, as for NPDS and NPHDS we explicitly set the timeout
+   * as 0 (no timeout).
+   */
+  config_source.mutable_initial_fetch_timeout()->set_nanos(50000000);
+  config_source.set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+  auto api_config_source = config_source.mutable_api_config_source();
+  api_config_source->set_set_node_on_first_message_only(true);
+  api_config_source->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+  api_config_source->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
+  api_config_source->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("xds-grpc-cilium");
+  return config_source;
+}
+
+const envoy::config::core::v3::ConfigSource CILIUM_XDS_API_CONFIG = getCiliumXDSAPIConfig();
+
 namespace BpfMetadata {
 
 // Singleton registration via macro defined in envoy/singleton/manager.h
@@ -179,20 +201,23 @@ SINGLETON_MANAGER_REGISTRATION(cilium_network_policy);
 namespace {
 
 std::shared_ptr<const Cilium::PolicyHostMap>
-createHostMap(Server::Configuration::ListenerFactoryContext& context) {
+createHostMap(Server::Configuration::ListenerFactoryContext& context,
+              envoy::config::core::v3::ConfigSource& npds_config) {
   return context.serverFactoryContext().singletonManager().getTyped<const Cilium::PolicyHostMap>(
-      SINGLETON_MANAGER_REGISTERED_NAME(cilium_host_map), [&context] {
+      SINGLETON_MANAGER_REGISTERED_NAME(cilium_host_map), [&context, npds_config] {
         auto map = std::make_shared<Cilium::PolicyHostMap>(context.serverFactoryContext());
-        map->startSubscription(context.serverFactoryContext());
+        map->startSubscription(context.serverFactoryContext(), npds_config);
         return map;
       });
 }
 
 std::shared_ptr<const Cilium::NetworkPolicyMap>
-createPolicyMap(Server::Configuration::FactoryContext& context) {
+createPolicyMap(Server::Configuration::FactoryContext& context,
+                envoy::config::core::v3::ConfigSource& npds_config) {
   return context.serverFactoryContext().singletonManager().getTyped<const Cilium::NetworkPolicyMap>(
-      SINGLETON_MANAGER_REGISTERED_NAME(cilium_network_policy),
-      [&context] { return std::make_shared<Cilium::NetworkPolicyMap>(context, true); });
+      SINGLETON_MANAGER_REGISTERED_NAME(cilium_network_policy), [&context, npds_config] {
+        return std::make_shared<Cilium::NetworkPolicyMap>(context, npds_config, true);
+      });
 }
 
 } // namespace
@@ -213,10 +238,9 @@ Config::Config(const ::cilium::BpfMetadata& config,
       l7lb_policy_name_(config.l7lb_policy_name()),
       ipcache_entry_ttl_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, cache_entry_ttl, DEFAULT_CACHE_ENTRY_TTL_MS)),
-      random_(context.serverFactoryContext().api().randomGenerator()) {
-  if (config.has_npds_config()) {
-    throw EnvoyException("cilium.bpf_metadata: npds_config is not yet supported");
-  }
+      random_(context.serverFactoryContext().api().randomGenerator()),
+      npds_config_(config.has_npds_config() ? config.npds_config()
+                                            : Cilium::CILIUM_XDS_API_CONFIG) {
   if (is_l7lb_ && is_ingress_) {
     throw EnvoyException("cilium.bpf_metadata: is_l7lb may not be set with is_ingress");
   }
@@ -234,9 +258,8 @@ Config::Config(const ::cilium::BpfMetadata& config,
         fmt::format("cilium.bpf_metadata: ipv6_source_address is not an IPv6 address: {}",
                     config.ipv6_source_address()));
   }
-
   if (config.use_nphds()) {
-    hosts_ = createHostMap(context);
+    hosts_ = createHostMap(context, npds_config_);
   }
 
   // Note: all instances use the bpf root of the first filter with non-empty
@@ -273,7 +296,7 @@ Config::Config(const ::cilium::BpfMetadata& config,
   // instances!
   // Only created if either ipcache_ or hosts_ map exists
   if (ipcache_ || hosts_) {
-    npmap_ = createPolicyMap(context);
+    npmap_ = createPolicyMap(context, npds_config_);
   }
 }
 

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -9,6 +9,7 @@
 
 #include "envoy/api/io_error.h"
 #include "envoy/common/random_generator.h"
+#include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/network/address.h"
 #include "envoy/network/filter.h"
 #include "envoy/network/listener_filter_buffer.h"
@@ -30,6 +31,10 @@
 
 namespace Envoy {
 namespace Cilium {
+
+// Cilium XDS API config source. Used for all Cilium XDS.
+extern const envoy::config::core::v3::ConfigSource CILIUM_XDS_API_CONFIG;
+
 namespace BpfMetadata {
 
 #define DEFAULT_CACHE_ENTRY_TTL_MS 3
@@ -168,6 +173,7 @@ public:
   std::string l7lb_policy_name_;
   std::chrono::milliseconds ipcache_entry_ttl_;
   Random::RandomGenerator& random_;
+  envoy::config::core::v3::ConfigSource npds_config_;
 
   std::shared_ptr<const Cilium::NetworkPolicyMap> npmap_;
   Cilium::CtMapSharedPtr ct_maps_;

--- a/cilium/grpc_subscription.cc
+++ b/cilium/grpc_subscription.cc
@@ -120,35 +120,14 @@ const Protobuf::MethodDescriptor& sotwGrpcMethod(absl::string_view type_url) {
       it->second.sotw_grpc_method_);
 }
 
-// Hard-coded Cilium gRPC cluster
-// Note: No rate-limit settings are used, consider if needed.
-envoy::config::core::v3::ConfigSource getCiliumXDSAPIConfig() {
-  auto config_source = envoy::config::core::v3::ConfigSource();
-  /* config_source.initial_fetch_timeout is set to 50 millliseconds.
-   * This applies only to SDS Secrets for now, as for NPDS and NPHDS we explicitly set the timeout
-   * as 0 (no timeout).
-   */
-  config_source.mutable_initial_fetch_timeout()->set_nanos(50000000);
-  config_source.set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
-  auto api_config_source = config_source.mutable_api_config_source();
-  api_config_source->set_set_node_on_first_message_only(true);
-  api_config_source->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
-  api_config_source->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
-  api_config_source->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("xds-grpc-cilium");
-  return config_source;
-}
-
-envoy::config::core::v3::ConfigSource cilium_xds_api_config = getCiliumXDSAPIConfig();
-
 std::unique_ptr<Config::GrpcSubscriptionImpl>
-subscribe(const std::string& type_url, const LocalInfo::LocalInfo& local_info,
-          Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
-          Random::RandomGenerator& random, Stats::Scope& scope,
+subscribe(const std::string& type_url, const envoy::config::core::v3::ConfigSource& npds_config,
+          const LocalInfo::LocalInfo& local_info, Upstream::ClusterManager& cm,
+          Event::Dispatcher& dispatcher, Random::RandomGenerator& random, Stats::Scope& scope,
           Config::SubscriptionCallbacks& callbacks,
           Config::OpaqueResourceDecoderSharedPtr resource_decoder,
           std::chrono::milliseconds init_fetch_timeout) {
-  const envoy::config::core::v3::ApiConfigSource& api_config_source =
-      cilium_xds_api_config.api_config_source();
+  auto& api_config_source = npds_config.api_config_source();
   THROW_IF_NOT_OK(Config::Utility::checkApiConfigSourceSubscriptionBackingCluster(
       cm.primaryClusters(), api_config_source));
 

--- a/cilium/grpc_subscription.h
+++ b/cilium/grpc_subscription.h
@@ -19,9 +19,6 @@
 namespace Envoy {
 namespace Cilium {
 
-// Cilium XDS API config source. Used for all Cilium XDS.
-extern envoy::config::core::v3::ConfigSource cilium_xds_api_config;
-
 // GrpcMux wrapper to get access to control plane identifier
 class GrpcMuxImpl : public Config::GrpcMuxImpl {
 public:
@@ -47,9 +44,9 @@ private:
 };
 
 std::unique_ptr<Config::GrpcSubscriptionImpl>
-subscribe(const std::string& type_url, const LocalInfo::LocalInfo& local_info,
-          Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
-          Random::RandomGenerator& random, Stats::Scope& scope,
+subscribe(const std::string& type_url, const envoy::config::core::v3::ConfigSource& npds_config,
+          const LocalInfo::LocalInfo& local_info, Upstream::ClusterManager& cm,
+          Event::Dispatcher& dispatcher, Random::RandomGenerator& random, Stats::Scope& scope,
           Config::SubscriptionCallbacks& callbacks,
           Config::OpaqueResourceDecoderSharedPtr resource_decoder,
           std::chrono::milliseconds init_fetch_timeout = std::chrono::milliseconds(0));

--- a/cilium/host_map.cc
+++ b/cilium/host_map.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "envoy/common/exception.h"
+#include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/server/factory_context.h"
@@ -170,11 +171,12 @@ PolicyHostMap::PolicyHostMap(Server::Configuration::CommonFactoryContext& contex
   scope_ = context.serverScope().createScope(name_);
 }
 
-void PolicyHostMap::startSubscription(Server::Configuration::CommonFactoryContext& context) {
-  subscription_ = subscribe("type.googleapis.com/cilium.NetworkPolicyHosts", context.localInfo(),
-                            context.clusterManager(), context.mainThreadDispatcher(),
-                            context.api().randomGenerator(), *scope_, *this,
-                            std::make_shared<Cilium::PolicyHostDecoder>());
+void PolicyHostMap::startSubscription(Server::Configuration::CommonFactoryContext& context,
+                                      const envoy::config::core::v3::ConfigSource& npds_config) {
+  subscription_ = subscribe("type.googleapis.com/cilium.NetworkPolicyHosts", npds_config,
+                            context.localInfo(), context.clusterManager(),
+                            context.mainThreadDispatcher(), context.api().randomGenerator(),
+                            *scope_, *this, std::make_shared<Cilium::PolicyHostDecoder>());
   subscription_->start({});
 }
 

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "envoy/common/exception.h"
+#include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
 #include "envoy/network/address.h"
 #include "envoy/protobuf/message_validator.h"
@@ -101,7 +102,8 @@ public:
     ENVOY_LOG(debug, "Cilium PolicyHostMap({}): PolicyHostMap is deleted NOW!", name_);
   }
 
-  void startSubscription(Server::Configuration::CommonFactoryContext& context);
+  void startSubscription(Server::Configuration::CommonFactoryContext& context,
+                         const envoy::config::core::v3::ConfigSource& npds_config);
 
   // This is used for testing with a file-based subscription
   void startSubscription(std::unique_ptr<Envoy::Config::Subscription>&& subscription) {

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -20,6 +20,7 @@
 #include "envoy/common/optref.h"
 #include "envoy/config/core/v3/address.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
 #include "envoy/http/header_map.h"
 #include "envoy/init/manager.h"
@@ -1821,9 +1822,11 @@ private:
 
 // Common base constructor
 // This is used directly for testing with a file-based subscription
-NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& context, bool subscribe)
+NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& context,
+                                   const envoy::config::core::v3::ConfigSource& npds_config,
+                                   bool subscribe)
     : context_(context.serverFactoryContext()) {
-  impl_ = std::make_unique<NetworkPolicyMapImpl>(context);
+  impl_ = std::make_unique<NetworkPolicyMapImpl>(context, npds_config);
 
   if (context_.admin().has_value()) {
     ENVOY_LOG(debug, "Registering NetworkPolicies to config tracker");
@@ -1858,7 +1861,8 @@ NetworkPolicyMap::~NetworkPolicyMap() {
   context_.mainThreadDispatcher().post([impl = std::move(impl_)]() {});
 }
 
-NetworkPolicyMapImpl::NetworkPolicyMapImpl(Server::Configuration::FactoryContext& context)
+NetworkPolicyMapImpl::NetworkPolicyMapImpl(Server::Configuration::FactoryContext& context,
+                                           const envoy::config::core::v3::ConfigSource& npds_config)
     : context_(context.serverFactoryContext()), map_ptr_(nullptr),
       npds_stats_scope_(context_.serverScope().createScope("cilium.npds.")),
       policy_stats_scope_(context_.serverScope().createScope("cilium.policy.")),
@@ -1872,6 +1876,7 @@ NetworkPolicyMapImpl::NetworkPolicyMapImpl(Server::Configuration::FactoryContext
           std::make_shared<Server::Configuration::TransportSocketFactoryContextImpl>(
               context_, *npds_stats_scope_,
               context_.messageValidationContext().dynamicValidationVisitor())),
+      npds_config_(npds_config),
       stats_{ALL_CILIUM_POLICY_STATS(POOL_COUNTER(*policy_stats_scope_),
                                      POOL_HISTOGRAM(*policy_stats_scope_))} {
   // Use listener init manager for subscription initialization
@@ -1890,10 +1895,10 @@ NetworkPolicyMapImpl::~NetworkPolicyMapImpl() {
 }
 
 void NetworkPolicyMapImpl::startSubscription() {
-  subscription_ = subscribe("type.googleapis.com/cilium.NetworkPolicy", context_.localInfo(),
-                            context_.clusterManager(), context_.mainThreadDispatcher(),
-                            context_.api().randomGenerator(), *npds_stats_scope_, *this,
-                            std::make_shared<NetworkPolicyDecoder>());
+  subscription_ = subscribe("type.googleapis.com/cilium.NetworkPolicy", npds_config_,
+                            context_.localInfo(), context_.clusterManager(),
+                            context_.mainThreadDispatcher(), context_.api().randomGenerator(),
+                            *npds_stats_scope_, *this, std::make_shared<NetworkPolicyDecoder>());
 }
 
 void NetworkPolicyMapImpl::tlsWrapperMissingPolicyInc() const {

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -15,6 +15,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/regex.h"
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
 #include "envoy/http/header_map.h"
 #include "envoy/network/address.h"
@@ -232,10 +233,13 @@ using RawPolicyMap = absl::flat_hash_map<std::string, std::shared_ptr<const Poli
 class NetworkPolicyMapImpl : public Envoy::Config::SubscriptionCallbacks,
                              public Logger::Loggable<Logger::Id::config> {
 public:
-  NetworkPolicyMapImpl(Server::Configuration::FactoryContext& context);
+  NetworkPolicyMapImpl(Server::Configuration::FactoryContext& context,
+                       const envoy::config::core::v3::ConfigSource& npds_config);
   ~NetworkPolicyMapImpl() override;
 
   void startSubscription();
+
+  const envoy::config::core::v3::ConfigSource& getConfigSource() const { return npds_config_; }
 
   // This is used for testing with a file-based subscription
   void startSubscription(std::unique_ptr<Envoy::Config::Subscription>&& subscription) {
@@ -326,6 +330,7 @@ private:
       transport_factory_context_;
 
   std::unique_ptr<Envoy::Config::Subscription> subscription_;
+  envoy::config::core::v3::ConfigSource npds_config_;
 
 protected:
   friend class NetworkPolicyMap;
@@ -339,7 +344,9 @@ class AllowAllEgressPolicyInstanceImpl;
 
 class NetworkPolicyMap : public Singleton::Instance, public Logger::Loggable<Logger::Id::config> {
 public:
-  NetworkPolicyMap(Server::Configuration::FactoryContext& context, bool subscribe = false);
+  NetworkPolicyMap(Server::Configuration::FactoryContext& context,
+                   const envoy::config::core::v3::ConfigSource& npds_config,
+                   bool subscribe = false);
   ~NetworkPolicyMap() override;
 
   // This is used for testing with a file-based subscription

--- a/cilium/secret_watcher.cc
+++ b/cilium/secret_watcher.cc
@@ -23,7 +23,6 @@
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
 #include "cilium/api/npds.pb.h"
-#include "cilium/grpc_subscription.h"
 #include "cilium/network_policy.h"
 
 namespace Envoy {
@@ -32,15 +31,18 @@ namespace Cilium {
 namespace {
 
 // SDS config used in production
-envoy::config::core::v3::ConfigSource getCiliumSDSConfig(const std::string&) {
-  /* returned config_source has initial_fetch_timeout of 50 milliseconds. */
-  return Cilium::cilium_xds_api_config;
+envoy::config::core::v3::ConfigSource
+getCiliumSDSConfig(const std::string&, const envoy::config::core::v3::ConfigSource& config_source) {
+  // This is used in production, where the SDS config is always the same and does not need to
+  // be overridden.
+  return config_source;
 }
 
 Secret::GenericSecretConfigProviderSharedPtr
 secretProvider(Server::Configuration::TransportSocketFactoryContext& context,
-               const std::string& sds_name) {
-  envoy::config::core::v3::ConfigSource config_source = getSDSConfig(sds_name);
+               const std::string& sds_name, const NetworkPolicyMapImpl& parent) {
+  const envoy::config::core::v3::ConfigSource& config_source =
+      getSDSConfig(sds_name, parent.getConfigSource());
   return context.serverFactoryContext().secretManager().findOrCreateGenericSecretProvider(
       config_source, sds_name, context.serverFactoryContext(), context.initManager());
 }
@@ -53,7 +55,7 @@ void resetSDSConfigFunc() { getSDSConfig = &getCiliumSDSConfig; }
 
 SecretWatcher::SecretWatcher(const NetworkPolicyMapImpl& parent, const std::string& sds_name)
     : parent_(parent), name_(sds_name),
-      secret_provider_(secretProvider(parent.transportFactoryContext(), sds_name)),
+      secret_provider_(secretProvider(parent.transportFactoryContext(), sds_name, parent)),
       update_secret_(readAndWatchSecret()) {}
 
 SecretWatcher::~SecretWatcher() {
@@ -97,12 +99,13 @@ TLSContext::TLSContext(const NetworkPolicyMapImpl& parent, const std::string& na
 namespace {
 
 void setCommonConfig(const cilium::TLSContext config,
-                     envoy::extensions::transport_sockets::tls::v3::CommonTlsContext* tls_context) {
+                     envoy::extensions::transport_sockets::tls::v3::CommonTlsContext* tls_context,
+                     const NetworkPolicyMapImpl& parent) {
   if (!config.validation_context_sds_secret().empty()) {
     auto sds_secret = tls_context->mutable_validation_context_sds_secret_config();
     sds_secret->set_name(config.validation_context_sds_secret());
     auto* config_source = sds_secret->mutable_sds_config();
-    *config_source = getSDSConfig(config.validation_context_sds_secret());
+    *config_source = getSDSConfig(config.validation_context_sds_secret(), parent.getConfigSource());
   } else if (!config.trusted_ca().empty()) {
     auto validation_context = tls_context->mutable_validation_context();
     auto trusted_ca = validation_context->mutable_trusted_ca();
@@ -112,7 +115,7 @@ void setCommonConfig(const cilium::TLSContext config,
     auto sds_secret = tls_context->add_tls_certificate_sds_secret_configs();
     sds_secret->set_name(config.tls_sds_secret());
     auto* config_source = sds_secret->mutable_sds_config();
-    *config_source = getSDSConfig(config.tls_sds_secret());
+    *config_source = getSDSConfig(config.tls_sds_secret(), parent.getConfigSource());
   } else if (!config.certificate_chain().empty()) {
     auto tls_certificate = tls_context->add_tls_certificates();
     auto certificate_chain = tls_certificate->mutable_certificate_chain();
@@ -150,7 +153,7 @@ DownstreamTLSContext::DownstreamTLSContext(const NetworkPolicyMapImpl& parent,
     auto require_tls_certificate = context_config.mutable_require_client_certificate();
     require_tls_certificate->set_value(true);
   }
-  setCommonConfig(config, tls_context);
+  setCommonConfig(config, tls_context, parent);
 
   for (int i = 0; i < config.server_names_size(); i++) {
     server_names_.emplace_back(config.server_names(i));
@@ -195,7 +198,7 @@ UpstreamTLSContext::UpstreamTLSContext(const NetworkPolicyMapImpl& parent,
 
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext context_config;
   auto tls_context = context_config.mutable_common_tls_context();
-  setCommonConfig(config, tls_context);
+  setCommonConfig(config, tls_context, parent);
 
   if (config.server_names_size() > 0) {
     if (config.server_names_size() > 1) {

--- a/cilium/secret_watcher.h
+++ b/cilium/secret_watcher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -25,8 +26,12 @@
 namespace Envoy {
 namespace Cilium {
 
+// Cilium XDS API config source. Used for all Cilium XDS.
+extern const envoy::config::core::v3::ConfigSource CILIUM_XDS_API_CONFIG;
+
 // Facility for SDS config override for testing
-using GetSdsConfigFunc = envoy::config::core::v3::ConfigSource (*)(const std::string&);
+using GetSdsConfigFunc = std::function<const envoy::config::core::v3::ConfigSource(
+    const std::string&, const envoy::config::core::v3::ConfigSource&)>;
 extern GetSdsConfigFunc getSDSConfig;
 void setSDSConfigFunc(GetSdsConfigFunc);
 void resetSDSConfigFunc();

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -116,14 +116,15 @@ envoy_cc_test(
     srcs = ["cilium_network_policy_test.cc"],
     repository = "@envoy",
     deps = [
+        ":bpf_metadata_lib",
         "//cilium:network_policy_lib",
         "@envoy//test/mocks/server:factory_context_mocks",
     ],
 )
 
 envoy_cc_test(
-    name = "metadata_config_test",
-    srcs = ["metadata_config_test.cc"],
+    name = "bpf_metadata_config_test",
+    srcs = ["bpf_metadata_config_test.cc"],
     repository = "@envoy",
     deps = [
         ":bpf_metadata_lib",

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -89,17 +89,17 @@ createPolicyMap(const std::string& config,
             THROW_IF_NOT_OK(Envoy::Config::Utility::checkFilesystemSubscriptionBackingPath(
                 sds_path, context.serverFactoryContext().api()));
           }
-          Cilium::setSDSConfigFunc(
-              [](const std::string& name) -> envoy::config::core::v3::ConfigSource {
-                auto file_config = envoy::config::core::v3::ConfigSource();
-                /* initial_fetch_timeout left at default 15 seconds. */
-                file_config.set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
-                auto sds_path =
-                    TestEnvironment::temporaryPath(fmt::sprintf("secret-%s.yaml", name));
-                *file_config.mutable_path_config_source() =
-                    Envoy::Config::makePathConfigSource(sds_path);
-                return file_config;
-              });
+          Cilium::setSDSConfigFunc([](const std::string& name,
+                                      const envoy::config::core::v3::ConfigSource&)
+                                       -> const envoy::config::core::v3::ConfigSource {
+            auto file_config = envoy::config::core::v3::ConfigSource();
+            /* initial_fetch_timeout left at default 15 seconds. */
+            file_config.set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+            auto sds_path = TestEnvironment::temporaryPath(fmt::sprintf("secret-%s.yaml", name));
+            *file_config.mutable_path_config_source() =
+                Envoy::Config::makePathConfigSource(sds_path);
+            return file_config;
+          });
         }
         // File subscription.
         policy_path = TestEnvironment::writeStringToFileForTest("network_policy.yaml", config);
@@ -111,7 +111,8 @@ createPolicyMap(const std::string& config,
             policy_path, context.serverFactoryContext().api()));
         Envoy::Config::SubscriptionStats stats =
             Envoy::Config::Utility::generateStats(context.scope());
-        auto map = std::make_shared<Cilium::NetworkPolicyMap>(context);
+        auto map =
+            std::make_shared<Cilium::NetworkPolicyMap>(context, Cilium::CILIUM_XDS_API_CONFIG);
         auto subscription = std::make_unique<Envoy::Config::FilesystemSubscriptionImpl>(
             context.serverFactoryContext().mainThreadDispatcher(),
             Envoy::Config::makePathConfigSource(policy_path), map->getImpl(),

--- a/tests/bpf_metadata_config_test.cc
+++ b/tests/bpf_metadata_config_test.cc
@@ -224,13 +224,12 @@ resources:
   std::list<Init::TargetHandlePtr> target_handles_;
 };
 
-TEST_F(MetadataConfigTest, NpdsConfigNotSupported) {
+TEST_F(MetadataConfigTest, NpdsConfigSupported) {
   ::cilium::BpfMetadata config{};
   config.mutable_npds_config()->mutable_api_config_source()->set_api_type(
       envoy::config::core::v3::ApiConfigSource::GRPC);
 
-  EXPECT_THROW_WITH_MESSAGE(initialize(config), EnvoyException,
-                            "cilium.bpf_metadata: npds_config is not yet supported");
+  EXPECT_NO_THROW(initialize(config));
 }
 
 TEST_F(MetadataConfigTest, EmptyConfig) {

--- a/tests/cilium_network_policy_test.cc
+++ b/tests/cilium_network_policy_test.cc
@@ -38,6 +38,9 @@
 namespace Envoy {
 namespace Cilium {
 
+// Cilium XDS API config source. Used for all Cilium XDS.
+extern const envoy::config::core::v3::ConfigSource CILIUM_XDS_API_CONFIG;
+
 #define ON_CALL_SDS_SECRET_PROVIDER(SECRET_MANAGER, PROVIDER_TYPE, API_TYPE)                       \
   ON_CALL(SECRET_MANAGER, findOrCreate##PROVIDER_TYPE##Provider(_, _, _, _))                       \
       .WillByDefault(Invoke([](const envoy::config::core::v3::ConfigSource& sds_config_source,     \
@@ -71,7 +74,8 @@ protected:
     ON_CALL_SDS_SECRET_PROVIDER(secret_manager_, TlsSessionTicketKeysContext, TlsSessionTicketKeys);
     ON_CALL_SDS_SECRET_PROVIDER(secret_manager_, GenericSecret, GenericSecret);
 
-    policy_map_ = std::make_shared<NetworkPolicyMap>(factory_context_);
+    policy_map_ =
+        std::make_shared<NetworkPolicyMap>(factory_context_, Cilium::CILIUM_XDS_API_CONFIG);
   }
 
   void TearDown() override {


### PR DESCRIPTION
When `npds_config` config field is set in bpf_metadata,  override the existing default cilium_xds_api_config_source and use it to fetch network policies, network policy hosts and secrets. This is prerequisite for supporting ads in cilium proxy.