### PR TITLE
http-filters: enable Stateful Session

### DIFF
--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -221,7 +221,7 @@ EXTENSIONS = {
     # "envoy.filters.http.tap":                           "//source/extensions/filters/http/tap:config",
     # "envoy.filters.http.thrift_to_metadata":            "//source/extensions/filters/http/thrift_to_metadata:config",
     "envoy.filters.http.wasm":                          "//source/extensions/filters/http/wasm:config",
-    # "envoy.filters.http.stateful_session":              "//source/extensions/filters/http/stateful_session:config",
+    "envoy.filters.http.stateful_session":              "//source/extensions/filters/http/stateful_session:config",
     # "envoy.filters.http.sse_to_metadata":               "//source/extensions/filters/http/sse_to_metadata:config",
     # "envoy.filters.http.header_mutation":               "//source/extensions/filters/http/header_mutation:config",
     # "envoy.filters.http.transform":                     "//source/extensions/filters/http/transform:config",
@@ -456,7 +456,7 @@ EXTENSIONS = {
     # Stateful session
     #
 
-    # "envoy.http.stateful_session.cookie":                "//source/extensions/http/stateful_session/cookie:config",
+    "envoy.http.stateful_session.cookie":                "//source/extensions/http/stateful_session/cookie:config",
     # "envoy.http.stateful_session.envelope":              "//source/extensions/http/stateful_session/envelope:config",
     # "envoy.http.stateful_session.header":                "//source/extensions/http/stateful_session/header:config",
 


### PR DESCRIPTION
Enable Stateful Session filter and cookie extension in the Envoy build config.

This is required for Cilium's implementation of Gateway API session persistence in https://github.com/cilium/cilium/pull/48029