### PR TITLE
[v1.37] http-filters: enable Stateful Session

### DIFF
--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -212,7 +212,7 @@ EXTENSIONS = {
     # "envoy.filters.http.tap":                           "//source/extensions/filters/http/tap:config",
     # "envoy.filters.http.thrift_to_metadata":            "//source/extensions/filters/http/thrift_to_metadata:config",
     "envoy.filters.http.wasm": "//source/extensions/filters/http/wasm:config",
-    # "envoy.filters.http.stateful_session":              "//source/extensions/filters/http/stateful_session:config",
+    "envoy.filters.http.stateful_session": "//source/extensions/filters/http/stateful_session:config",
     # "envoy.filters.http.header_mutation":               "//source/extensions/filters/http/header_mutation:config",
     # "envoy.filters.http.transform":                     "//source/extensions/filters/http/transform:config",
 
@@ -434,7 +434,7 @@ EXTENSIONS = {
     # Stateful session
     #
 
-    # "envoy.http.stateful_session.cookie":                "//source/extensions/http/stateful_session/cookie:config",
+    "envoy.http.stateful_session.cookie": "//source/extensions/http/stateful_session/cookie:config",
     # "envoy.http.stateful_session.envelope":              "//source/extensions/http/stateful_session/envelope:config",
     # "envoy.http.stateful_session.header":                "//source/extensions/http/stateful_session/header:config",
 


### PR DESCRIPTION
Enable Stateful Session filter and cookie extension in the Envoy build config.

Backport of https://github.com/cilium/proxy/pull/2003