### PR TITLE
make: Pull up-to-date clang 18.1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 include Makefile.defs
 
+MIN_CLANG_VERSION := 18.1.8
 COMPILER_DEP := clang.bazelrc
 
 ENVOY_BINS = cilium-envoy bazel-bin/cilium-envoy cilium-envoy-starter bazel-bin/cilium-envoy-starter
@@ -96,7 +97,18 @@ else
 
   # Install clang if needed
   define install_clang
-	$(SUDO) apt install -y clang clangd llvm llvm-dev lld lldb clang-format clang-tools clang-tidy libc++-dev libc++abi-dev
+	add_llvm_source() { \
+		if [ ! -f /etc/apt/trusted.gpg.d/apt.llvm.org.asc ]; then \
+		  $(SUDO) wget -q -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key; \
+		fi; \
+		local CODENAME=$$(lsb_release -cs); \
+		apt_source="deb http://apt.llvm.org/$$CODENAME/ llvm-toolchain-$$CODENAME-18 main" && \
+		$(SUDO) apt-add-repository -y "$${apt_source}" && \
+		$(SUDO) apt update; \
+	}; \
+	version="$$(dpkg-query -W -f='$${Version}' clang-18 2>/dev/null || echo 0)"; \
+	if ! dpkg --compare-versions "$$version" ge 1:$(MIN_CLANG_VERSION)~; then add_llvm_source; fi; \
+	$(SUDO) apt install -y clang-18 clangd-18 llvm-18-dev lld-18 lldb-18 clang-format-18 clang-tools-18 clang-tidy-18 libc++-18-dev libc++abi-18-dev
   endef
 endif
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,8 +30,12 @@ apt-get update && \
       libc6-dev \
       autoconf automake cmake coreutils curl git libtool make ninja-build patch patchelf \
       python3 python-is-python3 unzip virtualenv wget zip \
-      software-properties-common \
-      clang clang-tools lldb lld clang-format libc++-dev libc++abi-dev && \
+      software-properties-common && \
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    apt-add-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      clang-18 clangd-18 llvm-18-dev lld-18 lldb-18 clang-format-18 clang-tools-18 clang-tidy-18 libc++-18-dev libc++abi-18-dev && \
     apt-get purge --auto-remove && \
     apt-get clean
 SCRIPT


### PR DESCRIPTION
Sync "clang.bazelrc" make target with the Dockerfile.builder and pull the latest clang 18.1.8. Ubuntu 24.04 repositories have only 18.1.3, which causes Envoy crashes like this:

GWP-ASan Mismatched-size-delete of 24 bytes (expected 25 bytes)

This is due to incompatibility issue with std::basic_string implementation in libc++ in clang 18.1.3, where it can drop the lowest bit in the allocation length, causing delete to be called with length 24, when the length required of allocation was 25. This is fixes in later clang libc++ versoins.

Upstream Envoy is pinned on Clang 18.1.8, and Dockerfile.builder already pulls the latest in version 18, which is 18.1.8.

Fixes: #1820