### PR TITLE
bpf_metadata: Override unimplemented Delta xDS in npds_config

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -241,6 +241,19 @@ Config::Config(const ::cilium::BpfMetadata& config,
       random_(context.serverFactoryContext().api().randomGenerator()),
       npds_config_(config.has_npds_config() ? config.npds_config()
                                             : Cilium::CILIUM_XDS_API_CONFIG) {
+  // Delta xDS is not yet supported, override if present.
+  // This is needed for upgrade/downgrade compatibility.
+  if (npds_config_.config_source_specifier_case() ==
+      envoy::config::core::v3::ConfigSource::kApiConfigSource) {
+    const auto& api_type = npds_config_.api_config_source().api_type();
+    if (api_type == envoy::config::core::v3::ApiConfigSource::DELTA_GRPC) {
+      npds_config_.mutable_api_config_source()->set_api_type(
+          envoy::config::core::v3::ApiConfigSource::GRPC);
+    } else if (api_type == envoy::config::core::v3::ApiConfigSource::AGGREGATED_DELTA_GRPC) {
+      npds_config_.mutable_api_config_source()->set_api_type(
+          envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC);
+    }
+  }
   if (is_l7lb_ && is_ingress_) {
     throw EnvoyException("cilium.bpf_metadata: is_l7lb may not be set with is_ingress");
   }

--- a/tests/bpf_metadata_config_test.cc
+++ b/tests/bpf_metadata_config_test.cc
@@ -232,6 +232,26 @@ TEST_F(MetadataConfigTest, NpdsConfigSupported) {
   EXPECT_NO_THROW(initialize(config));
 }
 
+TEST_F(MetadataConfigTest, NpdsConfigDowngradesDeltaGrpcToSotw) {
+  ::cilium::BpfMetadata config{};
+  config.mutable_npds_config()->mutable_api_config_source()->set_api_type(
+      envoy::config::core::v3::ApiConfigSource::DELTA_GRPC);
+
+  EXPECT_NO_THROW(initialize(config));
+  EXPECT_EQ(envoy::config::core::v3::ApiConfigSource::GRPC,
+            config_->npds_config_.api_config_source().api_type());
+}
+
+TEST_F(MetadataConfigTest, NpdsConfigDowngradesAggregatedDeltaGrpcToSotw) {
+  ::cilium::BpfMetadata config{};
+  config.mutable_npds_config()->mutable_api_config_source()->set_api_type(
+      envoy::config::core::v3::ApiConfigSource::AGGREGATED_DELTA_GRPC);
+
+  EXPECT_NO_THROW(initialize(config));
+  EXPECT_EQ(envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC,
+            config_->npds_config_.api_config_source().api_type());
+}
+
 TEST_F(MetadataConfigTest, EmptyConfig) {
   ::cilium::BpfMetadata config{};
 


### PR DESCRIPTION
We do not yet implement Delta xDS so downgrade it to SotW in npds_config. This is needed for upgrade/downgrade support, where an upgraded agent may ask an v1.36 proxy to use Delta xDS. When this is done without this downgrade, Delta SDS will be used for Secrets referenced in the network policy. The Delta mode for SDS then remains stuck for the lifetime of the proxy, even if Cilium Agent later downgrades to a version that does not implement Delta SDS.