### PR TITLE
docs: refresh README version compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,15 @@ Note: The below table is updated by script `tools/update_version_matrix.sh`
 
 | Cilium Version | Envoy version |
 |----------------|---------------|
-| (main)         | v1.36.x       |
+| (main)         | v1.37.x       |
+| v1.19.4        | v1.36.6       |
+| v1.19.3        | v1.36.6       |
+| v1.19.2        | v1.35.9       |
+| v1.19.1        | v1.35.9       |
 | v1.19.0        | v1.35.9       |
+| v1.18.10       | v1.36.6       |
+| v1.18.9        | v1.36.6       |
+| v1.18.8        | v1.35.9       |
 | v1.18.7        | v1.35.9       |
 | v1.18.6        | v1.35.9       |
 | v1.18.5        | v1.34.12      |
@@ -26,6 +33,9 @@ Note: The below table is updated by script `tools/update_version_matrix.sh`
 | v1.18.2        | v1.34.7       |
 | v1.18.1        | v1.34.4       |
 | v1.18.0        | v1.34.4       |
+| v1.17.16       | v1.36.6       |
+| v1.17.15       | v1.36.6       |
+| v1.17.14       | v1.35.9       |
 | v1.17.13       | v1.35.9       |
 | v1.17.12       | v1.34.12      |
 | v1.17.11       | v1.34.12      |


### PR DESCRIPTION
README version matrix is kinda stale.

`tools/update_version_matrix.sh --dry-run` prints newer supported Cilium patch releases, but `README.md` still stops earlier. `(main)` is also behind and still says `v1.36.x`.

This just refreshes the generated table in `README.md`. no runtime code, no build logic, just docs sync.

How to repro:
1. check out `main`
2. run `SUPPORTED_MINOR_VERSIONS=3 ./tools/update_version_matrix.sh --dry-run`
3. compare the printed table with `README.md`
4. you will see missing rows like `v1.19.4`, `v1.18.10`, `v1.17.16`, and `(main)` still on `v1.36.x`

Double checked this against current `cilium/cilium` release tags and `images/cilium/Dockerfile`, so the table lines up now. pretty small one, but useful.