### PR TITLE
ci: allow fork PR checkout after approval

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -51,6 +51,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Prep for build
         run: |


### PR DESCRIPTION
Allow the CI image build workflow to check out code from pull requests opened from forks. `actions/checkout` now rejects fork PR checkouts in `pull_request_target` workflows unless they are explicitly enabled. 

The job uses the protected `ci-build` environment, which requires approval from an authorized Cilium team before the job starts and its secrets become available. External contributor code therefore remains behind the existing manual approval gate.