### PR TITLE
ci: Derive archive image and cache keys from branch name

### DIFF
--- a/.github/workflows/build-envoy-image-ci.yaml
+++ b/.github/workflows/build-envoy-image-ci.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: /tmp/buildx-cache
           key: docker-cache-${{ github.head_ref }}
-          restore-keys: docker-cache-main
+          restore-keys: docker-cache-${{ github.base_ref }}
 
       - name: Login to quay.io
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -106,7 +106,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BUILDER_BASE=quay.io/cilium/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
-            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:main-archive-latest
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:${{ github.base_ref }}-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
           cache-from: type=local,src=/tmp/buildx-cache
           cache-to: type=local,dest=/tmp/buildx-cache,mode=max

--- a/.github/workflows/build-envoy-images-release-base.yaml
+++ b/.github/workflows/build-envoy-images-release-base.yaml
@@ -170,7 +170,7 @@ jobs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: /tmp/buildx-cache
-        key: docker-cache-main
+        key: docker-cache-${{ github.ref_name }}
 
     - name: Clear cache
       run: |

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           path: /tmp/buildx-cache
           key: docker-cache-tests
-          restore-keys: docker-cache-main
+          restore-keys: docker-cache-${{ github.base_ref }}
 
       - name: Checkout PR Source Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -78,7 +78,7 @@ jobs:
           platforms: linux/amd64
           build-args: |
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
-            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ github.base_ref }}-archive-latest
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false
             BAZEL_TEST_OPTS=--jobs=HOST_RAM*.0002 --test_timeout=300 --local_test_jobs=4 --flaky_test_attempts=3
           cache-from: type=local,src=/tmp/buildx-cache
@@ -127,7 +127,7 @@ jobs:
           platforms: linux/amd64
           build-args: |
             BUILDER_BASE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder-dev:${{ env.BUILDER_DOCKER_HASH }}
-            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ github.base_ref }}-archive-latest
             DEBUG=1
             BAZEL_BUILD_OPTS=--remote_upload_local_results=false --config=asan --config=clang-asan
             BAZEL_TEST_OPTS=--jobs=HOST_RAM*.0001 --test_timeout=600 --local_test_jobs=2 --flaky_test_attempts=1 --noshow_progress --noshow_loading_progress
@@ -181,7 +181,7 @@ jobs:
             PROXYLIB_CC=/usr/lib/llvm-18/bin/clang
             PROXYLIB_GO_BUILD_FLAGS=-msan -buildvcs=false
             PROXYLIB_GOCACHE=/tmp/go-build
-            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ github.base_ref }}-archive-latest
             DEBUG=1
             BAZEL_BUILD_OPTS=--config=msan --remote_upload_local_results=false
             BAZEL_TEST_OPTS=--jobs=HOST_RAM*.00005 --test_timeout=900 --local_test_jobs=1 --notest_keep_going --flaky_test_attempts=1 --noshow_progress --noshow_loading_progress --test_env=MSAN_SYMBOLIZER_PATH=/usr/lib/llvm-18/bin/llvm-symbolizer
@@ -236,7 +236,7 @@ jobs:
             PROXYLIB_CGO_CFLAGS=-fsanitize=thread
             PROXYLIB_GO_BUILD_FLAGS=-installsuffix=tsan -buildvcs=false
             PROXYLIB_GOCACHE=/tmp/go-build
-            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-main-archive-latest
+            ARCHIVE_IMAGE=quay.io/${{ github.repository_owner }}/cilium-envoy-builder:test-${{ github.base_ref }}-archive-latest
             DEBUG=1
             BAZEL_BUILD_OPTS=--config=tsan --remote_upload_local_results=false
             BAZEL_TEST_OPTS=--jobs=HOST_RAM*.00005 --test_timeout=900 --local_test_jobs=1 --notest_keep_going --flaky_test_attempts=1 --noshow_progress --noshow_loading_progress --test_env=TSAN_OPTIONS=report_atomic_races=0:halt_on_error=1:external_symbolizer_path=/usr/lib/llvm-18/bin/llvm-symbolizer:strip_path_prefix=/proc/self/cwd/


### PR DESCRIPTION
Use github.base_ref / github.ref_name instead of hardcoded main so release branches need no workflow edits.