### PR TITLE
tests: fix connection-close and flow-control flakes

### DIFF
--- a/tests/cilium_http_integration_test.cc
+++ b/tests/cilium_http_integration_test.cc
@@ -345,16 +345,21 @@ public:
     cleanupUpstreamAndDownstream();
   }
 
-  void deniedL3(Http::TestRequestHeaderMapImpl&& headers) {
+  void deniedL3(Http::TestRequestHeaderMapImpl&&) {
     initialize();
-    codec_client_ = makeHttpConnection(lookupPort("http"));
-    auto response = codec_client_->makeHeaderOnlyRequest(headers);
+    codec_client_ = makeL3DeniedHttpConnection();
     ASSERT_TRUE(codec_client_->waitForDisconnect());
 
-    // Validate that request access log message is logged
-    absl::optional<std::string> maybe_x_request_id;
+    // Validate that the deny access log message is logged.
     EXPECT_TRUE(expectAccessLogDeniedTo([](const ::cilium::LogEntry&) { return true; }));
     cleanupUpstreamAndDownstream();
+  }
+
+  IntegrationCodecClientPtr makeL3DeniedHttpConnection() {
+    // L3/L4 policy denial happens in the network filter during connection setup, so the reset may
+    // reach the client before Envoy's HTTP test helper observes the connection as established.
+    return makeRawHttpConnection(makeClientConnection(lookupPort("http")), absl::nullopt,
+                                 absl::nullopt, /*wait_till_connected=*/false);
   }
 
   void accepted(Http::TestRequestHeaderMapImpl&& headers) {
@@ -996,9 +1001,7 @@ TEST_P(CiliumIntegrationPortRangeTest, InvalidRange) {
 
   // This would normally be allowed, but since the policy fails, everything will
   // be rejected.
-  Http::TestRequestHeaderMapImpl headers = {
-      {":method", "GET"}, {":path", "/allowed"}, {":authority", "host"}};
-  codec_client_ = makeHttpConnection(lookupPort("http"));
+  codec_client_ = makeL3DeniedHttpConnection();
   ASSERT_TRUE(codec_client_->waitForDisconnect());
   cleanupUpstreamAndDownstream();
 }

--- a/tests/cilium_websocket_codec_integration_test.cc
+++ b/tests/cilium_websocket_codec_integration_test.cc
@@ -223,11 +223,12 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketLargeWrite) {
       test_server_->counter("tcp.tcp_stats.downstream_flow_control_paused_reading_total")->value();
   uint32_t downstream_resumes =
       test_server_->counter("tcp.tcp_stats.downstream_flow_control_resumed_reading_total")->value();
-  // Since we are receiving early data, downstream connection will already be read
-  // disabled so downstream pause metric is not emitted when upstream buffer hits high
-  // watermark. When the upstream buffer watermark goes down, downstream will be read
-  // enabled and downstream resume metric will be emitted.
-  EXPECT_EQ(downstream_pauses, 0);
+  // Early data usually has downstream reads disabled before the upstream buffer hits high
+  // watermark, which suppresses the downstream pause metric. If scheduling lets the pause
+  // happen first, it must still be balanced by the resume below.
+  EXPECT_TRUE(downstream_pauses == 0 || downstream_pauses == downstream_resumes)
+      << "downstream pauses: " << downstream_pauses
+      << ", downstream resumes: " << downstream_resumes;
   EXPECT_EQ(downstream_resumes, 1);
 }
 

--- a/tests/cilium_websocket_encap_integration_test.cc
+++ b/tests/cilium_websocket_encap_integration_test.cc
@@ -195,10 +195,11 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketHandshakeNonHTTPResponse) 
                                               "world"));
   ASSERT_TRUE(fake_upstream_connection->close());
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
-  tcp_client->waitForHalfClose();
-  tcp_client->close();
-
   test_server_->waitForCounterGe("websocket.handshake_not_http", 1);
+
+  // Handshake errors close the downstream with NoFlush, which may be observed as either a
+  // graceful FIN or an RST. The counter above is the behavior under test.
+  tcp_client->close();
 }
 
 static const char HANDSHAKE_RESPONSE_FMT[] =
@@ -227,7 +228,8 @@ TEST_P(CiliumWebSocketIntegrationTest, CiliumWebSocketHandshakeInvalidResponse) 
 
   test_server_->waitForCounterGe("websocket.handshake_invalid_websocket_response", 1);
 
-  tcp_client->waitForHalfClose();
+  // Handshake errors close the downstream with NoFlush, which may be observed as either a
+  // graceful FIN or an RST. The counter above is the behavior under test.
   tcp_client->close();
 }
 


### PR DESCRIPTION
Fix three test flakes:
- accept early L3/L4 deny resets in HTTP tests by avoiding the connected HTTP helper
- allow websocket handshake failures to close with FIN or RST
- accept balanced downstream flow-control pause/resume accounting

Found locally with:
```
CARGO_BAZEL_REPIN=true  bazel  test --platforms=//bazel:linux_aarch64 --jobs=12 --test_timeout=100 --cache_test_results=no --runs_per_test=10 //tests/...
```