### PR TITLE
.github: Harden image pushes to use GH environment

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -15,8 +15,11 @@ concurrency:
 
 jobs:
   build-and-push-prs:
-    timeout-minutes: 360
     name: Build and push multi-arch images
+    environment:
+      name: ci-build
+      deployment: false
+    timeout-minutes: 360
     runs-on: ${{ vars.PROXY_BUILD_GITHUB_RUNNER }}
     outputs:
       sha: ${{ steps.tag.outputs.sha }}

--- a/.github/workflows/build-envoy-images-release-base.yaml
+++ b/.github/workflows/build-envoy-images-release-base.yaml
@@ -27,8 +27,11 @@ concurrency:
 
 jobs:
   test-cache-refresh:
-    timeout-minutes: 360
     name: Build test cache and push images
+    environment:
+      name: release-base-images
+      deployment: false
+    timeout-minutes: 360
     runs-on: ${{ vars.PROXY_BUILD_GITHUB_RUNNER }}
     steps:
     - name: Set up QEMU
@@ -94,8 +97,11 @@ jobs:
         tags: quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ github.ref_name }}-archive-latest
 
   build-cache-and-push-images:
-    timeout-minutes: 360
     name: Build cache and push images
+    environment:
+      name: release-base-images
+      deployment: false
+    timeout-minutes: 360
     runs-on: ${{ vars.PROXY_BUILD_GITHUB_RUNNER }}
     steps:
     - name: Set up QEMU


### PR DESCRIPTION
Make use of GitHub environments to access CI or release credentials,
respectively, depending on the workflow that is run.
