### PR TITLE
ci: use base branch archive image for PR builds

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: /tmp/buildx-cache
           key: docker-cache-${{ github.head_ref }}
-          restore-keys: docker-cache-main
+          restore-keys: docker-cache-${{ github.base_ref }}
 
       - name: Login to quay.io
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -106,7 +106,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BUILDER_BASE=quay.io/cilium/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
-            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:main-archive-latest
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ github.base_ref }}-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
           cache-from: type=local,src=/tmp/buildx-cache
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max


### PR DESCRIPTION
Use github.base_ref instead of hardcoded main so PR builds on release branches pull the matching builder archive and buildx cache.