### PR TITLE
fix: prevent index-out-of-bounds panics in text memcached parser

### DIFF
--- a/proxylib/libcilium/proxylib_memcached_test.go
+++ b/proxylib/libcilium/proxylib_memcached_test.go
@@ -571,6 +571,39 @@ var textTestCases = []testCase{
 			}, proxylib.OK, "")
 		},
 	},
+	{
+		"text empty command line returns error",
+		"",
+		func(t *testing.T) {
+			CheckOnData(t, 1, false, false, &[][]byte{[]byte("\r\n")}, []ExpFilterOp{},
+				proxylib.PARSER_ERROR, "")
+		},
+	},
+	{
+		"text malformed storage command returns error",
+		"",
+		func(t *testing.T) {
+			// storage command missing flags/exptime/bytes fields
+			CheckOnData(t, 1, false, false, &[][]byte{[]byte("set key\r\n")}, []ExpFilterOp{},
+				proxylib.PARSER_ERROR, "")
+		},
+	},
+	{
+		"text malformed delete command returns error",
+		"",
+		func(t *testing.T) {
+			CheckOnData(t, 1, false, false, &[][]byte{[]byte("delete\r\n")}, []ExpFilterOp{},
+				proxylib.PARSER_ERROR, "")
+		},
+	},
+	{
+		"text malformed gat command returns error",
+		"",
+		func(t *testing.T) {
+			CheckOnData(t, 1, false, false, &[][]byte{[]byte("gat\r\n")}, []ExpFilterOp{},
+				proxylib.PARSER_ERROR, "")
+		},
+	},
 }
 
 var binaryTestCases = []testCase{

--- a/proxylib/memcached/text/parser.go
+++ b/proxylib/memcached/text/parser.go
@@ -87,6 +87,11 @@ func (p *Parser) OnData(reply, endStream bool, dataBuffers [][]byte) (proxylib.O
 	// Tokenizing in memcached is done by spaces: https://github.com/memcached/memcached/blob/master/memcached.c#L2978
 	tokens := bytes.Fields(data[:linefeed])
 
+	if len(tokens) == 0 {
+		logrus.Error("Could not parse text memcache frame: empty command line")
+		return proxylib.ERROR, 0
+	}
+
 	if !reply {
 		meta := meta.MemcacheMeta{
 			Command: string(tokens[0]),
@@ -101,10 +106,18 @@ func (p *Parser) OnData(reply, endStream bool, dataBuffers [][]byte) (proxylib.O
 			if bytes.HasPrefix(command, []byte("get")) {
 				meta.Keys = tokens[1:]
 			} else if bytes.HasPrefix(command, []byte("gat")) {
+				if len(tokens) < 2 {
+					logrus.Error("Could not parse text memcache gat command: missing exptime")
+					return proxylib.ERROR, 0
+				}
 				meta.Keys = tokens[2:]
 			}
 		case p.isCommandStorage(command):
-			// storage commands
+			// storage commands: <cmd> <key> <flags> <exptime> <bytes> [noreply]
+			if len(tokens) < 5 {
+				logrus.Error("Could not parse text memcache storage command: too few tokens")
+				return proxylib.ERROR, 0
+			}
 			meta.Keys = tokens[1:2]
 			nBytes, err := strconv.Atoi(string(tokens[4]))
 			if err != nil {
@@ -120,12 +133,24 @@ func (p *Parser) OnData(reply, endStream bool, dataBuffers [][]byte) (proxylib.O
 				hasNoreply = len(tokens) == storageWithNoreplyFields
 			}
 		case p.isCommandDelete(command):
+			if len(tokens) < 2 {
+				logrus.Error("Could not parse text memcache delete command: missing key")
+				return proxylib.ERROR, 0
+			}
 			meta.Keys = tokens[1:2]
 			hasNoreply = len(tokens) == deleteWithNoreplyFields
 		case p.isCommandIncrDecr(command):
+			if len(tokens) < 2 {
+				logrus.Error("Could not parse text memcache incr/decr command: missing key")
+				return proxylib.ERROR, 0
+			}
 			meta.Keys = tokens[1:2]
 			hasNoreply = len(tokens) == incrWithNoreplyFields
 		case bytes.Equal(command, []byte("touch")):
+			if len(tokens) < 2 {
+				logrus.Error("Could not parse text memcache touch command: missing key")
+				return proxylib.ERROR, 0
+			}
 			meta.Keys = tokens[1:2]
 			hasNoreply = len(tokens) == touchWithNoreplyFields
 		case bytes.Equal(command, []byte("slabs")),
@@ -190,6 +215,10 @@ func (p *Parser) OnData(reply, endStream bool, dataBuffers [][]byte) (proxylib.O
 	//reply
 	logrus.Debugf("reply, parsing to figure out if we have it all")
 
+	if len(p.replyQueue) == 0 {
+		logrus.Error("Unexpected text memcache reply: no pending request in queue")
+		return proxylib.ERROR, 0
+	}
 	intent := p.replyQueue[0]
 
 	logEntry := &cilium.LogEntry_GenericL7{


### PR DESCRIPTION
text memcached parser panics on malformed input. any client can trigger it by sending `\r\n` (empty command) or a truncated storage command like `set key\r\n` (missing fields).

root cause: `OnData` tokenizes with `bytes.Fields` but never checks if the result is empty before accessing `tokens[0]`. same story for per-command token counts - storage needs 5 tokens, no guard exists. `replyQueue[0]` is also read without checking if the queue is empty, so an unexpected server reply hits the same fate.

fix: add `len` checks before each unsafe slice access, return `proxylib.ERROR` instead of panicking. added 4 test cases covering the crash paths (empty command, truncated storage/delete/gat).

how to reproduce (before fix):

```go
// in proxylib/libcilium/proxylib_memcached_test.go, add to textTestCases:
CheckOnData(t, 1, false, false, &[][]byte{[]byte("\r\n")}, ...)
// -> panic: runtime error: index out of range [0] with length 0
```

or just run:

```
go test ./proxylib/... -run TestMemcache/text_empty_command_line_returns_error
```

related: #1889