### PR TITLE
gh: Use builder runner for clang tidy job

### DIFF
--- a/.github/workflows/ci-check-format.yaml
+++ b/.github/workflows/ci-check-format.yaml
@@ -63,7 +63,7 @@ jobs:
   tidy:
     timeout-minutes: 120
     name: Lint source style
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.PROXY_BUILD_GITHUB_RUNNER || 'oracle-vm-32cpu-128gb-x86-64' }}
     steps:
       - name: Checkout PR Source Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Clang tidy needs a beefier runner.