### PR TITLE
npds: skip GrpcMuxImpl stream detection in ADS mode

### DIFF
--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -182,6 +182,13 @@ public:
 
 protected:
   bool isNewStream() const {
+    // In ADS mode, policies arrive over the shared ADS stream managed by the
+    // Cilium agent. Stream reconnection detection is not needed because an
+    // agent restart recreates everything including the ipcache.
+    if (config_source_.config_source_specifier_case() ==
+        envoy::config::core::v3::ConfigSource::kAds) {
+      return false;
+    }
     auto sub = dynamic_cast<Config::GrpcSubscriptionImpl*>(subscription_.get());
     if (!sub) {
       ENVOY_LOG(error, "Cilium NetworkPolicyMapImpl: Cannot get GrpcSubscriptionImpl");

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -344,6 +344,7 @@ envoy_cc_test(
         "@envoy//source/extensions/filters/network/tcp_proxy:config",
         "@envoy//test/common/grpc:grpc_client_integration_lib",
         "@envoy//test/integration:integration_lib",
+        "@envoy//test/test_common:logging_lib",
         "@envoy//test/test_common:resources_lib",
         "@envoy//test/test_common:utility_lib",
     ],

--- a/tests/bpf_metadata_integration_test.cc
+++ b/tests/bpf_metadata_integration_test.cc
@@ -19,8 +19,11 @@
 #include "test/config/utility.h"
 #include "test/integration/base_integration_test.h"
 #include "test/integration/fake_upstream.h"
+#include "test/test_common/logging.h"
 #include "test/test_common/resources.h"
 #include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
 
 #include "cilium/api/bpf_metadata.pb.h"
 #include "cilium/api/npds.pb.h"
@@ -265,6 +268,45 @@ TEST_P(BpfMetadataIntegrationTest, BpfMetadataWithNpdsAndNpdhsViaAds) {
   test_server_->waitForCounterGe("cilium.policy.update_success", 1);
   sendNphdsResponse("1");
   test_server_->waitForCounterGe("cilium.hostmap.update_success", 1);
+}
+
+// Verify that when using ADS for NPDS, the isNewStream() early return prevents
+// the "Cannot get GrpcMuxImpl" error that would occur when trying to downcast
+// the ADS mux to Cilium::GrpcMuxImpl.
+TEST_P(BpfMetadataIntegrationTest, AdsNpdsUpdateDoesNotLogGrpcMuxImplError) {
+  on_server_init_function_ = [&]() {
+    createAdsStream();
+    addBpfMetadataListenerFilter(listener_config_, /*use_ads=*/true);
+    EXPECT_TRUE(compareDiscoveryRequest(
+        Config::TestTypeUrl::get().Cluster, "", {}, {}, {},
+        /*expect_node=*/true, Envoy::Grpc::Status::WellKnownGrpcStatus::Ok, "", ads_stream_.get()));
+    sendCdsResponse("1");
+    EXPECT_TRUE(compareDiscoveryRequest(
+        Config::TestTypeUrl::get().Listener, "", {}, {}, {}, /*expect_node=*/false,
+        Grpc::Status::WellKnownGrpcStatus::Ok, "", ads_stream_.get()));
+    sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "1");
+  };
+  initialize();
+
+  test_server_->waitForCounterGe("listener_manager.lds.update_success", 1);
+
+  // Start recording logs to verify no "Cannot get GrpcMuxImpl" error appears.
+  LogLevelSetter save_levels(spdlog::level::trace);
+  StartStopRecording recording(GetLogSink());
+
+  // Send multiple NPDS updates to exercise the isNewStream() code path repeatedly.
+  sendNpdsResponse("1");
+  test_server_->waitForCounterGe("cilium.policy.update_success", 1);
+
+  sendNpdsResponse("2");
+  test_server_->waitForCounterGe("cilium.policy.update_success", 2);
+
+  // Verify no "Cannot get GrpcMuxImpl" or "Cannot get GrpcSubscriptionImpl" error was logged.
+  // In ADS mode, isNewStream() should return false immediately without attempting the downcast.
+  for (const std::string& message : recording.messages()) {
+    EXPECT_THAT(message, ::testing::Not(::testing::HasSubstr("Cannot get GrpcMuxImpl")));
+    EXPECT_THAT(message, ::testing::Not(::testing::HasSubstr("Cannot get GrpcSubscriptionImpl")));
+  }
 }
 
 } // namespace


### PR DESCRIPTION
In ADS mode, the NPDS subscription uses the shared ADS mux instead of a dedicated `GrpcMuxImpl`. The `isNewStream()` method tries to dynamic_cast to `GrpcMuxImpl`, which fails and logs an error on every policy update:

```
/Users/knezdoli/Downloads/cilium-sysdumps-Installation and Connectivity Test (ads)/cilium-sysdump-20260603-142243/logs-cilium-6mdfw-cilium-agent-20260603-142243.log:16827:2026-06-03T14:23:46.443818481Z time=2026-06-03T14:23:46.443739211Z level=error source=/go/src/github.com/cilium/cilium/pkg/envoy/standalone_envoy.go:329 msg="[Cilium NetworkPolicyMapImpl: Cannot get GrpcMuxImpl" module=agent.controlplane.envoy-proxy subsys=envoy-config threadID=983
/Users/knezdoli/Downloads/cilium-sysdumps-Installation and Connectivity Test (ads)/cilium-sysdump-20260603-142243/logs-cilium-6mdfw-cilium-agent-20260603-142243.log:17140:2026-06-03T14:23:46.469932586Z time=2026-06-03T14:23:46.46953724Z level=error source=/go/src/github.com/cilium/cilium/pkg/envoy/standalone_envoy.go:329 msg="[Cilium NetworkPolicyMapImpl: Cannot get GrpcMuxImpl" module=agent.controlplane.envoy-proxy subsys=envoy-config threadID=983
```

While the failure does not have impact on ADS delivery of resources, it triggers connectivity test failures in cilium repository, when ci tools grep for any error level logs and fail entire CI run.

`isNewStream()` detects dedicated NPDS stream reconnects to reopen ipcache after agent restarts. In ADS mode this is unnecessary since the ADS server runs inside the agent; a restart recreates everything.