### PR TITLE
chore: replace absl::optional/nullopt with std equivalents

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -37,7 +38,6 @@
 #include "source/common/protobuf/utility.h"
 
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include "cilium/api/bpf_metadata.pb.h"
 #include "cilium/api/bpf_metadata.pb.validate.h" // IWYU pragma: keep
 #include "cilium/conntrack.h"
@@ -390,7 +390,7 @@ const PolicyInstance& Config::getPolicy(const std::string& pod_ip) const {
 
 bool Config::exists(const std::string& pod_ip) const { return npmap_->exists(pod_ip); }
 
-absl::optional<Cilium::BpfMetadata::SocketMetadata>
+std::optional<Cilium::BpfMetadata::SocketMetadata>
 Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
   Network::Address::InstanceConstSharedPtr src_address =
       socket.connectionInfoProvider().remoteAddress();
@@ -403,7 +403,7 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
   if (!sip || !dip) {
     ENVOY_LOG(debug, "Non-IP addresses: src: {} dst: {}", src_address->asString(),
               dst_address->asString());
-    return absl::nullopt;
+    return std::nullopt;
   }
 
   std::string pod_ip, other_ip, ingress_policy_name;
@@ -452,7 +452,7 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
                 "cilium.bpf_metadata (east/west L7 LB): Non-local pod can not use original "
                 "source address: {}",
                 pod_ip);
-      return absl::nullopt;
+      return std::nullopt;
     }
     // Use original source address with L7 LB for local endpoint sources if requested, as policy
     // enforcement after the proxy depends on it (i.e., for "east/west" LB).
@@ -472,7 +472,7 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
           "cilium.bpf_metadata (north/south L7 LB): No local Ingress IP source address configured "
           "for the family of {}",
           sip->addressAsString());
-      return absl::nullopt;
+      return std::nullopt;
     }
 
     // Enforce pod policy only for local pods.
@@ -495,7 +495,7 @@ Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
                 "cilium.bpf_metadata (north/south L7 LB): Unknown local Ingress IP source address "
                 "configured: {}",
                 ingress_ip->addressAsString());
-      return absl::nullopt;
+      return std::nullopt;
     }
 
     // Original source address is never used for north/south LB

--- a/cilium/bpf_metadata.h
+++ b/cilium/bpf_metadata.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -18,7 +19,6 @@
 #include "source/common/common/logger.h"
 
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include "cilium/api/bpf_metadata.pb.h"
 #include "cilium/conntrack.h"
 #include "cilium/filter_state_cilium_destination.h"
@@ -156,7 +156,7 @@ public:
   const PolicyInstance& getPolicy(const std::string&) const override;
   bool exists(const std::string&) const override;
 
-  virtual absl::optional<SocketMetadata> extractSocketMetadata(Network::ConnectionSocket& socket);
+  virtual std::optional<SocketMetadata> extractSocketMetadata(Network::ConnectionSocket& socket);
 
   // Possibility to prevent socket options that require
   // NET_ADMIN privileges from being applied. Used by tests.

--- a/cilium/grpc_subscription.cc
+++ b/cilium/grpc_subscription.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -38,7 +39,6 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -176,8 +176,8 @@ void ManagedGrpcSubscription::create() {
         rate_limit_settings_or_error.value(),
         *scope_,
         std::move(nop_config_validators),
-        /*xds_resources_delegate_=*/absl::nullopt,
-        /*xds_config_tracker_=*/absl::nullopt,
+        /*xds_resources_delegate_=*/std::nullopt,
+        /*xds_config_tracker_=*/std::nullopt,
         std::make_unique<JitteredExponentialBackOffStrategy>(
             Config::SubscriptionFactory::RetryInitialDelayMs,
             Config::SubscriptionFactory::RetryMaxDelayMs, context_.api().randomGenerator()),

--- a/cilium/l7policy.cc
+++ b/cilium/l7policy.cc
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -31,7 +32,6 @@
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include "cilium/accesslog.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/api/l7policy.pb.h"
@@ -98,7 +98,7 @@ void AccessFilter::onDestroy() {}
 
 void AccessFilter::sendLocalError(absl::string_view details) {
   ENVOY_LOG(warn, details);
-  callbacks_->sendLocalReply(Http::Code::InternalServerError, "", nullptr, absl::nullopt,
+  callbacks_->sendLocalReply(Http::Code::InternalServerError, "", nullptr, std::nullopt,
                              StringUtil::replaceAllEmptySpace(details));
 }
 
@@ -202,7 +202,7 @@ Http::FilterHeadersStatus AccessFilter::decodeHeaders(Http::RequestHeaderMap& he
       if (!allowed) {
         config_->log(*log_entry_, ::cilium::EntryType::Denied);
         callbacks_->sendLocalReply(Http::Code::Forbidden, config_->denied_403_body_, nullptr,
-                                   absl::nullopt, absl::string_view());
+                                   std::nullopt, absl::string_view());
         return Http::FilterHeadersStatus::StopIteration;
       }
 
@@ -272,7 +272,7 @@ Http::FilterHeadersStatus AccessFilter::decodeHeaders(Http::RequestHeaderMap& he
       if (!allowed) {
         config_->log(*log_entry_, ::cilium::EntryType::Denied);
         callbacks_->sendLocalReply(Http::Code::Forbidden, config_->denied_403_body_, nullptr,
-                                   absl::nullopt, absl::string_view());
+                                   std::nullopt, absl::string_view());
         return Http::FilterHeadersStatus::StopIteration;
       }
     }
@@ -288,7 +288,7 @@ Http::FilterHeadersStatus AccessFilter::decodeHeaders(Http::RequestHeaderMap& he
       if (!allowed) {
         config_->log(*log_entry_, ::cilium::EntryType::Denied);
         callbacks_->sendLocalReply(Http::Code::Forbidden, config_->denied_403_body_, nullptr,
-                                   absl::nullopt, absl::string_view());
+                                   std::nullopt, absl::string_view());
         return Http::FilterHeadersStatus::StopIteration;
       }
     }

--- a/cilium/l7policy.h
+++ b/cilium/l7policy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "envoy/buffer/buffer.h"
@@ -15,7 +16,6 @@
 #include "source/common/common/logger.h"
 
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include "cilium/accesslog.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/api/l7policy.pb.h"
@@ -114,7 +114,7 @@ private:
   AccessLog::Entry* log_entry_ = nullptr;
 
   OptRef<Http::RequestHeaderMap> latched_headers_;
-  absl::optional<bool> latched_end_stream_;
+  std::optional<bool> latched_end_stream_;
 };
 
 } // namespace Cilium

--- a/cilium/socket_option_cilium_mark.h
+++ b/cilium/socket_option_cilium_mark.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "envoy/config/core/v3/socket_option.pb.h"
 #include "envoy/network/socket.h"
 
 #include "source/common/common/logger.h"
-
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -21,10 +20,10 @@ class CiliumMarkSocketOption : public Network::Socket::Option,
                                public Logger::Loggable<Logger::Id::filter> {
 public:
   CiliumMarkSocketOption(uint32_t mark);
-  absl::optional<Network::Socket::Option::Details>
+  std::optional<Network::Socket::Option::Details>
   getOptionDetails(const Network::Socket&,
                    envoy::config::core::v3::SocketOption::SocketState) const override {
-    return absl::nullopt;
+    return std::nullopt;
   }
 
   bool setOption(Network::Socket& socket,

--- a/cilium/socket_option_ip_transparent.h
+++ b/cilium/socket_option_ip_transparent.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "envoy/config/core/v3/socket_option.pb.h"
 #include "envoy/network/socket.h"
 
 #include "source/common/common/logger.h"
-
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Cilium {
@@ -21,10 +20,10 @@ class IpTransparentSocketOption : public Network::Socket::Option,
 public:
   IpTransparentSocketOption();
 
-  absl::optional<Network::Socket::Option::Details>
+  std::optional<Network::Socket::Option::Details>
   getOptionDetails(const Network::Socket&,
                    envoy::config::core::v3::SocketOption::SocketState) const override {
-    return absl::nullopt;
+    return std::nullopt;
   }
 
   bool setOption(Network::Socket& socket,

--- a/cilium/socket_option_source_address.h
+++ b/cilium/socket_option_source_address.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "envoy/config/core/v3/socket_option.pb.h"
@@ -10,7 +11,6 @@
 
 #include "source/common/common/logger.h"
 
-#include "absl/types/optional.h"
 #include "cilium/filter_state_cilium_destination.h"
 #include "cilium/filter_state_cilium_policy.h"
 
@@ -33,10 +33,10 @@ public:
       std::shared_ptr<CiliumDestinationFilterState> dest_fs = nullptr,
       std::shared_ptr<CiliumPolicyFilterState> policy_fs = nullptr);
 
-  absl::optional<Network::Socket::Option::Details>
+  std::optional<Network::Socket::Option::Details>
   getOptionDetails(const Network::Socket&,
                    envoy::config::core::v3::SocketOption::SocketState) const override {
-    return absl::nullopt;
+    return std::nullopt;
   }
 
   bool setOption(Network::Socket& socket,

--- a/tests/accesslog_server.cc
+++ b/tests/accesslog_server.cc
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <functional>
+#include <optional>
 #include <string>
 
 #include "source/common/common/logger.h"
@@ -9,7 +10,6 @@
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include "cilium/api/accesslog.pb.h"
 #include "tests/uds_server.h"
 
@@ -27,10 +27,10 @@ void AccessLogServer::clear() {
   messages_.clear();
 }
 
-absl::optional<::cilium::LogEntry>
+std::optional<::cilium::LogEntry>
 AccessLogServer::waitForMessage(::cilium::EntryType entry_type, std::chrono::milliseconds timeout) {
   absl::MutexLock lock(&mutex_);
-  absl::optional<::cilium::LogEntry> entry;
+  std::optional<::cilium::LogEntry> entry;
   auto predicate = [this, &entry, entry_type]() ABSL_SHARED_LOCKS_REQUIRED(mutex_) {
     mutex_.AssertHeld();
     for (auto& msg : messages_) {

--- a/tests/accesslog_server.h
+++ b/tests/accesslog_server.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -8,7 +9,6 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
-#include "absl/types/optional.h"
 #include "cilium/api/accesslog.pb.h"
 #include "tests/uds_server.h"
 
@@ -20,7 +20,7 @@ public:
   ~AccessLogServer() override;
 
   void clear();
-  absl::optional<::cilium::LogEntry>
+  std::optional<::cilium::LogEntry>
   waitForMessage(::cilium::EntryType entry_type,
                  std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 

--- a/tests/bpf_metadata.cc
+++ b/tests/bpf_metadata.cc
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -26,7 +27,6 @@
 #include "test/test_common/environment.h"
 
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include "cilium/api/bpf_metadata.pb.h"
 #include "cilium/bpf_metadata.h"
 #include "cilium/host_map.h"
@@ -164,7 +164,7 @@ TestConfig::~TestConfig() {
   npmap.reset();
 }
 
-absl::optional<Cilium::BpfMetadata::SocketMetadata>
+std::optional<Cilium::BpfMetadata::SocketMetadata>
 TestConfig::extractSocketMetadata(Network::ConnectionSocket& socket) {
   // TLS filter chain matches this, make namespace part of this (e.g.,
   // "default")?

--- a/tests/bpf_metadata.h
+++ b/tests/bpf_metadata.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -9,7 +10,6 @@
 #include "envoy/network/listen_socket.h"
 #include "envoy/server/factory_context.h"
 
-#include "absl/types/optional.h"
 #include "cilium/bpf_metadata.h"
 #include "cilium/host_map.h"
 #include "cilium/network_policy.h"
@@ -47,7 +47,7 @@ public:
              Server::Configuration::ListenerFactoryContext& context);
   ~TestConfig() override;
 
-  absl::optional<Cilium::BpfMetadata::SocketMetadata>
+  std::optional<Cilium::BpfMetadata::SocketMetadata>
   extractSocketMetadata(Network::ConnectionSocket& socket) override;
 
   // Prevent socket options that require NET_ADMIN privileges from being applied during test

--- a/tests/cilium_http_integration.h
+++ b/tests/cilium_http_integration.h
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -16,7 +17,6 @@
 #include "test/integration/http_integration.h"
 #include "test/test_common/utility.h"
 
-#include "absl/types/optional.h"
 #include "cilium/api/accesslog.pb.h"
 #include "tests/accesslog_server.h"
 
@@ -41,7 +41,7 @@ public:
     return std::vector<std::pair<std::string, std::string>>{};
   }
 
-  absl::optional<::cilium::LogEntry>
+  std::optional<::cilium::LogEntry>
   waitForAccessLogMessage(::cilium::EntryType entry_type,
                           std::chrono::milliseconds timeout = TestUtility::DefaultTimeout) {
     return accessLogServer_.waitForMessage(entry_type, timeout);
@@ -59,7 +59,7 @@ public:
     return accessLogServer_.expectDeniedTo(pred);
   }
 
-  static absl::optional<std::string>
+  static std::optional<std::string>
   getHeader(const Protobuf::RepeatedPtrField<::cilium::KeyValue>& headers,
             const std::string& name) {
     for (const auto& entry : headers) {
@@ -67,7 +67,7 @@ public:
         return entry.value();
       }
     }
-    return absl::nullopt;
+    return std::nullopt;
   }
 
   static bool hasHeader(const Protobuf::RepeatedPtrField<::cilium::KeyValue>& headers,

--- a/tests/cilium_http_integration_test.cc
+++ b/tests/cilium_http_integration_test.cc
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -28,7 +29,6 @@
 
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/host_map.h"
 #include "cilium/secret_watcher.h"
@@ -323,7 +323,7 @@ public:
     ASSERT_TRUE(response->waitForEndStream());
 
     // Validate that request access log message with x-request-id is logged
-    absl::optional<std::string> maybe_x_request_id;
+    std::optional<std::string> maybe_x_request_id;
     EXPECT_TRUE(expectAccessLogDeniedTo([&maybe_x_request_id](const ::cilium::LogEntry& entry) {
       maybe_x_request_id = getHeader(entry.http().headers(), "x-request-id");
       return entry.http().status() == 0;
@@ -331,7 +331,7 @@ public:
     ASSERT_TRUE(maybe_x_request_id.has_value());
 
     // Validate that response x-request-id is the same as in request
-    absl::optional<std::string> maybe_x_request_id_resp;
+    std::optional<std::string> maybe_x_request_id_resp;
     EXPECT_TRUE(
         expectAccessLogResponseTo([&maybe_x_request_id_resp](const ::cilium::LogEntry& entry) {
           maybe_x_request_id_resp = getHeader(entry.http().headers(), "x-request-id");
@@ -358,8 +358,8 @@ public:
   IntegrationCodecClientPtr makeL3DeniedHttpConnection() {
     // L3/L4 policy denial happens in the network filter during connection setup, so the reset may
     // reach the client before Envoy's HTTP test helper observes the connection as established.
-    return makeRawHttpConnection(makeClientConnection(lookupPort("http")), absl::nullopt,
-                                 absl::nullopt, /*wait_till_connected=*/false);
+    return makeRawHttpConnection(makeClientConnection(lookupPort("http")), std::nullopt,
+                                 std::nullopt, /*wait_till_connected=*/false);
   }
 
   void accepted(Http::TestRequestHeaderMapImpl&& headers) {
@@ -368,7 +368,7 @@ public:
     auto response = sendRequestAndWaitForResponse(headers, 0, default_response_headers_, 0);
 
     // Validate that request access log message with x-request-id is logged
-    absl::optional<std::string> maybe_x_request_id;
+    std::optional<std::string> maybe_x_request_id;
     EXPECT_TRUE(expectAccessLogRequestTo([&maybe_x_request_id](const ::cilium::LogEntry& entry) {
       maybe_x_request_id = getHeader(entry.http().headers(), "x-request-id");
       return entry.http().status() == 0;
@@ -376,7 +376,7 @@ public:
     ASSERT_TRUE(maybe_x_request_id.has_value());
 
     // Validate that response x-request-id is the same as in request
-    absl::optional<std::string> maybe_x_request_id_resp;
+    std::optional<std::string> maybe_x_request_id_resp;
     EXPECT_TRUE(
         expectAccessLogResponseTo([&maybe_x_request_id_resp](const ::cilium::LogEntry& entry) {
           maybe_x_request_id_resp = getHeader(entry.http().headers(), "x-request-id");

--- a/tests/cilium_http_upstream_integration_test.cc
+++ b/tests/cilium_http_upstream_integration_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -18,7 +19,6 @@
 
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include "cilium/api/accesslog.pb.h"
 #include "cilium/secret_watcher.h"
 #include "tests/bpf_metadata.h" // host_map_config
@@ -360,7 +360,7 @@ resources:
     ASSERT_TRUE(response->waitForEndStream());
 
     // Validate that request access log message with x-request-id is logged
-    absl::optional<std::string> maybe_x_request_id;
+    std::optional<std::string> maybe_x_request_id;
     EXPECT_TRUE(expectAccessLogDeniedTo([&maybe_x_request_id](const ::cilium::LogEntry& entry) {
       maybe_x_request_id = getHeader(entry.http().headers(), "x-request-id");
       return entry.http().status() == 0;
@@ -368,7 +368,7 @@ resources:
     ASSERT_TRUE(maybe_x_request_id.has_value());
 
     // Validate that response x-request-id is the same as in request
-    absl::optional<std::string> maybe_x_request_id_resp;
+    std::optional<std::string> maybe_x_request_id_resp;
     EXPECT_TRUE(
         expectAccessLogResponseTo([&maybe_x_request_id_resp](const ::cilium::LogEntry& entry) {
           maybe_x_request_id_resp = getHeader(entry.http().headers(), "x-request-id");
@@ -388,7 +388,7 @@ resources:
     auto response = sendRequestAndWaitForResponse(headers, 0, default_response_headers_, 0);
 
     // Validate that request access log message with x-request-id is logged
-    absl::optional<std::string> maybe_x_request_id;
+    std::optional<std::string> maybe_x_request_id;
     EXPECT_TRUE(expectAccessLogRequestTo([&maybe_x_request_id](const ::cilium::LogEntry& entry) {
       maybe_x_request_id = getHeader(entry.http().headers(), "x-request-id");
       return entry.http().status() == 0;
@@ -396,7 +396,7 @@ resources:
     ASSERT_TRUE(maybe_x_request_id.has_value());
 
     // Validate that response x-request-id is the same as in request
-    absl::optional<std::string> maybe_x_request_id_resp;
+    std::optional<std::string> maybe_x_request_id_resp;
     EXPECT_TRUE(
         expectAccessLogResponseTo([&maybe_x_request_id_resp](const ::cilium::LogEntry& entry) {
           maybe_x_request_id_resp = getHeader(entry.http().headers(), "x-request-id");

--- a/tests/health_check_sink_server.cc
+++ b/tests/health_check_sink_server.cc
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <functional>
+#include <optional>
 #include <string>
 
 #include "envoy/data/core/v3/health_check_event.pb.h"
@@ -11,7 +12,6 @@
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include "tests/uds_server.h"
 
 namespace Envoy {
@@ -28,7 +28,7 @@ void HealthCheckSinkServer::clear() {
   events_.clear();
 }
 
-absl::optional<envoy::data::core::v3::HealthCheckEvent>
+std::optional<envoy::data::core::v3::HealthCheckEvent>
 HealthCheckSinkServer::waitForEvent(std::chrono::milliseconds timeout) {
   absl::MutexLock lock(&mutex_);
   auto predicate = [this]() ABSL_SHARED_LOCKS_REQUIRED(mutex_) {

--- a/tests/health_check_sink_server.h
+++ b/tests/health_check_sink_server.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <list>
+#include <optional>
 #include <string>
 
 #include "envoy/data/core/v3/health_check_event.pb.h"
@@ -11,7 +12,6 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
-#include "absl/types/optional.h"
 #include "tests/uds_server.h"
 
 namespace Envoy {
@@ -22,7 +22,7 @@ public:
   ~HealthCheckSinkServer() override;
 
   void clear();
-  absl::optional<envoy::data::core::v3::HealthCheckEvent>
+  std::optional<envoy::data::core::v3::HealthCheckEvent>
   waitForEvent(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
   template <typename P>


### PR DESCRIPTION
Replaces deprecated absl::optional, absl::nullopt with std::optional and std::nullopt.

