### PR TITLE
[release debug] Fix workflow permissions

### DIFF
--- a/.github/workflows/build-envoy-images-release-debug.yaml
+++ b/.github/workflows/build-envoy-images-release-debug.yaml
@@ -1,7 +1,11 @@
 name: Refresh test & build cache & build latest wth debug symbols
 on:
   workflow_dispatch:
-  
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-envoy-images-release-debug:
     uses: ./.github/workflows/build-envoy-images-release-base.yaml


### PR DESCRIPTION
Grant `id-token: write` permission in `build-envoy-images-release-debug` workflow. Attempt to fix:
```
Invalid workflow file: .github/workflows/build-envoy-images-release-debug.yaml#L6The workflow is not valid. .github/workflows/build-envoy-images-release-debug.yaml (Line: 6, Col: 3): Error calling workflow 'cilium/proxy/.github/workflows/build-envoy-images-release-base.yaml@b89a0f1f2c93c9d6675a4911cb3452c269e9ebad'. The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.
--


[Invalid workflow file: .github/workflows/build-envoy-images-release-debug.yaml#L6](https://github.com/cilium/proxy/actions/runs/24663862461/workflow)
The workflow is not valid. .github/workflows/build-envoy-images-release-debug.yaml (Line: 6, Col: 3): Error calling workflow 'cilium/proxy/.github/workflows/build-envoy-images-release-base.yaml@b89a0f1f2c93c9d6675a4911cb3452c269e9ebad'. The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.
```