### PR TITLE
gh: Bump clang tidy timeout to 2 hours

### DIFF
--- a/.github/workflows/ci-check-format.yaml
+++ b/.github/workflows/ci-check-format.yaml
@@ -61,7 +61,7 @@ jobs:
           retention-days: 5
 
   tidy:
-    timeout-minutes: 60
+    timeout-minutes: 120
     name: Lint source style
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Clang tidy is very slow, and we have hit the 1 hour timeout on the GH action on large PRs. Bump the timeout to 2 hour so that even larger PRs can get throught the workflow.