### PR TITLE
cilium: Separate NPHDS subscription and host map stats

### DIFF
--- a/cilium/host_map.cc
+++ b/cilium/host_map.cc
@@ -205,10 +205,11 @@ PolicyHostMap::PolicyHostMap(Server::Configuration::CommonFactoryContext& contex
                              bool subscribe)
     : ManagedGrpcSubscription(
           NetworkPolicyHostsTypeUrl, []() { return std::make_shared<Cilium::PolicyHostDecoder>(); },
-          config_source, context, context.serverScope().createScope("cilium.hostmap."), subscribe),
+          config_source, context, context.serverScope().createScope("cilium.nphds."), subscribe),
       tls_(context.threadLocal().allocateSlot()),
       name_(absl::StrCat("cilium.hostmap.", fmt::format("{}", instance_id_ + 1), ".")),
-      stats_({CILIUM_POLICY_HOSTS_STATS(POOL_COUNTER(scope()))}) {
+      host_stats_scope_(context.serverScope().createScope("cilium.hostmap.")),
+      stats_({CILIUM_POLICY_HOSTS_STATS(POOL_COUNTER(*host_stats_scope_))}) {
   instance_id_++;
   ENVOY_LOG(debug, "PolicyHostMap({}) created.", name_);
 

--- a/cilium/host_map.h
+++ b/cilium/host_map.h
@@ -19,6 +19,7 @@
 #include "envoy/protobuf/message_validator.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/singleton/instance.h"
+#include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/thread_local/thread_local_object.h"
@@ -222,6 +223,7 @@ private:
   std::string name_;
   uint64_t accepted_stream_generation_{0};
   static uint64_t instance_id_;
+  Stats::ScopeSharedPtr host_stats_scope_;
   PolicyHostsStats stats_;
 };
 


### PR DESCRIPTION
Use the cilium.nphds scope for the generic gRPC subscription stats while retaining cilium.hostmap for stats tracking successfully applied host map updates.

Previously both sets of stats shared the cilium.hostmap scope, causing update_success to be incremented twice for each accepted NPHDS response. Tests waiting on this counter could consequently proceed before the corresponding host map update had been installed, resulting in a timing-dependent assertion failure under ASAN.

This follows the existing policy map convention, where NPDS subscription stats and successfully applied policy update stats use separate scopes.

Since NPHDS is not used in production this only showed up as CI test flakes like this:
```
#18 221.5 tests/bpf_metadata_integration_test.cc:648: Failure
#18 221.5 Expected equality of these values:
#18 221.5   resolveHostPolicyId("10.1.1.1")
#18 221.5     Which is: 111
#18 221.5   Cilium::ID::UNKNOWN
#18 221.5     Which is: 0
```