### PR TITLE
git: Ignore Python caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@
 # Emacs backup files
 *~
 
+# Python bytecode caches
+__pycache__/
+
 # To run Envoy tests under gdb do "cd envoy && make debug && ln -s bazel-envoy/external external"
 /external
 


### PR DESCRIPTION
Ignore local Python bytecode caches to keep git status clean and prevent accidental tracking of them.