### PR TITLE
ci: Use cilium v1.19 branch

### DIFF
--- a/.github/workflows/cilium-gateway-api.yaml
+++ b/.github/workflows/cilium-gateway-api.yaml
@@ -27,7 +27,7 @@ env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION: v0.32.0
   CILIUM_REPO_OWNER: cilium
-  CILIUM_REPO_REF: main
+  CILIUM_REPO_REF: v1.19
   CILIUM_CLI_REF: latest
   CURL_PARALLEL: ${{ vars.CURL_PARALLEL || 10 }}
 


### PR DESCRIPTION
Cilium/proxy v1.36 is used in cilium v1.19, but not main, so we should use v1.19 for testing instead.