### PR TITLE
ci: add MSAN integration test job

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,10 @@
 # curl -sSL https://raw.githubusercontent.com/envoyproxy/envoy-wasm/master/.bazelrc > envoy.bazelrc
 import %workspace%/envoy.bazelrc
 
+# MSAN does not recognize host libc's stat() as initializing Bazel's runfiles buffer.
+# Scope zero initialization to this helper so proxy and Envoy sources remain fully checked.
+build:msan --per_file_copt=external/bazel_tools/tools/cpp/runfiles/runfiles[.]cc@-ftrivial-auto-var-init=zero
+
 # Rust crate repinning for repository rules. Inherit CARGO_BAZEL_REPIN from the
 # invocation environment so developers can repin explicitly without forcing
 # every normal Bazel invocation to recompute the crate index.

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -133,3 +133,57 @@ jobs:
             BAZEL_TEST_OPTS=--jobs=HOST_RAM*.0001 --test_timeout=600 --local_test_jobs=2 --flaky_test_attempts=1 --noshow_progress --noshow_loading_progress
           cache-from: type=local,src=/tmp/buildx-cache
           push: false
+
+  msan-tests:
+    timeout-minutes: 360
+    name: Run MSAN integration tests on amd64
+    runs-on: ${{ vars.PROXY_BUILD_GITHUB_RUNNER || 'oracle-vm-32cpu-128gb-x86-64' }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Cache Docker layers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/buildx-cache
+          key: docker-cache-tests-msan
+          restore-keys: docker-cache-tests
+
+      - name: Checkout PR Source Code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Prep for build
+        run: |
+          echo "${{ github.event.pull_request.head.sha }}" >SOURCE_VERSION
+          echo "BUILDER_DOCKER_HASH=$(git ls-tree --full-tree HEAD -- ./Dockerfile.builder | awk '{ print $3 }')" >> $GITHUB_ENV
+
+      - name: Wait for build image
+        uses: ./.github/workflows/wait-for-image
+        with:
+          SHA: ${{ env.BUILDER_DOCKER_HASH }}
+          repo: cilium
+          images: cilium-envoy-builder-dev
+
+      - name: Run MSAN integration tests on amd64
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        id: docker_msan_tests_ci
+        with:
+          provenance: false
+          context: .
+          file: ./Dockerfile.tests
+          platforms: linux/amd64
+          build-args: |
+            BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
+            PROXYLIB_BUILDER=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
+            PROXYLIB_CC=/usr/lib/llvm-18/bin/clang
+            PROXYLIB_GO_BUILD_FLAGS=-msan -buildvcs=false
+            PROXYLIB_GOCACHE=/tmp/go-build
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
+            DEBUG=1
+            BAZEL_BUILD_OPTS=--config=msan --remote_upload_local_results=false
+            BAZEL_TEST_OPTS=--jobs=HOST_RAM*.00005 --test_timeout=900 --local_test_jobs=1 --flaky_test_attempts=1 --noshow_progress --noshow_loading_progress --test_env=MSAN_SYMBOLIZER_PATH=/usr/lib/llvm-18/bin/llvm-symbolizer
+          cache-from: type=local,src=/tmp/buildx-cache
+          push: false

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -19,9 +19,17 @@ ARG ARCHIVE_IMAGE=builder-fresh
 
 FROM --platform=$BUILDPLATFORM $PROXYLIB_BUILDER AS proxylib
 WORKDIR /go/src/github.com/cilium/proxy
+ENV PATH=/usr/local/go/bin:$PATH
 ARG TARGETARCH
-RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/proxy --mount=mode=0777,target=/cilium/proxy/.cache,type=cache --mount=mode=0777,target=/go/pkg,type=cache \
-    GOARCH=${TARGETARCH} make -C proxylib all && mv proxylib/libcilium.so /tmp/libcilium.so
+ARG PROXYLIB_CC=gcc
+ARG PROXYLIB_GO_BUILD_FLAGS
+ARG PROXYLIB_GOCACHE
+RUN --mount=type=bind,target=/go/src/github.com/cilium/proxy \
+    --mount=mode=0777,target=/cilium/proxy/.cache,type=cache \
+    --mount=mode=0777,target=/go/pkg,type=cache \
+    --mount=mode=0777,uid=1337,gid=1337,target=/tmp/go-build,type=cache \
+    if [ -n "${PROXYLIB_GOCACHE}" ]; then export GOCACHE="${PROXYLIB_GOCACHE}"; fi && \
+    CC="${PROXYLIB_CC}" GOARCH="${TARGETARCH}" GO_BUILD_FLAGS="${PROXYLIB_GO_BUILD_FLAGS}" make -C proxylib TARGET=/tmp/libcilium.so all
 
 FROM --platform=$BUILDPLATFORM $BUILDER_BASE AS builder-fresh
 LABEL maintainer="maintainer@cilium.io"

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,11 @@ EXTRA_BAZEL_BUILD_OPTS := $(BAZEL_BUILD_OPTS)
 BAZEL_ASAN_BUILD_OPTS ?= $(EXTRA_BAZEL_BUILD_OPTS) -c dbg --config=asan --config=clang-asan
 BAZEL_ASAN_TEST_OPTS ?= --jobs=HOST_RAM*.0001 --test_timeout=600 --local_test_jobs=2 --flaky_test_attempts=1 --test_output=errors
 
+BAZEL_MSAN_BUILD_OPTS ?= --config=msan $(EXTRA_BAZEL_BUILD_OPTS) -c dbg
+BAZEL_MSAN_TEST_OPTS ?= --jobs=HOST_RAM*.00005 --test_timeout=900 --local_test_jobs=1 --flaky_test_attempts=1 --test_output=errors
+PROXYLIB_MSAN_CC ?= clang
+PROXYLIB_MSAN_GO_BUILD_FLAGS ?= -msan -buildvcs=false
+
 ifdef DEBUG
   BAZEL_BUILD_OPTS += -c dbg
 else ifdef RELEASE_DEBUG
@@ -208,6 +213,14 @@ envoy-tests: $(COMPILER_DEP) SOURCE_VERSION proxylib/libcilium.so
 .PHONY: envoy-asan-tests
 envoy-asan-tests:
 	$(MAKE) envoy-tests BAZEL_BUILD_OPTS="$(BAZEL_ASAN_BUILD_OPTS)" BAZEL_TEST_OPTS="$(BAZEL_ASAN_TEST_OPTS)"
+
+.PHONY: proxylib-msan
+proxylib-msan:
+	$(MAKE) -C proxylib all CC="$(PROXYLIB_MSAN_CC)" GO_BUILD_FLAGS="$(PROXYLIB_MSAN_GO_BUILD_FLAGS)"
+
+.PHONY: envoy-msan-tests
+envoy-msan-tests: proxylib-msan
+	$(MAKE) envoy-tests BAZEL_BUILD_OPTS="$(BAZEL_MSAN_BUILD_OPTS)" BAZEL_TEST_OPTS="$(BAZEL_MSAN_TEST_OPTS)"
 
 .PHONY: \
 	install \

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,6 +1,18 @@
+constraint_setting(
+    name = "cilium_target_platform",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "cilium_target_platform_enabled",
+    constraint_setting = ":cilium_target_platform",
+    visibility = ["//visibility:public"],
+)
+
 platform(
     name = "linux_aarch64",
     constraint_values = [
+        ":cilium_target_platform_enabled",
         "@platforms//cpu:aarch64",
         "@platforms//os:linux",
     ],
@@ -9,6 +21,7 @@ platform(
 platform(
     name = "linux_x86_64",
     constraint_values = [
+        ":cilium_target_platform_enabled",
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],

--- a/bazel/toolchains/BUILD
+++ b/bazel/toolchains/BUILD
@@ -4,6 +4,14 @@ load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 # Using platform-provided files
 filegroup(name = "empty")
 
+config_setting(
+    name = "msan_target_build",
+    constraint_values = [
+        "//bazel:cilium_target_platform_enabled",
+    ],
+    values = {"define": "ENVOY_CONFIG_MSAN=1"},
+)
+
 toolchain(
     name = "aarch64_linux_cc_toolchain",
     exec_compatible_with = ["@platforms//os:linux"],
@@ -168,7 +176,10 @@ cc_toolchain_config(
         "/usr/x86_64-linux-gnu/include",
         "/usr/include",
     ],
-    cxx_flags = ["-std=c++0x"],
+    cxx_flags = ["-std=c++0x"] + select({
+        "@envoy//bazel:msan_build": ["-stdlib=libc++"],
+        "//conditions:default": [],
+    }),
     dbg_compile_flags = ["-g"],
     host_system_name = "local",
     link_flags = [
@@ -177,11 +188,26 @@ cc_toolchain_config(
         "-Wl,-no-as-needed",
         "-Wl,-z,relro,-z,now",
         "-lm",
-    ],
-    link_libs = [
-        "-l:libstdc++.a",
-        "-latomic",
-    ],
+    ] + select({
+        "@envoy//bazel:msan_build": ["-L/usr/lib/llvm-18/lib"],
+        "//conditions:default": [],
+    }),
+    # Envoy supplies instrumented libc++ for MSAN targets. Non-instrumented
+    # Bazel exec tools use the system libc++ runtime below.
+    link_libs = select({
+        ":msan_target_build": [
+            "-latomic",
+        ],
+        "@envoy//bazel:msan_build": [
+            "-l:libc++.a",
+            "-l:libc++abi.a",
+            "-latomic",
+        ],
+        "//conditions:default": [
+            "-l:libstdc++.a",
+            "-latomic",
+        ],
+    }),
     opt_compile_flags = [
         "-g0",
         "-O2",

--- a/proxylib/Makefile
+++ b/proxylib/Makefile
@@ -15,7 +15,8 @@ ifeq ($(CROSS_ARCH),arm64)
 else ifeq ($(CROSS_ARCH),amd64)
     CGO_CC = CC=x86_64-linux-gnu-gcc
 endif
-GO_BUILD_WITH_CGO = CGO_ENABLED=1 $(CGO_CC) $(GO) build
+GO_BUILD_FLAGS ?=
+GO_BUILD_WITH_CGO = CGO_ENABLED=1 $(CGO_CC) $(GO) build $(GO_BUILD_FLAGS)
 
 EXTRA_GO_BUILD_LDFLAGS = -extldflags -Wl,-soname,libcilium.so
 


### PR DESCRIPTION
Running the existing C++ integration tests under MemorySanitizer adds coverage for use of uninitialized memory in exercised Cilium proxy code paths.

The MSAN job builds libcilium.so with Go sanitizer interoperability and the matching Clang toolchain so shadow state is preserved across the C++/Go boundary while retaining proxylib-backed tests. 

Lets see if proxylib part works.