### PR TITLE
policy: Remove memory leak on exception

### DIFF
--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -1966,8 +1966,8 @@ absl::Status NetworkPolicyMapImpl::onConfigUpdate(
   transport_factory_context_->setInitManager(version_init_manager);
 
   const auto* old_map = load();
+  RawPolicyMap new_map;
   {
-    auto new_map = new RawPolicyMap();
     try {
       for (const auto& resource : resources) {
         const auto& config = dynamic_cast<const cilium::NetworkPolicy&>(resource.get().resource());
@@ -1989,7 +1989,7 @@ absl::Status NetworkPolicyMapImpl::onConfigUpdate(
             ENVOY_LOG(trace, "New policy is equal to old one, not updating.");
             for (const auto& endpoint_ip : config.endpoint_ips()) {
               ENVOY_LOG(trace, "Cilium keeping network policy for endpoint {}", endpoint_ip);
-              new_map->emplace(endpoint_ip, old_policy);
+              new_map.emplace(endpoint_ip, old_policy);
             }
             continue;
           }
@@ -2001,7 +2001,7 @@ absl::Status NetworkPolicyMapImpl::onConfigUpdate(
         for (const auto& endpoint_ip : config.endpoint_ips()) {
           ENVOY_LOG(trace, "Cilium updating network policy for endpoint {}", endpoint_ip);
           // new_map is not exception safe, new_policy must be computed separately!
-          new_map->emplace(endpoint_ip, new_policy);
+          new_map.emplace(endpoint_ip, new_policy);
         }
       }
     } catch (const EnvoyException& e) {
@@ -2018,7 +2018,7 @@ absl::Status NetworkPolicyMapImpl::onConfigUpdate(
 
     // Swap the new map in, new_map goes out of scope right after to eliminate accidental
     // modification.
-    old_map = exchange(new_map);
+    old_map = exchange(new RawPolicyMap(std::move(new_map)));
   }
 
   // Delete the old map once all worker threads have entered their event queues, as this


### PR DESCRIPTION
Keep the new map in the stack so that it is not leaked on exception. Move-construct to the heap when exchanging for the old map.

Constructing the new `RawPolicyMap` on the stack first is both safe and efficient here. It keeps the whole update transactional: while parsing and populating the map, all temporary state remains thread-local and unpublished, so any exception simply unwinds without exposing a partially built policy map to readers. Only once the map is fully ready do we allocate the final heap object and move the finished `absl::flat_hash_map` into it for atomic publication. That move is efficient: for this `flat_hash_map<std::string, std::shared_ptr<...>>` type, Abseil’s move constructor transfers ownership of the existing backing table rather than copying or rebuilding the entries, so the extra cost at publication time is essentially just one heap allocation for the map object itself.