### PR TITLE
ci: only install ListenerSet CRD when the Gateway API version ships it

### DIFF
--- a/.github/workflows/cilium-gateway-api.yaml
+++ b/.github/workflows/cilium-gateway-api.yaml
@@ -95,7 +95,11 @@ jobs:
           kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
           kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
           kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
-          kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
+          # ListenerSet only exists in the standard group from Gateway API v1.5; older Cilium branches pin earlier versions.
+          listenersets_crd=https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
+          if curl -sfI "$listenersets_crd" > /dev/null; then
+            kubectl apply --server-side -f "$listenersets_crd"
+          fi
           ## TLSRoute is only available in experimental channel in v0.7.0
           kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$gateway_api_version/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
 
@@ -108,7 +112,9 @@ jobs:
           kubectl wait --for condition=Established crd/tcproutes.gateway.networking.k8s.io --timeout=${{ env.timeout }}
           kubectl wait --for condition=Established crd/udproutes.gateway.networking.k8s.io --timeout=${{ env.timeout }}
           kubectl wait --for condition=Established crd/referencegrants.gateway.networking.k8s.io --timeout=${{ env.timeout }}
-          kubectl wait --for condition=Established crd/listenersets.gateway.networking.k8s.io --timeout=${{ env.timeout }}
+          if kubectl get crd listenersets.gateway.networking.k8s.io > /dev/null 2>&1; then
+            kubectl wait --for condition=Established crd/listenersets.gateway.networking.k8s.io --timeout=${{ env.timeout }}
+          fi
 
       - name: Install Cilium
         timeout-minutes: 10


### PR DESCRIPTION
Since 1501f02a release-branch PRs run the Gateway API tests against the matching Cilium release branch. Cilium v1.19 pins Gateway API v1.4.0-rc.2, which does not ship the standard-group ListenerSet CRD (gateway.networking.k8s.io_listenersets.yaml), so the unconditional kubectl apply of that manifest fails with a 404 and breaks the job for PRs against v1.36.