### PR TITLE
tls_wrapper: Initialize socket earlier for downstream/server connections

### DIFF
--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -49,6 +49,17 @@ public:
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override {
     callbacks_ = &callbacks;
+
+    // Downstream listeners build the filter chain after transport socket callbacks are installed.
+    // Create the wrapped socket eagerly so connection().ssl() is already populated when network
+    // filters such as HCM initialize their SSL-specific connection stats.
+    //
+    // For upstream sockets this spot is likely too early, as the destination address, filter state,
+    // etc. might not be in place yet. So keep the current onConnected() site for socket preparation
+    // for the client sockets and for any server sockets that might have missed this call.
+    if (!socket_ && state_ == Extensions::TransportSockets::Tls::InitialState::Server) {
+      prepareSocket();
+    }
   }
 
   std::string protocol() const override { return socket_ ? socket_->protocol() : EMPTY_STRING; }
@@ -83,6 +94,17 @@ public:
   }
 
   void onConnected() override {
+    if (!socket_) {
+      prepareSocket();
+    }
+
+    if (socket_) {
+      socket_->onConnected();
+    }
+  }
+
+private:
+  void prepareSocket() {
     // Get the Cilium policy filter state from the callbacks in order to get the TLS
     // configuration.
     // Cilium socket option is only created if the (initial) policy for the local pod exists.
@@ -188,12 +210,9 @@ public:
                      "Policy (Cilium socket option not found)",
                      conn);
     }
-
-    if (socket_) {
-      socket_->onConnected();
-    }
   }
 
+public:
   Ssl::ConnectionInfoConstSharedPtr ssl() const override {
     return socket_ ? socket_->ssl() : nullptr;
   }

--- a/tests/cilium_tls_http_integration_test.cc
+++ b/tests/cilium_tls_http_integration_test.cc
@@ -330,6 +330,22 @@ public:
     cleanupUpstreamAndDownstream();
   }
 
+  void acceptedWithSslGaugeCheck(Http::TestRequestHeaderMapImpl&& headers) {
+    initialize();
+    auto response = sendRequestAndWaitForResponse(headers, 0, default_response_headers_, 0);
+
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ("200", response->headers().getStatusValue());
+    EXPECT_TRUE(upstream_request_->complete());
+    EXPECT_EQ(0, upstream_request_->bodyLength());
+
+    test_server_->waitForGaugeEq("http.config_test.downstream_cx_ssl_active", 1);
+
+    cleanupUpstreamAndDownstream();
+
+    test_server_->waitForGaugeEq("http.config_test.downstream_cx_ssl_active", 0);
+  }
+
   // Upstream
   bool upstream_tls_{true};
   std::string upstream_cert_name_{"upstreamlocalhost"};
@@ -355,6 +371,11 @@ TEST_P(CiliumTLSHttpIntegrationTest, DeniedPathPrefix) {
 
 TEST_P(CiliumTLSHttpIntegrationTest, AllowedPathPrefix) {
   accepted({{":method", "GET"}, {":path", "/allowed"}, {":authority", "localhost"}});
+}
+
+TEST_P(CiliumTLSHttpIntegrationTest, AllowedPathPrefixTracksSslActiveGauge) {
+  acceptedWithSslGaugeCheck(
+      {{":method", "GET"}, {":path", "/allowed"}, {":authority", "localhost"}});
 }
 
 TEST_P(CiliumTLSHttpIntegrationTest, AllowedPathPrefixStrippedHeader) {


### PR DESCRIPTION
Downstream listeners build the filter chain after transport socket callbacks are installed, but our TLS wrapper instantiated the SSL socket only later, in `onConnected()` callback. This caused `HttpConnectionManager` to miscount SSL connection stats and underflow in the count on delete. This underflow is guarded by an `ASSERT` that is not enforced on production builds (`NDEBUG` defined). This is why this never tripped in production, but the SSL active connection stats would have been underflowing to large positive values prior to this fix.

Create the wrapped socket eagerly so `connection().ssl()` is already populated when network filters such as HCM initialize their SSL-specific connection stats.