### PR TITLE
ci: add ASAN integration test job

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -83,3 +83,53 @@ jobs:
             BAZEL_TEST_OPTS=--jobs=HOST_RAM*.0002 --test_timeout=300 --local_test_jobs=4 --flaky_test_attempts=3
           cache-from: type=local,src=/tmp/buildx-cache
           push: false
+
+  asan-tests:
+    timeout-minutes: 360
+    name: Run ASAN integration tests on amd64
+    runs-on: ${{ vars.PROXY_BUILD_GITHUB_RUNNER || 'oracle-vm-32cpu-128gb-x86-64' }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Cache Docker layers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/buildx-cache
+          key: docker-cache-tests-asan
+          restore-keys: docker-cache-tests
+
+      - name: Checkout PR Source Code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Prep for build
+        run: |
+          echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
+          echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
+
+      - name: Wait for build image
+        uses: ./.github/workflows/wait-for-image
+        with:
+          SHA: ${{ env.BUILDER_DOCKER_HASH }}
+          repo: cilium
+          images: cilium-envoy-builder-dev
+
+      - name: Run ASAN integration tests on amd64
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        id: docker_asan_tests_ci
+        with:
+          provenance: false
+          context: .
+          file: ./Dockerfile.tests
+          platforms: linux/amd64
+          build-args: |
+            BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
+            DEBUG=1
+            BAZEL_BUILD_OPTS=--remote_upload_local_results=false --config=asan --config=clang-asan
+            BAZEL_TEST_OPTS=--jobs=HOST_RAM*.0001 --test_timeout=600 --local_test_jobs=2 --flaky_test_attempts=1
+          cache-from: type=local,src=/tmp/buildx-cache
+          push: false

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -130,6 +130,6 @@ jobs:
             ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
             DEBUG=1
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false --config=asan --config=clang-asan
-            BAZEL_TEST_OPTS=--jobs=HOST_RAM*.0001 --test_timeout=600 --local_test_jobs=2 --flaky_test_attempts=1
+            BAZEL_TEST_OPTS=--jobs=HOST_RAM*.0001 --test_timeout=600 --local_test_jobs=2 --flaky_test_attempts=1 --noshow_progress --noshow_loading_progress
           cache-from: type=local,src=/tmp/buildx-cache
           push: false

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -44,13 +44,14 @@ RUN apt-get update && \
 # (deliberately, alongside Envoy upgrades) rather than via automated updates.
 ENV LLVM_VERSION=18.1.8
 ENV LIBTINFO5_VERSION=6.3-2ubuntu0.1
+ENV UBUNTU_SNAPSHOT=20240501T120000Z
 RUN case "$TARGETARCH" in \
-      amd64) LLVM_ARCH=x86_64-linux-gnu-ubuntu-18.04; TINFO_MIRROR=http://archive.ubuntu.com/ubuntu ;; \
-      arm64) LLVM_ARCH=aarch64-linux-gnu;             TINFO_MIRROR=http://ports.ubuntu.com/ubuntu-ports ;; \
+      amd64) LLVM_ARCH=x86_64-linux-gnu-ubuntu-18.04 ;; \
+      arm64) LLVM_ARCH=aarch64-linux-gnu ;; \
       *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac && \
     # libtinfo.so.5 compat ABI, required to run the upstream clang on noble
-    curl -sfL "${TINFO_MIRROR}/pool/universe/n/ncurses/libtinfo5_${LIBTINFO5_VERSION}_${TARGETARCH}.deb" -o /tmp/libtinfo5.deb && \
+    curl -sfL "https://snapshot.ubuntu.com/ubuntu/${UBUNTU_SNAPSHOT}/pool/universe/n/ncurses/libtinfo5_${LIBTINFO5_VERSION}_${TARGETARCH}.deb" -o /tmp/libtinfo5.deb && \
     dpkg -i /tmp/libtinfo5.deb && \
     rm /tmp/libtinfo5.deb && \
     # upstream LLVM toolchain, extracted into the path the bazel toolchain expects

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -63,7 +63,7 @@ RUN case "$TARGETARCH" in \
     # toolchain binaries referenced by //bazel/toolchains plus clang-format and
     # clang-tidy, and drop static archives, tooling shared libs and docs.
     cd /usr/lib/llvm-18/bin && \
-    keep=" clang-18 lld clang-format clang-tidy clang-apply-replacements run-clang-tidy llvm-ar llvm-nm llvm-strip llvm-objcopy llvm-objdump llvm-dwp llvm-cov llvm-config " && \
+    keep=" clang-18 lld clang-format clang-tidy clang-apply-replacements run-clang-tidy llvm-ar llvm-nm llvm-strip llvm-objcopy llvm-objdump llvm-dwp llvm-cov llvm-config llvm-symbolizer " && \
     for f in $(find . -maxdepth 1 -type f -printf '%f\n'); do case "$keep" in *" $f "*) : ;; *) rm -f "$f" ;; esac; done && \
     cd /usr/lib/llvm-18 && \
     find lib -maxdepth 1 -name '*.a' ! -name 'libc++*.a' ! -name 'libunwind*.a' -delete && \
@@ -71,10 +71,11 @@ RUN case "$TARGETARCH" in \
     rm -rf share libexec && \
     # Create unversioned and -18 suffixed symlinks so tools are on PATH either way
     for tool in clang clang++ clang-cpp lld ld.lld clang-format clang-tidy run-clang-tidy clang-apply-replacements \
-                llvm-ar llvm-nm llvm-strip llvm-objcopy llvm-objdump llvm-dwp llvm-cov llvm-config; do \
+                llvm-ar llvm-nm llvm-strip llvm-objcopy llvm-objdump llvm-dwp llvm-cov llvm-config llvm-symbolizer; do \
       ln -sf /usr/lib/llvm-18/bin/$tool /usr/bin/$tool && \
       ln -sf /usr/lib/llvm-18/bin/$tool /usr/bin/$tool-18; \
-    done
+    done && \
+    /usr/lib/llvm-18/bin/llvm-symbolizer --version
 
 #
 # Install Bazelisk

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ endif
 # Extra opts are passed to docker targets, which will choose the bazel platform themselves
 EXTRA_BAZEL_BUILD_OPTS := $(BAZEL_BUILD_OPTS)
 
+BAZEL_ASAN_BUILD_OPTS ?= $(EXTRA_BAZEL_BUILD_OPTS) -c dbg --config=asan --config=clang-asan
+BAZEL_ASAN_TEST_OPTS ?= --jobs=HOST_RAM*.0001 --test_timeout=600 --local_test_jobs=2 --flaky_test_attempts=1 --test_output=errors
+
 ifdef DEBUG
   BAZEL_BUILD_OPTS += -c dbg
 else ifdef RELEASE_DEBUG
@@ -201,6 +204,10 @@ envoy-tests: $(COMPILER_DEP) SOURCE_VERSION proxylib/libcilium.so
 	# Upstream tcp_proxy_integration_test included to validate that our custom patches
 	# didn't break anything
 	$(BAZEL) $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) $(BAZEL_TEST_OPTS) //tests/... @envoy//test/integration:tcp_proxy_integration_test $(BAZEL_FILTER)
+
+.PHONY: envoy-asan-tests
+envoy-asan-tests:
+	$(MAKE) envoy-tests BAZEL_BUILD_OPTS="$(BAZEL_ASAN_BUILD_OPTS)" BAZEL_TEST_OPTS="$(BAZEL_ASAN_TEST_OPTS)"
 
 .PHONY: \
 	install \

--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -520,9 +520,9 @@ public:
           return true; // nothing to remove
         }
 
-        // Remove the header with an incorrect value
-        headers.remove(name_);
+        // Log the incorrect value before removing its backing header storage.
         logRejected(log_entry, header_value.result().value());
+        headers.remove(name_);
         return true;
       case cilium::HeaderMatch::REPLACE_ON_MISMATCH:
         // Log the wrong value as rejected, if the header existed with a wrong value

--- a/tests/cilium_tcp_integration_test.cc
+++ b/tests/cilium_tcp_integration_test.cc
@@ -5,7 +5,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <cstring>
 #include <string>
 
 #include "test/integration/fake_upstream.h"
@@ -746,10 +745,9 @@ TEST_P(CiliumGoBlocktesterIntegrationTest, CiliumGoBlockParserInjectBufferOverfl
   ASSERT_TRUE(tcp_client->write("26:INJECT reply direction\n"));
   ASSERT_TRUE(tcp_client->write("27:DROP original direction\n"));
 
-  char buf[5000];
-  memset(buf, 'A', sizeof buf);
-  strncpy(buf, "5000:INSERT original direction", 30);
-  buf[sizeof buf - 1] = '\n';
+  std::string buf(5000, 'A');
+  buf.replace(0, 30, "5000:INSERT original direction");
+  buf.back() = '\n';
 
   ASSERT_TRUE(tcp_client->write(buf));
   tcp_client->waitForData("26:INJECT reply direction\n", false);


### PR DESCRIPTION
Running the existing integration tests under AddressSanitizer and UndefinedBehaviorSanitizer gives us a targeted signal for use-after-free, buffer overflows, invalid lifetime assumptions, and undefined behavior in exercised proxy code paths.

The ASAN job reuses the Dockerfile.tests flow with reduced parallelism and longer timeouts to keep sanitizer output readable. The job passes the sanitizer Bazel configs explicitly so the check stays scoped to the Cilium proxy CI path.