### PR TITLE
conntrack: Demote info log on address family mismatch to debug

### DIFF
--- a/cilium/bpf_metadata.cc
+++ b/cilium/bpf_metadata.cc
@@ -399,9 +399,17 @@ bool Config::exists(const std::string& pod_ip) const { return npmap_->exists(pod
 
 absl::optional<Cilium::BpfMetadata::SocketMetadata>
 Config::extractSocketMetadata(Network::ConnectionSocket& socket) {
+  // connectionInfoProvider may provide original addresses as carried in PROXY protocol. Thus the
+  // source address may be of a different address family than the destination address.
   Network::Address::InstanceConstSharedPtr src_address =
       socket.connectionInfoProvider().remoteAddress();
   const auto sip = src_address->ip();
+  // Destination address is taken from the socket, as that way we get the original/restored
+  // destinatino address as seen before TPROXY redirection, while the Envoy listener address may be,
+  // e.g., a loopback address. This is the address used as the upstream destination for non-L7LB
+  // cases, while L7LB listener is expected to choose a different destination address.
+  // The family (IPv4/IPv6) of this address is used to select the upstream source address when
+  // original source address is not used.
   const auto dst_address = THROW_OR_RETURN_VALUE(socket.ioHandle().localAddress(),
                                                  Network::Address::InstanceConstSharedPtr);
   const auto dip = dst_address->ip();

--- a/cilium/conntrack.cc
+++ b/cilium/conntrack.cc
@@ -142,7 +142,14 @@ uint32_t CtMap::lookupSrcIdentity(const Network::Address::Ip* sip, const Network
     key6.nexthdr = 6; // TCP only for now
     key6.flags = ingress ? TUPLE_F_IN : TUPLE_F_OUT;
   } else {
-    ENVOY_LOG(info, "cilium.bpf_metadata: Address type mismatch: Source: {}, Dest: {}",
+    // Address family mismatch is expected when an incoming IPv6 request is forwarded as IPv4 by a
+    // load balancer as we use the original IPv6 source address as preserved via the PROXY protocol
+    // in that case.
+    //
+    // NOTE: Do not change to locate the conntrack entry based on the direct source address which in
+    // this case would be the address of the load balancer, as CIDR policy enforcement depends on
+    // the original source address.
+    ENVOY_LOG(debug, "cilium.bpf_metadata: Address type mismatch: Source: {}, Dest: {}",
               sip->addressAsString(), dip->addressAsString());
     return 0;
   }


### PR DESCRIPTION
Demote info log on address family mismatch to debug as an address family mismatch is expected when an incoming IPv6 request is forwarded as IPv4 by a load balancer as we use the original IPv6 source address as preserved via the PROXY protocol in that case.

Related-to: #1944