### PR TITLE
ci: select cilium branch from PR base branch

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -172,6 +172,9 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
       commit_ref: ${{ github.event.pull_request.head.sha }}
+      # pull_request_target runs the default-branch workflow files, so the Cilium
+      # branch is derived from the PR base branch here instead of per-branch overrides.
+      cilium_ref: ${{ github.base_ref == 'v1.37' && 'v1.20' || github.base_ref == 'v1.36' && 'v1.19' || 'main' }}
     secrets: inherit
 
   cilium-gateway-api-tests:
@@ -185,4 +188,5 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
       commit_ref: ${{ github.event.pull_request.head.sha }}
+      cilium_ref: ${{ github.base_ref == 'v1.37' && 'v1.20' || github.base_ref == 'v1.36' && 'v1.19' || 'main' }}
     secrets: inherit

--- a/.github/workflows/cilium-gateway-api.yaml
+++ b/.github/workflows/cilium-gateway-api.yaml
@@ -11,6 +11,10 @@ on:
         description: 'Git commit ref for image.'
         type: string
         required: true
+      cilium_ref:
+        description: 'Cilium branch or tag to run the tests against.'
+        type: string
+        default: main
 
 concurrency:
   group: gateway-api-${{ github.workflow }}-${{ inputs.repository }}-${{ github.event.pull_request.number || github.event.after || inputs.commit_ref }}
@@ -27,7 +31,7 @@ env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION: v0.32.0
   CILIUM_REPO_OWNER: cilium
-  CILIUM_REPO_REF: main
+  CILIUM_REPO_REF: ${{ inputs.cilium_ref }}
   CILIUM_CLI_REF: latest
   CURL_PARALLEL: ${{ vars.CURL_PARALLEL || 10 }}
 

--- a/.github/workflows/cilium-integration-tests.yaml
+++ b/.github/workflows/cilium-integration-tests.yaml
@@ -11,6 +11,10 @@ on:
         description: 'Git commit ref for image.'
         type: string
         required: true
+      cilium_ref:
+        description: 'Cilium branch or tag to run the tests against.'
+        type: string
+        default: main
 
 concurrency:
   group: integration-test-${{ github.workflow }}-${{ inputs.repository }}-${{ github.event.pull_request.number || github.event.after || inputs.commit_ref }}
@@ -27,7 +31,7 @@ env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION: v0.32.0
   CILIUM_REPO_OWNER: cilium
-  CILIUM_REPO_REF: main
+  CILIUM_REPO_REF: ${{ inputs.cilium_ref }}
   CILIUM_CLI_REF: latest
   CURL_PARALLEL: ${{ vars.CURL_PARALLEL || 10 }}
 


### PR DESCRIPTION
Workflows triggered by pull_request_target always run the workflow files from the default branch, regardless of the PR's base branch. As a result the CILIUM_REPO_REF override in the v1.36 branch (cf56df1c "ci: Use cilium v1.19 branch") is never used: PRs against v1.36 still run the integration and gateway API tests against cilium/cilium main.

Derive the Cilium ref from github.base_ref in the caller instead and pass it to the reusable workflows via a new optional `cilium_ref` input (default: main), so release-branch PRs are tested against the matching Cilium release branch without needing per-branch workflow edits.