### PR TITLE
docs: refresh README version compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Note: The below table is updated by script `tools/update_version_matrix.sh`
 | Cilium Version | Envoy version |
 |----------------|---------------|
 | (main)         | v1.37.x       |
+| v1.19.5        | v1.36.8       |
 | v1.19.4        | v1.36.6       |
 | v1.19.3        | v1.36.6       |
 | v1.19.2        | v1.35.9       |
 | v1.19.1        | v1.35.9       |
 | v1.19.0        | v1.35.9       |
+| v1.18.11       | v1.36.8       |
 | v1.18.10       | v1.36.6       |
 | v1.18.9        | v1.36.6       |
 | v1.18.8        | v1.35.9       |
@@ -33,6 +35,7 @@ Note: The below table is updated by script `tools/update_version_matrix.sh`
 | v1.18.2        | v1.34.7       |
 | v1.18.1        | v1.34.4       |
 | v1.18.0        | v1.34.4       |
+| v1.17.17       | v1.36.8       |
 | v1.17.16       | v1.36.6       |
 | v1.17.15       | v1.36.6       |
 | v1.17.14       | v1.35.9       |


### PR DESCRIPTION
README version matrix is stale again.

`./tools/update_version_matrix.sh --dry-run` shows 3 missing rows in `README.md`:
- `v1.19.5 -> v1.36.8`
- `v1.18.11 -> v1.36.8`
- `v1.17.17 -> v1.36.8`

This just syncs the generated table. no code paths, no build logic.

Repro:
1. Check out `main`
2. Run `./tools/update_version_matrix.sh --dry-run`
3. Compare the printed table with `README.md`

Checked against current `cilium/cilium` release tags and `images/cilium/Dockerfile`, so this should be good. tiny doc fix, but useful.
