### PR TITLE
fix: avoid duplicate memcached denial queueing

### DIFF
--- a/proxylib/libcilium/proxylib_memcached_test.go
+++ b/proxylib/libcilium/proxylib_memcached_test.go
@@ -713,6 +713,14 @@ var binaryTestCases = []testCase{
 			CheckOnData(t, 1, true, false, &[][]byte{getHelloResp}, []ExpFilterOp{
 				{proxylib.PASS, len(getHelloResp)}, {proxylib.INJECT, len(binarymemcache.DeniedMsgBase)},
 			}, proxylib.OK, string(binarymemcache.DeniedMsgBase))
+
+			CheckOnData(t, 1, false, false, &[][]byte{setHello, getHello}, []ExpFilterOp{
+				{proxylib.PASS, len(setHello)}, {proxylib.DROP, len(getHello)}, {proxylib.MORE, 24},
+			}, proxylib.OK, "")
+
+			CheckOnData(t, 1, true, false, &[][]byte{getHelloResp}, []ExpFilterOp{
+				{proxylib.PASS, len(getHelloResp)}, {proxylib.INJECT, len(binarymemcache.DeniedMsgBase)},
+			}, proxylib.OK, string(binarymemcache.DeniedMsgBase))
 		},
 	},
 }

--- a/proxylib/memcached/binary/parser.go
+++ b/proxylib/memcached/binary/parser.go
@@ -121,8 +121,6 @@ func (p *Parser) OnData(reply, endStream bool, dataBuffers [][]byte) (proxylib.O
 		p.injectQueue = append(p.injectQueue, queuedInject{magic, p.requestCount})
 	}
 
-	p.injectQueue = append(p.injectQueue, queuedInject{magic, p.requestCount})
-
 	p.connection.Log(cilium.EntryType_Denied, logEntry)
 	return proxylib.DROP, int(bodyLength + headerSize)
 }


### PR DESCRIPTION
Fixes a small binary memcached parser bug.

When a denied request had to wait behind an earlier allowed response, the parser queued that denied response twice. First one got injected, but the stale duplicate stayed at the front of the queue. After that, the next delayed denial could get stuck behind it. tiny thing, but yeah, not great.

How to reproduce the bug on the old code:

1. send an allowed binary memcached request
2. send a denied binary memcached request
3. receive the allowed response, this injects the first denial
4. repeat allowed + denied
5. receive the allowed response again

Expected: second denial gets injected too.
Actual before this patch: only the allowed response passes, no inject. oops.

Added that sequence to the existing memcached test, so it fails before the fix and passes after.

Tested:

```
go test ./proxylib/... -count=1
```