### PR TITLE
build: Pass --force_pic to bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,10 @@ import %workspace%/envoy.bazelrc
 build --incompatible_enable_cc_toolchain_resolution
 build --platform_mappings=bazel/platform_mappings
 
+# envoy.bazelrc always sets -fPIC, tell bazel about it to suppress building both .o and .pic.o
+# objects from the same C++ sources.
+build --force_pic
+
 # Enable path normalization by default.
 # See: https://github.com/envoyproxy/envoy/pull/6519
 build --define path_normalization_by_default=true


### PR DESCRIPTION
We already pass the `-fPIC` option in `envoy.bazelrc` (`build:linux --copt=-fPIC`) to the compiler, but Bazel does not know about it and still builds both `.pic.o` and `.o` objects. Passing `--force_pic` to Bazel suppresses the `.o` compilation and saves build time.

Noticed when non-test sources (such as `source/common/network/address_impl.cc`) were compiled for tests right after cilium-envoy was built. With the `--force_pic` option the tests build shows building only test files.