### PR TITLE
policy: use dispatcher-thread deletion for deferred map teardown

### DIFF
--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -22,6 +22,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
+#include "envoy/event/dispatcher_thread_deletable.h"
 #include "envoy/http/header_map.h"
 #include "envoy/init/manager.h"
 #include "envoy/network/address.h"
@@ -1843,9 +1844,6 @@ NetworkPolicyMap::NetworkPolicyMap(Server::Configuration::FactoryContext& contex
 }
 
 NetworkPolicyMap::~NetworkPolicyMap() {
-  ENVOY_LOG(debug,
-            "Cilium L7 NetworkPolicyMap: posting NetworkPolicyMapImpl deletion to main thread");
-
   // Policy map destruction happens when the last listener with the Cilium bpf_metadata listener
   // filter has drained out and is finally removed, and last connection of the old listener is
   // closed. This does not happen if new listener(s) with references to policy map are created in
@@ -1853,12 +1851,18 @@ NetworkPolicyMap::~NetworkPolicyMap() {
   //
   // Destruction of the NetworkPolicyMapImpl must be made from the main thread to ensure integrity
   // of SDS subscription management. Since this can be called from a worker thread of the last
-  // connection we must post the destruction to the main thread dispatcher.
-  //
-  // Move the NetworkPolicyMapImpl to the lambda capture so that it goes out of scope and gets
-  // deleted in the main thread.
+  // connection we must post the destruction to the main thread dispatcher in that case.
+  if (Thread::MainThread::isMainOrTestThread()) {
+    ENVOY_LOG(debug, "Cilium L7 NetworkPolicyMap: deleting NetworkPolicyMapImpl in main thread");
+    impl_.reset();
+    return;
+  }
 
-  context_.mainThreadDispatcher().post([impl = std::move(impl_)]() {});
+  ENVOY_LOG(debug,
+            "Cilium L7 NetworkPolicyMap: posting NetworkPolicyMapImpl deletion to main thread");
+
+  context_.mainThreadDispatcher().deleteInDispatcherThread(
+      Event::DispatcherThreadDeletableConstPtr(impl_.release()));
 }
 
 NetworkPolicyMapImpl::NetworkPolicyMapImpl(Server::Configuration::FactoryContext& context,

--- a/cilium/network_policy.h
+++ b/cilium/network_policy.h
@@ -17,6 +17,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/config/subscription.h"
+#include "envoy/event/dispatcher_thread_deletable.h"
 #include "envoy/http/header_map.h"
 #include "envoy/network/address.h"
 #include "envoy/protobuf/message_validator.h"
@@ -231,6 +232,7 @@ struct PolicyStats {
 using RawPolicyMap = absl::flat_hash_map<std::string, std::shared_ptr<const PolicyInstanceImpl>>;
 
 class NetworkPolicyMapImpl : public Envoy::Config::SubscriptionCallbacks,
+                             public Envoy::Event::DispatcherThreadDeletable,
                              public Logger::Loggable<Logger::Id::config> {
 public:
   NetworkPolicyMapImpl(Server::Configuration::FactoryContext& context,


### PR DESCRIPTION
Use immediate `NetworkPolicyMapImpl` destruction when the last reference is released on Envoy's main/test thread, but use `mainThreadDispatcher().deleteInDispatcherThread()` for the worker-thread case instead of posting a lambda that owns the map.

This makes the deferred teardown path use Envoy's dedicated dispatcher-thread deletion mechanism while preserving the existing main-thread destruction guarantee.

The change to destruct synchronously for test threads makes test teardown more predictable and helps avoid spurious test flakes.