### PR TITLE
ci: define runner fallback on ci-tests.yaml

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -38,7 +38,7 @@ jobs:
   tests:
     timeout-minutes: 360
     name: Run integration tests on amd64
-    runs-on: ${{ vars.PROXY_BUILD_GITHUB_RUNNER }}
+    runs-on: ${{ vars.PROXY_BUILD_GITHUB_RUNNER || 'oracle-vm-32cpu-128gb-x86-64' }}
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0


### PR DESCRIPTION
Currently, ci-tests.yaml fails no runner is defined.

```
Error when evaluating 'runs-on' for job 'tests'. .github/workflows/ci-tests.yaml (Line: 41, Col: 14): Unexpected value ''
```

The reason is that the runner is defined as GH action variable that isn't in the context for workflows that run with `pull_request` (which is the case for `ci-tests.yaml`).

Therefore, this commit adds a fallback runner. Unfortunately this comes with a maintenance burden of periodically updating that value if necessary.

See https://github.com/cilium/proxy/actions/runs/25546244582