### PR TITLE
build: Move capset and chmod to install-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,11 @@ $(DESTDIR)$(GLIBC_DIR): bazel-bin/cilium-envoy
 install: bazel-bin/cilium-envoy-starter bazel-bin/cilium-envoy
 	$(SUDO) $(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(SUDO) $(INSTALL) -m 0755 -T bazel-bin/cilium-envoy-starter $(DESTDIR)$(BINDIR)/cilium-envoy-starter
-	$(SUDO) setcap 'cap_net_admin,cap_bpf+pe' $(DESTDIR)$(BINDIR)/cilium-envoy-starter || true
-	$(SUDO) chmod u+s $(DESTDIR)$(BINDIR)/cilium-envoy-starter || true
 	$(SUDO) $(INSTALL) -m 0755 -T bazel-bin/cilium-envoy $(DESTDIR)$(BINDIR)/cilium-envoy
+
+install-local: install
+	$(SUDO) setcap 'cap_net_admin,cap_bpf+pe' $(DESTDIR)$(BINDIR)/cilium-envoy-starter
+	$(SUDO) chmod u+s $(DESTDIR)$(BINDIR)/cilium-envoy-starter
 
 install-glibc: install $(DESTDIR)$(GLIBC_DIR)
 	LD_LINUX=$$(basename $$(patchelf --print-interpreter bazel-bin/cilium-envoy)); \


### PR DESCRIPTION
Move setcap or chmod to install-local target to not break the production install.